### PR TITLE
fix race condition when link gets deleted

### DIFF
--- a/src/roflibs/netlink/nbi_impl.cpp
+++ b/src/roflibs/netlink/nbi_impl.cpp
@@ -33,8 +33,8 @@ void nbi_impl::port_notification(
       tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this);
       break;
     case PORT_EVENT_DEL:
-      tap_man->destroy_tapdev(ntfy.port_id, ntfy.name);
       cnetlink::get_instance().unregister_link(ntfy.port_id, ntfy.name);
+      tap_man->destroy_tapdev(ntfy.port_id, ntfy.name);
       break;
     default:
       break;

--- a/src/roflibs/netlink/tap_manager.cpp
+++ b/src/roflibs/netlink/tap_manager.cpp
@@ -23,6 +23,9 @@ int tap_manager::create_tapdev(uint32_t port_id, const std::string &port_name,
       LOG(ERROR) << __FUNCTION__ << ": failed to create tapdev " << port_name;
       r = -EINVAL;
     }
+  } else {
+    LOG(INFO) << __FUNCTION__ << ": " << port_name
+              << " with port_id=" << port_id << " already existing";
   }
   return r;
 }
@@ -34,8 +37,9 @@ int tap_manager::destroy_tapdev(uint32_t port_id,
     return 0;
   }
 
-  delete it->second;
+  auto dev = it->second;
   devs.erase(it);
+  delete dev;
 
   return 0;
 }


### PR DESCRIPTION
* remove link from registered links before deleting it:

E1028 18:06:13.851470 28380 cnetlink.cpp:195] handle_wakeup: no ifindex of port_id=5 found
E1028 18:07:17.923408 28380 cnetlink.cpp:711] neigh_ll_deleted: eRtLinkNotFound: crtlinks::get_link() / error: ifin
F1028 18:07:17.923449 28380 cnetlink.cpp:365] route_link_apply: insertion to registered_port_to_ifindex failed

* neigh_ll_deleted updated as well, since l2 fdb is updated later
* registered_port_to_ifindex was not erased