### PR TITLE
nbi: add missing include

### DIFF
--- a/src/roflibs/netlink/nbi_impl.hpp
+++ b/src/roflibs/netlink/nbi_impl.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "sai.hpp"
 #include "tap_manager.hpp"
 


### PR DESCRIPTION
compilation on CentOS 7 failed due to this