### PR TITLE
updates to basebox

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ if (test "${have_libnl3}" = "yes"); then
         LIBS+="$LIBNL3_LIBS"
 fi
 
-PKG_CHECK_MODULES([ROFL], rofl >= 0.3.0, [have_rofl=yes], [have_rofl=no])
+PKG_CHECK_MODULES([ROFL], rofl_common >= 0.6.0, [have_rofl=yes], [have_rofl=no])
 if (test "${have_rofl}" = "yes"); then
         CPPFLAGS+="$ROFL_CFLAGS"
         LIBS+="$ROFL_LIBS"

--- a/src/baseboxd/cbasebox.cpp
+++ b/src/baseboxd/cbasebox.cpp
@@ -98,16 +98,14 @@ cbasebox::run(int argc, char** argv)
 	/*
 	 * extract daemonize flag
 	 */
-	bool daemonize = true;
+	bool daemonize = false;
 	if (env_parser.is_arg_set("daemonize")) {
-		daemonize = atoi(env_parser.get_arg("pidfile").c_str());
+		daemonize = atoi(env_parser.get_arg("daemonize").c_str());
 	} else if (ethcore::cconfig::get_instance().exists("baseboxd.daemon.daemonize")) {
 		daemonize = (bool)ethcore::cconfig::get_instance().lookup("baseboxd.daemon.daemonize");
 	} else {
-		daemonize = true; // default
+		/* default to false */
 	}
-
-
 
 	/*
 	 * daemonize

--- a/src/roflibs/netlink/cnetlink.cpp
+++ b/src/roflibs/netlink/cnetlink.cpp
@@ -405,7 +405,7 @@ cnetlink::route_neigh_cb(struct nl_cache* cache, struct nl_object* obj, int acti
 				cnetlink::get_instance().notify_neigh_in4_updated(ifindex, nbindex);
 			} break;
 			case AF_INET6: {
-				rofcore::logging::debug << "[roflibs][cnetlink][route_neigh_cb] updated neigh_in6" << std::endl << crtneigh_in4((struct rtnl_neigh*)obj);
+				rofcore::logging::debug << "[roflibs][cnetlink][route_neigh_cb] updated neigh_in6" << std::endl << crtneigh_in6((struct rtnl_neigh*)obj);
 				unsigned int nbindex = cnetlink::get_instance().set_links().set_link(ifindex).set_neighs_in6().set_neigh(crtneigh_in6((struct rtnl_neigh*)obj));
 				rofcore::logging::debug << rofcore::cnetlink::get_instance().get_links().get_link(ifindex).str() << std::endl;
 				cnetlink::get_instance().notify_neigh_in6_updated(ifindex, nbindex);
@@ -422,7 +422,7 @@ cnetlink::route_neigh_cb(struct nl_cache* cache, struct nl_object* obj, int acti
 				rofcore::logging::debug << rofcore::cnetlink::get_instance().get_links().get_link(ifindex).str() << std::endl;
 			} break;
 			case AF_INET6: {
-				rofcore::logging::debug << "[roflibs][cnetlink][route_neigh_cb] deleted neigh_in6" << std::endl << crtneigh_in4((struct rtnl_neigh*)obj);
+				rofcore::logging::debug << "[roflibs][cnetlink][route_neigh_cb] deleted neigh_in6" << std::endl << crtneigh_in6((struct rtnl_neigh*)obj);
 				unsigned int nbindex = cnetlink::get_instance().get_links().get_link(ifindex).get_neighs_in6().get_neigh(crtneigh_in6((struct rtnl_neigh*)obj));
 				cnetlink::get_instance().notify_neigh_in6_deleted(ifindex, nbindex);
 				cnetlink::get_instance().set_links().set_link(ifindex).set_neighs_in6().drop_neigh(nbindex);


### PR DESCRIPTION
* fixed daemonize switch (now default to not daemonize if there is no daemonize switch)
* fixed wrong typecast for v6 neighbor addresses
* update to rofl-common