### PR TITLE
a bunch of cleanup

### DIFF
--- a/src/roflibs/netlink/crtlink.hpp
+++ b/src/roflibs/netlink/crtlink.hpp
@@ -20,9 +20,10 @@
 #include <netlink/route/link.h>
 #include <netlink/route/link/bridge.h>
 #include <inttypes.h>
+#include <linux/if.h>
 #include <linux/if_arp.h>
 
-#include <roflibs/netlink/crtneighs.hpp>
+#include "roflibs/netlink/crtneighs.hpp"
 
 namespace rofcore {
 

--- a/src/roflibs/netlink/crtneigh.hpp
+++ b/src/roflibs/netlink/crtneigh.hpp
@@ -2,20 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef CRTNEIGH_H_
-#define CRTNEIGH_H_ 1
+#pragma once
 
 #include <ostream>
+#include <cinttypes>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-#include <inttypes.h>
 #include <netlink/route/neighbour.h>
 #include <linux/neighbour.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include <rofl/common/caddress.h>
 
@@ -27,39 +20,27 @@ class crtneigh {
 public:
   class eRtNeighBase : public std::runtime_error {
   public:
-    eRtNeighBase(const std::string &__arg) : std::runtime_error(__arg){};
+    eRtNeighBase(const std::string &__arg) : std::runtime_error(__arg){}
   };
   class eRtNeighNotFound : public eRtNeighBase {
   public:
-    eRtNeighNotFound(const std::string &__arg) : eRtNeighBase(__arg){};
+    eRtNeighNotFound(const std::string &__arg) : eRtNeighBase(__arg){}
   };
   class eRtNeighExists : public eRtNeighBase {
   public:
-    eRtNeighExists(const std::string &__arg) : eRtNeighBase(__arg){};
+    eRtNeighExists(const std::string &__arg) : eRtNeighBase(__arg){}
   };
 
 public:
-  /**
-   *
-   */
   crtneigh()
       : state(0), flags(0), ifindex(0),
         lladdr(rofl::cmacaddr("00:00:00:00:00:00")), family(0), type(0),
-        vlan(0){};
+        vlan(0){}
 
-  /**
-   *
-   */
-  virtual ~crtneigh(){};
+  virtual ~crtneigh() {};
 
-  /**
-   *
-   */
-  crtneigh(const crtneigh &rtneigh) { *this = rtneigh; };
+  crtneigh(const crtneigh &rtneigh) { *this = rtneigh; }
 
-  /**
-   *
-   */
   crtneigh &operator=(const crtneigh &neigh) {
     if (this == &neigh)
       return *this;
@@ -73,11 +54,8 @@ public:
     vlan = neigh.vlan;
 
     return *this;
-  };
+  }
 
-  /**
-   *
-   */
   crtneigh(struct rtnl_neigh *neigh)
       : state(0), flags(0), ifindex(0),
         lladdr(rofl::cmacaddr("00:00:00:00:00:00")), family(0), type(0) {
@@ -103,26 +81,17 @@ public:
 
     nl_object_put(
         (struct nl_object *)neigh); // decrement reference counter by one
-  };
+  }
 
-  /**
-   *
-   */
   bool operator==(const crtneigh &rtneigh) {
     return ((ifindex == rtneigh.ifindex) && (family == rtneigh.family) &&
             (type == rtneigh.type) && (vlan == rtneigh.vlan) &&
             (lladdr == rtneigh.lladdr));
-  };
+  }
 
 public:
-  /**
-   *
-   */
-  int get_state() const { return state; };
+  int get_state() const { return state; }
 
-  /**
-   *
-   */
   std::string get_state_s() const {
     std::string str;
 
@@ -151,37 +120,19 @@ public:
     }
 
     return str;
-  };
+  }
 
-  /**
-   *
-   */
-  unsigned int get_flags() const { return flags; };
+  unsigned int get_flags() const { return flags; }
 
-  /**
-   *
-   */
-  int get_ifindex() const { return ifindex; };
+  int get_ifindex() const { return ifindex; }
 
-  /**
-   *
-   */
-  const rofl::cmacaddr &get_lladdr() const { return lladdr; };
+  const rofl::cmacaddr &get_lladdr() const { return lladdr; }
 
-  /**
-   *
-   */
-  int get_family() const { return family; };
+  int get_family() const { return family; }
 
-  /**
-   *
-   */
-  int get_type() const { return type; };
+  int get_type() const { return type; }
 
-  /**
-   *
-   */
-  int get_vlan() const { return vlan; };
+  int get_vlan() const { return vlan; }
 
 public:
   friend std::ostream &operator<<(std::ostream &os, crtneigh const &neigh) {
@@ -197,7 +148,7 @@ public:
     os << rofcore::indent(2) << "<type: " << neigh.type << " >" << std::endl;
     os << rofcore::indent(2) << "<vlan: " << neigh.vlan << " >" << std::endl;
     return os;
-  };
+  }
 
 private:
   int state;
@@ -209,56 +160,33 @@ private:
   int vlan;
 };
 
-/**
- *
- */
 class crtneigh_ll_find : public std::unary_function<crtneigh, bool> {
   crtneigh rtneigh;
 
 public:
-  crtneigh_ll_find(const crtneigh &rtneigh) : rtneigh(rtneigh){};
-  bool operator()(const crtneigh &rtn) { return (rtneigh == rtn); };
+  crtneigh_ll_find(const crtneigh &rtneigh) : rtneigh(rtneigh){}
+  bool operator()(const crtneigh &rtn) { return (rtneigh == rtn); }
   bool operator()(const std::pair<unsigned int, crtneigh> &p) {
     return (rtneigh == p.second);
-  };
-#if 0
-	bool operator() (const std::pair<unsigned int, crtneigh*>& p) {
-		return (rtneigh == *(p.second));
-	};
-#endif
+  }
 };
 
 class crtneigh_in4 : public crtneigh {
 public:
-  /**
-   *
-   */
-  crtneigh_in4(){};
+  crtneigh_in4(){}
 
-  /**
-   *
-   */
-  virtual ~crtneigh_in4(){};
+  ~crtneigh_in4() override {};
 
-  /**
-   *
-   */
-  crtneigh_in4(const crtneigh_in4 &neigh) { *this = neigh; };
+  crtneigh_in4(const crtneigh_in4 &neigh) { *this = neigh; }
 
-  /**
-   *
-   */
   crtneigh_in4 &operator=(const crtneigh_in4 &neigh) {
     if (this == &neigh)
       return *this;
     crtneigh::operator=(neigh);
     dst = neigh.dst;
     return *this;
-  };
+  }
 
-  /**
-   *
-   */
   crtneigh_in4(struct rtnl_neigh *neigh) : crtneigh(neigh) {
 
     nl_object_get(
@@ -279,20 +207,14 @@ public:
 
     nl_object_put(
         (struct nl_object *)neigh); // decrement reference counter by one
-  };
+  }
 
-  /**
-   *
-   */
   bool operator==(const crtneigh_in4 &rtneigh) {
     return ((crtneigh::operator==(rtneigh)) && (dst == rtneigh.dst));
-  };
+  }
 
 public:
-  /**
-   *
-   */
-  const rofl::caddress_in4 get_dst() const { return dst; };
+  const rofl::caddress_in4 get_dst() const { return dst; }
 
 public:
   friend std::ostream &operator<<(std::ostream &os, const crtneigh_in4 &neigh) {
@@ -302,7 +224,7 @@ public:
     os << rofcore::indent(2) << "<dst: " << neigh.dst.str() << " >"
        << std::endl;
     return os;
-  };
+  }
 
   std::string str() const {
     /*
@@ -324,75 +246,49 @@ public:
     if (get_flags() & NUD_FAILED)
       ss << "FAILED";
     return ss.str();
-  };
+  }
 
-  /**
-   *
-   */
   class crtneigh_in4_find_by_dst {
     rofl::caddress_in4 dst;
 
   public:
-    crtneigh_in4_find_by_dst(const rofl::caddress_in4 &dst) : dst(dst){};
+    crtneigh_in4_find_by_dst(const rofl::caddress_in4 &dst) : dst(dst){}
     bool operator()(const std::pair<uint16_t, crtneigh_in4> &p) {
       return (p.second.dst == dst);
-    };
+    }
   };
 
 private:
   rofl::caddress_in4 dst;
 };
 
-/**
- *
- */
 class crtneigh_in4_find : public std::unary_function<crtneigh_in4, bool> {
   crtneigh_in4 rtneigh;
 
 public:
-  crtneigh_in4_find(const crtneigh_in4 &rtneigh) : rtneigh(rtneigh){};
-  bool operator()(const crtneigh_in4 &rtn) { return (rtneigh == rtn); };
+  crtneigh_in4_find(const crtneigh_in4 &rtneigh) : rtneigh(rtneigh){}
+  bool operator()(const crtneigh_in4 &rtn) { return (rtneigh == rtn); }
   bool operator()(const std::pair<unsigned int, crtneigh_in4> &p) {
     return (rtneigh == p.second);
-  };
-#if 0
-	bool operator() (const std::pair<unsigned int, crtneigh_in4*>& p) {
-		return (rtneigh == *(p.second));
-	};
-#endif
+  }
 };
 
 class crtneigh_in6 : public crtneigh {
 public:
-  /**
-   *
-   */
-  crtneigh_in6(){};
+  crtneigh_in6(){}
 
-  /**
-   *
-   */
-  virtual ~crtneigh_in6(){};
+  ~crtneigh_in6() override {};
 
-  /**
-   *
-   */
-  crtneigh_in6(const crtneigh_in6 &neigh) { *this = neigh; };
+  crtneigh_in6(const crtneigh_in6 &neigh) { *this = neigh; }
 
-  /**
-   *
-   */
   crtneigh_in6 &operator=(const crtneigh_in6 &neigh) {
     if (this == &neigh)
       return *this;
     crtneigh::operator=(neigh);
     dst = neigh.dst;
     return *this;
-  };
+  }
 
-  /**
-   *
-   */
   crtneigh_in6(struct rtnl_neigh *neigh) : crtneigh(neigh) {
 
     nl_object_get(
@@ -413,20 +309,14 @@ public:
 
     nl_object_put(
         (struct nl_object *)neigh); // decrement reference counter by one
-  };
+  }
 
-  /**
-   *
-   */
   bool operator==(const crtneigh_in6 &rtneigh) {
     return ((crtneigh::operator==(rtneigh)) && (dst == rtneigh.dst));
-  };
+  }
 
 public:
-  /**
-   *
-   */
-  const rofl::caddress_in6 get_dst() const { return dst; };
+  const rofl::caddress_in6 get_dst() const { return dst; }
 
 public:
   friend std::ostream &operator<<(std::ostream &os, const crtneigh_in6 &neigh) {
@@ -436,7 +326,7 @@ public:
     os << rofcore::indent(2) << "<dst: " << neigh.dst.str() << " >"
        << std::endl;
     return os;
-  };
+  }
 
   std::string str() const {
     /*
@@ -458,44 +348,31 @@ public:
     if (get_flags() & NUD_FAILED)
       ss << "FAILED";
     return ss.str();
-  };
+  }
 
-  /**
-   *
-   */
   class crtneigh_in6_find_by_dst {
     rofl::caddress_in6 dst;
 
   public:
-    crtneigh_in6_find_by_dst(const rofl::caddress_in6 &dst) : dst(dst){};
+    crtneigh_in6_find_by_dst(const rofl::caddress_in6 &dst) : dst(dst){}
     bool operator()(const std::pair<uint16_t, crtneigh_in6> &p) {
       return (p.second.dst == dst);
-    };
+    }
   };
 
 private:
   rofl::caddress_in6 dst;
 };
 
-/**
- *
- */
 class crtneigh_in6_find : public std::unary_function<crtneigh_in6, bool> {
   crtneigh_in6 rtneigh;
 
 public:
-  crtneigh_in6_find(const crtneigh_in6 &rtneigh) : rtneigh(rtneigh){};
-  bool operator()(const crtneigh_in6 &rtn) { return (rtneigh == rtn); };
+  crtneigh_in6_find(const crtneigh_in6 &rtneigh) : rtneigh(rtneigh){}
+  bool operator()(const crtneigh_in6 &rtn) { return (rtneigh == rtn); }
   bool operator()(const std::pair<unsigned int, crtneigh_in6> &p) {
     return (rtneigh == p.second);
-  };
-#if 0
-	bool operator() (const std::pair<unsigned int, crtneigh_in6*>& p) {
-		return (rtneigh == *(p.second));
-	};
-#endif
+  }
 };
 
-}; // end of namespace
-
-#endif /* CRTNEIGH_H_ */
+} // end of namespace

--- a/src/roflibs/netlink/ctapdev.hpp
+++ b/src/roflibs/netlink/ctapdev.hpp
@@ -5,46 +5,15 @@
 #ifndef CTAPDEV_H_
 #define CTAPDEV_H_ 1
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <linux/if_tun.h>
-#include <sys/ioctl.h>
-#include <unistd.h>
-#include <errno.h>
-
 #include <deque>
+#include <exception>
 
 #include <rofl/common/cthread.hpp>
-#include <rofl/common/cdptid.h>
 #include <rofl/common/cpacket.h>
-
-#include "roflibs/netlink/clogging.hpp"
 
 namespace rofcore {
 
 class tap_callback;
-
-class eTapDevBase : public std::runtime_error {
-public:
-  eTapDevBase(const std::string &__arg) : std::runtime_error(__arg) {}
-};
-class eTapDevSysCallFailed : public eTapDevBase {
-public:
-  eTapDevSysCallFailed(const std::string &__arg) : eTapDevBase(__arg) {}
-};
-class eTapDevOpenFailed : public eTapDevSysCallFailed {
-public:
-  eTapDevOpenFailed(const std::string &__arg) : eTapDevSysCallFailed(__arg) {}
-};
-class eTapDevIoctlFailed : public eTapDevSysCallFailed {
-public:
-  eTapDevIoctlFailed(const std::string &__arg) : eTapDevSysCallFailed(__arg) {}
-};
-class eTapDevNotFound : public eTapDevBase {
-public:
-  eTapDevNotFound(const std::string &__arg) : eTapDevBase(__arg) {}
-};
 
 class ctapdev : public rofl::cthread_env {
 
@@ -52,7 +21,6 @@ class ctapdev : public rofl::cthread_env {
   std::deque<rofl::cpacket *> pout_queue; // queue of outgoing packets
   mutable rofl::crwlock pout_queue_rwlock;
   std::string devname;
-  uint16_t pvid;
   rofl::cthread thread;
   tap_callback &cb;
 
@@ -86,14 +54,6 @@ public:
   virtual void enqueue(std::vector<rofl::cpacket *> pkts);
 
   /**
-   *
-   */
-  uint16_t get_pvid() const { return pvid; }
-
-protected:
-  void tx();
-
-  /**
    * @brief	open tapX device
    */
   void tap_open();
@@ -103,6 +63,9 @@ protected:
    *
    */
   void tap_close();
+
+protected:
+  void tx();
 
   /**
    * @brief	handle read events on file descriptor
@@ -115,12 +78,6 @@ protected:
   virtual void handle_write_event(rofl::cthread &thread, int fd);
 
   virtual void handle_wakeup(rofl::cthread &thread) { tx(); }
-
-  /**
-   * @brief	reschedule opening of port in case of failure
-   */
-  virtual void handle_timeout(rofl::cthread &thread, uint32_t timer_id,
-                              const std::list<unsigned int> &ttypes);
 };
 
 } // end of namespace rofcore

--- a/src/roflibs/netlink/tap_manager.cpp
+++ b/src/roflibs/netlink/tap_manager.cpp
@@ -46,6 +46,7 @@ int tap_manager::create_tapdev(const std::string &port_name, tap_callback &cb) {
     r = devs.size();
     devs.push_back(dev);
 
+    dev->tap_open();
     devname_to_spot.insert(std::make_pair(port_name, r));
   }
   return r;

--- a/src/roflibs/of-dpa/cbasebox.cpp
+++ b/src/roflibs/of-dpa/cbasebox.cpp
@@ -308,9 +308,6 @@ void cbasebox::handle_acl_policy_table(rofl::crofdpt &dpt,
   } catch (rofcore::ePacketPoolExhausted &e) {
     logging::error << __FUNCTION__ << " ePacketPoolExhausted: " << e.what()
                    << std::endl;
-  } catch (rofcore::eTapDevNotFound &e) {
-    logging::error << __FUNCTION__ << " eTapDevNotFound: " << e.what()
-                   << std::endl;
   } catch (std::exception &e) {
     logging::error << __FUNCTION__ << " exception: " << e.what() << std::endl;
   }

--- a/src/roflibs/of-dpa/cbasebox.hpp
+++ b/src/roflibs/of-dpa/cbasebox.hpp
@@ -5,8 +5,6 @@
 #ifndef CROFBASE_HPP_
 #define CROFBASE_HPP_
 
-#define OF_DPA
-
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -81,7 +79,7 @@ public:
 
   static bool running() { return keep_on_running; }
 
-  static void stop() { keep_on_running = false; };
+  static void stop() { keep_on_running = false; }
 
 protected:
   void handle_wakeup(rofl::cthread &thread) override;


### PR DESCRIPTION
mostly headers

and ctapdev:
* don't close tapdevs if open is called again
* check IFNAMSIZ of port name
* don't open/create tapdev during constructor, but during open
* remove obsolet pvid
