### PR TITLE
Reading rx_size and tx_size from /proc/sys/net/...

### DIFF
--- a/src/roflibs/netlink/cnetlink.hpp
+++ b/src/roflibs/netlink/cnetlink.hpp
@@ -83,6 +83,8 @@ class cnetlink : public rofl::cthread_env, public rofcore::nbi {
 
   ~cnetlink() override;
 
+  int load_from_file(const std::string &path);
+
   void init_caches();
 
   void destroy_caches();


### PR DESCRIPTION
In cnetlink.cpp added file read statements to load the rx_size and tx_size buffer sizes from /proc/sys/net/core/rmem_max and /proc/sys/net/core/wmem_max respectively