### PR TITLE
run tap io single threaded

### DIFF
--- a/src/roflibs/netlink/ctapdev.cpp
+++ b/src/roflibs/netlink/ctapdev.cpp
@@ -17,34 +17,20 @@
 
 namespace rofcore {
 
-static inline void release_packets(std::deque<rofl::cpacket *> &q) {
-  for (auto i : q) {
-    cpacketpool::get_instance().release_pkt(i);
-  }
-}
-
-ctapdev::ctapdev(tap_callback &cb, std::string const &devname, uint32_t port_id,
-                 pthread_t tid)
-    : fd(-1), devname(devname), thread(this), cb(cb), port_id(port_id) {
+ctapdev::ctapdev(std::string const &devname) : fd(-1), devname(devname) {
   if (devname.size() > IFNAMSIZ) {
     throw std::length_error("devname.size() > IFNAMSIZ");
   }
 }
 
-ctapdev::~ctapdev() {
-  tap_close();
-  thread.stop();
-
-  release_packets(pout_queue);
-}
+ctapdev::~ctapdev() { tap_close(); }
 
 void ctapdev::tap_open() {
   struct ifreq ifr;
   int rc;
 
   if (fd != -1) {
-    VLOG(1) << __FUNCTION__ << ": tapdev " << devname
-            << " is alredy open using fd=" << fd;
+    VLOG(1) << __FUNCTION__ << ": tapdev is already open using fd=" << fd;
     return;
   }
 
@@ -63,30 +49,13 @@ void ctapdev::tap_open() {
     LOG(FATAL) << __FUNCTION__ << ": ioctl TUNSETIFF failed on fd=" << fd;
   }
 
-  thread.add_read_fd(fd, true, false);
-  thread.add_write_fd(fd, true, false);
-  thread.start();
-
-  LOG(INFO) << __FUNCTION__ << ": created tapdev " << devname
-            << " port_id=" << port_id << " fd=" << fd
-            << " tid=" << thread.get_thread_id();
+  LOG(INFO) << __FUNCTION__ << ": created tapdev " << devname << " fd=" << fd
+            << " tid=" << pthread_self();
 }
 
 void ctapdev::tap_close() {
   if (fd == -1) {
     return;
-  }
-
-  try {
-    thread.drop_read_fd(fd);
-  } catch (std::exception &e) {
-    LOG(ERROR) << __FUNCTION__ << ": failed to drop read fd=" << fd;
-  }
-
-  try {
-    thread.drop_write_fd(fd);
-  } catch (std::exception &e) {
-    LOG(ERROR) << __FUNCTION__ << ": failed to drop write fd=" << fd;
   }
 
   int rv = close(fd);
@@ -96,97 +65,7 @@ void ctapdev::tap_close() {
   fd = -1;
 
   LOG(INFO) << __FUNCTION__ << ": closed tapdev " << devname
-            << " port_id=" << port_id << " tid=" << thread.get_thread_id();
-}
-
-void ctapdev::enqueue(rofl::cpacket *pkt) {
-  if (fd == -1) {
-    cpacketpool::get_instance().release_pkt(pkt);
-    return;
-  }
-
-  // store pkt in outgoing queue
-  {
-    rofl::AcquireReadWriteLock rwlock(pout_queue_rwlock);
-    pout_queue.push_back(pkt);
-  }
-
-  thread.wakeup();
-}
-
-void ctapdev::handle_read_event(rofl::cthread &thread, int fd) {
-  rofl::cpacket *pkt = nullptr;
-  try {
-    pkt = cpacketpool::get_instance().acquire_pkt();
-
-    ssize_t n_bytes = read(fd, pkt->soframe(), pkt->length());
-
-    // error occured (or non-blocking)
-    if (n_bytes < 0) {
-      switch (errno) {
-      case EAGAIN:
-        LOG(ERROR) << __FUNCTION__
-                   << ": EAGAIN XXX not implemented packet is dropped";
-        cpacketpool::get_instance().release_pkt(pkt);
-      default:
-        LOG(ERROR) << __FUNCTION__ << ": unknown error occured";
-        cpacketpool::get_instance().release_pkt(pkt);
-      }
-    } else {
-      VLOG(2) << __FUNCTION__ << ": read " << n_bytes << " bytes from fd=" << fd
-              << " (" << devname << ") into pkt=" << pkt
-              << " enqueuing as port_id=" << port_id
-              << " tid=" << pthread_self();
-      cb.enqueue_to_switch(port_id, pkt);
-    }
-
-  } catch (ePacketPoolExhausted &e) {
-    LOG(ERROR) << __FUNCTION__
-               << ": packet pool exhausted, no idle slots available";
-  }
-}
-
-void ctapdev::handle_write_event(rofl::cthread &thread, int fd) { tx(); }
-
-void ctapdev::tx() {
-  rofl::cpacket *pkt = NULL;
-  std::deque<rofl::cpacket *> out_queue;
-
-  {
-    rofl::AcquireReadWriteLock rwlock(pout_queue_rwlock);
-    std::swap(out_queue, pout_queue);
-  }
-
-  while (not out_queue.empty()) {
-
-    pkt = out_queue.front();
-    int rc = 0;
-    if ((rc = write(fd, pkt->soframe(), pkt->length())) < 0) {
-      switch (errno) {
-      case EAGAIN:
-        VLOG(1) << __FUNCTION__ << ": EAGAIN";
-        {
-          rofl::AcquireReadWriteLock rwlock(pout_queue_rwlock);
-          std::move(out_queue.rbegin(), out_queue.rend(),
-                    std::front_inserter(pout_queue));
-        }
-        return;
-      case EIO:
-        // tap not enabled drop packet
-        VLOG(1) << __FUNCTION__ << ": EIO";
-        release_packets(out_queue);
-        return;
-      default:
-        // will drop packets
-        release_packets(out_queue);
-        LOG(ERROR) << __FUNCTION__ << ": unknown error occured rc=" << rc
-                   << " errno=" << errno << " '" << strerror(errno);
-        return;
-      }
-    }
-    cpacketpool::get_instance().release_pkt(pkt);
-    out_queue.pop_front();
-  }
+            << " tid=" << pthread_self();
 }
 
 } // namespace rofcore

--- a/src/roflibs/netlink/ctapdev.hpp
+++ b/src/roflibs/netlink/ctapdev.hpp
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef CTAPDEV_H_
-#define CTAPDEV_H_ 1
+#pragma once
 
 #include <deque>
 #include <exception>
@@ -13,29 +12,16 @@
 
 namespace rofcore {
 
-class tap_callback {
-public:
-  //  virtual ~tap_callback(){};
-  virtual int enqueue_to_switch(uint32_t port_id, rofl::cpacket *) = 0;
-};
-
-class ctapdev : public rofl::cthread_env {
-  int fd;                                 // tap device file descriptor
-  std::deque<rofl::cpacket *> pout_queue; // queue of outgoing packets
-  mutable rofl::crwlock pout_queue_rwlock;
+class ctapdev {
+  int fd; // tap device file descriptor
   std::string devname;
-  rofl::cthread thread;
-  tap_callback &cb;
-  uint32_t port_id;
 
 public:
   /**
    *
-   * @param netdev_owner
    * @param devname
    */
-  ctapdev(tap_callback &cb, std::string const &devname, uint32_t port_id,
-          pthread_t tid = 0);
+  ctapdev(std::string const &devname);
 
   /**
    *
@@ -43,14 +29,6 @@ public:
   virtual ~ctapdev();
 
   const std::string &get_devname() const { return devname; }
-
-  /**
-   * @brief	Enqueues a single rofl::cpacket instance on cnetdev.
-   *
-   * rofl::cpacket instance must have been allocated on heap and must
-   * be removed
-   */
-  virtual void enqueue(rofl::cpacket *pkt);
 
   /**
    * @brief	open tapX device
@@ -63,22 +41,7 @@ public:
    */
   void tap_close();
 
-protected:
-  void tx();
-
-  /**
-   * @brief	handle read events on file descriptor
-   */
-  virtual void handle_read_event(rofl::cthread &thread, int fd);
-
-  /**
-   * @brief	handle write events on file descriptor
-   */
-  virtual void handle_write_event(rofl::cthread &thread, int fd);
-
-  virtual void handle_wakeup(rofl::cthread &thread) { tx(); }
+  int get_fd() const { return fd; }
 };
 
 } // end of namespace rofcore
-
-#endif /* CTAPDEV_H_ */

--- a/src/roflibs/netlink/nbi_impl.cpp
+++ b/src/roflibs/netlink/nbi_impl.cpp
@@ -59,7 +59,7 @@ int nbi_impl::enqueue(uint32_t port_id, rofl::cpacket *pkt) noexcept {
   int rv = 0;
   assert(pkt);
   try {
-    tap_man->get_dev(port_id)->enqueue(pkt);
+    tap_man->enqueue(port_id, pkt);
   } catch (std::exception &e) {
     LOG(ERROR) << __FUNCTION__
                << ": failed to enqueue packet for port_id=" << port_id << ": "

--- a/src/roflibs/netlink/nbi_impl.hpp
+++ b/src/roflibs/netlink/nbi_impl.hpp
@@ -11,7 +11,7 @@ namespace rofcore {
 
 class tap_manager;
 
-class nbi_impl : public nbi, public tap_callback {
+class nbi_impl : public nbi, public switch_callback {
   std::unique_ptr<tap_manager> tap_man;
   switch_interface *swi;
 

--- a/src/roflibs/netlink/tap_manager.cpp
+++ b/src/roflibs/netlink/tap_manager.cpp
@@ -4,21 +4,166 @@
 
 #include <glog/logging.h>
 #include "roflibs/netlink/tap_manager.hpp"
+#include "roflibs/netlink/cpacketpool.hpp"
 
 namespace rofcore {
+
+static inline void
+release_packets(std::deque<std::pair<int, rofl::cpacket *>> &q) {
+  for (auto i : q) {
+    cpacketpool::get_instance().release_pkt(i.second);
+  }
+}
+
+tap_io::~tap_io() { thread.stop(); }
+
+void tap_io::register_tap(int fd, uint32_t port_id, switch_callback &cb) {
+  {
+    std::lock_guard<std::mutex> guard(events_mutex);
+    events.emplace_back(std::make_tuple(TAP_IO_ADD, fd, port_id, &cb));
+  }
+
+  thread.wakeup();
+}
+
+void tap_io::unregister_tap(int fd, uint32_t port_id) {
+  {
+    std::lock_guard<std::mutex> guard(events_mutex);
+    events.emplace_back(std::make_tuple(TAP_IO_REM, fd, port_id, nullptr));
+  }
+
+  thread.wakeup();
+}
+
+void tap_io::enqueue(int fd, rofl::cpacket *pkt) {
+  if (fd == -1) {
+    cpacketpool::get_instance().release_pkt(pkt);
+    return;
+  }
+
+  // store pkt in outgoing queue
+  std::lock_guard<std::mutex> guard(pout_queue_mutex);
+  pout_queue.emplace_back(std::make_pair(fd, pkt));
+}
+
+void tap_io::handle_read_event(rofl::cthread &thread, int fd) {
+  rofl::cpacket *pkt = nullptr;
+  try {
+    pkt = cpacketpool::get_instance().acquire_pkt();
+
+    ssize_t n_bytes = read(fd, pkt->soframe(), pkt->length());
+
+    // error occured (or non-blocking)
+    if (n_bytes < 0) {
+      switch (errno) {
+      case EAGAIN:
+        LOG(ERROR) << __FUNCTION__
+                   << ": EAGAIN XXX not implemented packet is dropped";
+        cpacketpool::get_instance().release_pkt(pkt);
+      default:
+        LOG(ERROR) << __FUNCTION__ << ": unknown error occured";
+        cpacketpool::get_instance().release_pkt(pkt);
+      }
+    } else {
+      VLOG(1) << __FUNCTION__ << ": read " << n_bytes << " bytes from fd=" << fd
+              << " into pkt=" << pkt << " tid=" << pthread_self();
+      // std::map<int, std::pair<uint32_t, switch_callback *>> sw_cbs;
+      std::pair<uint32_t, switch_callback *> &cb = sw_cbs.at(fd);
+      cb.second->enqueue_to_switch(cb.first, pkt);
+    }
+
+  } catch (ePacketPoolExhausted &e) {
+    LOG(ERROR) << __FUNCTION__
+               << ": packet pool exhausted, no idle slots available";
+  }
+}
+
+void tap_io::handle_write_event(rofl::cthread &thread, int fd) { tx(); }
+
+void tap_io::tx() {
+  std::pair<int, rofl::cpacket *> pkt;
+  std::deque<std::pair<int, rofl::cpacket *>> out_queue;
+
+  {
+    std::lock_guard<std::mutex> guard(pout_queue_mutex);
+    std::swap(out_queue, pout_queue);
+  }
+
+  while (not out_queue.empty()) {
+
+    pkt = out_queue.front();
+    int rc = 0;
+    if ((rc = write(pkt.first, pkt.second->soframe(), pkt.second->length())) <
+        0) {
+      switch (errno) {
+      case EAGAIN:
+        VLOG(1) << __FUNCTION__ << ": EAGAIN";
+        {
+          std::lock_guard<std::mutex> guard(pout_queue_mutex);
+          std::move(out_queue.rbegin(), out_queue.rend(),
+                    std::front_inserter(pout_queue));
+        }
+        return;
+      case EIO:
+        // tap not enabled drop packet
+        VLOG(1) << __FUNCTION__ << ": EIO";
+        release_packets(out_queue);
+        return;
+      default:
+        // will drop packets
+        release_packets(out_queue);
+        LOG(ERROR) << __FUNCTION__ << ": unknown error occured rc=" << rc
+                   << " errno=" << errno << " '" << strerror(errno);
+        return;
+      }
+    }
+    cpacketpool::get_instance().release_pkt(pkt.second);
+    out_queue.pop_front();
+  }
+}
+
+void tap_io::handle_events() {
+  std::lock_guard<std::mutex> guard(events_mutex);
+
+  // register fds
+  for (auto ev : events) {
+    int fd = std::get<1>(ev);
+    switch (std::get<0>(ev)) {
+
+    case TAP_IO_ADD:
+      sw_cbs.emplace(
+          std::make_pair(fd, std::make_pair(std::get<2>(ev), std::get<3>(ev))));
+      thread.add_read_fd(fd, true, false);
+      thread.add_write_fd(fd, true, false);
+      break;
+    case TAP_IO_REM:
+      thread.drop_read_fd(fd);
+      thread.drop_write_fd(fd);
+      sw_cbs.erase(fd);
+      break;
+    default:
+      break;
+    }
+  }
+}
 
 tap_manager::~tap_manager() { destroy_tapdevs(); }
 
 int tap_manager::create_tapdev(uint32_t port_id, const std::string &port_name,
-                               tap_callback &cb) {
+                               switch_callback &cb) {
   int r = 0;
   auto it = devs.find(port_id);
   if (it == devs.end()) {
     ctapdev *dev;
     try {
-      dev = new ctapdev(cb, port_name, port_id);
+      // XXX create mapping of port_ids?
+      dev = new ctapdev(port_name);
       devs.insert(std::make_pair(port_id, dev));
       dev->tap_open();
+      int fd = dev->get_fd();
+
+      io.register_tap(fd, port_id, cb);
+
     } catch (std::exception &e) {
       LOG(ERROR) << __FUNCTION__ << ": failed to create tapdev " << port_name;
       r = -EINVAL;
@@ -40,8 +185,12 @@ int tap_manager::destroy_tapdev(uint32_t port_id,
   }
 
   auto dev = it->second;
+  int fd = dev->get_fd();
   devs.erase(it);
   delete dev;
+
+  // XXX check if previous to delete
+  io.unregister_tap(fd, port_id);
 
   return 0;
 }
@@ -52,6 +201,18 @@ void tap_manager::destroy_tapdevs() {
   for (auto &dev : ddevs) {
     delete dev.second;
   }
+}
+
+int tap_manager::enqueue(uint32_t port_id, rofl::cpacket *pkt) {
+  try {
+    int fd = devs.at(port_id)->get_fd();
+    io.enqueue(fd, pkt);
+  } catch (std::exception &e) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to enqueue packet " << pkt
+               << " to port_id=" << port_id;
+    cpacketpool::get_instance().release_pkt(pkt);
+  }
+  return 0;
 }
 
 } // namespace rofcore

--- a/src/roflibs/netlink/tap_manager.hpp
+++ b/src/roflibs/netlink/tap_manager.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <mutex>
 
 #include <rofl/common/cpacket.h>
 
@@ -16,26 +17,77 @@
 
 namespace rofcore {
 
+class tap_io;
+class tap_manager;
+
+class switch_callback {
+public:
+  virtual int enqueue_to_switch(uint32_t port_id, rofl::cpacket *) = 0;
+};
+
+class tap_io : public rofl::cthread_env {
+  enum tap_io_event {
+    TAP_IO_ADD,
+    TAP_IO_REM,
+  };
+
+  rofl::cthread thread;
+  std::deque<std::pair<int, rofl::cpacket *>> pout_queue;
+  std::mutex pout_queue_mutex;
+
+  std::deque<std::tuple<enum tap_io_event, int, uint32_t, switch_callback *>>
+      events;
+  std::mutex events_mutex;
+
+  std::deque<std::pair<int, rofl::cpacket *>> pin_queue;
+  std::map<int, std::pair<uint32_t, switch_callback *>> sw_cbs;
+
+public:
+  tap_io() : thread(this) { thread.start(); };
+  virtual ~tap_io();
+
+  // port_id should be removed at some point and be rather data
+  void register_tap(int fd, uint32_t port_id, switch_callback &cb);
+  void unregister_tap(int fd, uint32_t port_id);
+  void enqueue(int fd, rofl::cpacket *pkt);
+
+protected:
+  void handle_read_event(rofl::cthread &thread, int fd);
+  void handle_write_event(rofl::cthread &thread, int fd);
+  void handle_wakeup(rofl::cthread &thread) {
+    handle_events();
+    tx();
+  }
+  void handle_timeout(rofl::cthread &thread, uint32_t timer_id,
+                      const std::list<unsigned int> &ttypes) {}
+
+private:
+  void tx();
+  void handle_events();
+};
+
 class tap_manager final {
 
 public:
-  tap_manager(){};
+  tap_manager() {}
   ~tap_manager();
 
   int create_tapdev(uint32_t port_id, const std::string &port_name,
-                    tap_callback &callback);
+                    switch_callback &callback);
 
   int destroy_tapdev(uint32_t port_id, const std::string &port_name);
 
   void destroy_tapdevs();
 
-  ctapdev *get_dev(uint32_t port_id) { return devs.at(port_id); }
+  int enqueue(uint32_t port_id, rofl::cpacket *pkt);
 
 private:
   tap_manager(const tap_manager &other) = delete; // non construction-copyable
   tap_manager &operator=(const tap_manager &) = delete; // non copyable
 
   std::map<uint32_t, ctapdev *> devs;
+
+  rofcore::tap_io io;
 };
 
 } // namespace rofcore


### PR DESCRIPTION
every tap interface currently creates a thread for its io. This is now
merged into a single thread for performance reasonns.

use override syntax for rofl interface