### PR TITLE
rofl-common 0.12.0 adaptations

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = NAME
   config.vm.box = "fedora/25-cloud-base"
   config.vm.network "forwarded_port", guest: 6653, host: 6653
-  config.vm.synced_folder "salt/roots/", "/srv/salt/"
+  config.vm.synced_folder "salt/roots/", "/srv/salt/", type: "nfs", nfs_version: 4, nfs_udp: false
 
   config.vm.provision :salt do |salt|
     salt.masterless = true
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :libvirt do |libvirt, override|
-    override.vm.synced_folder "./", "/vagrant", type: "nfs"
+    override.vm.synced_folder "./", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
     libvirt.memory = 1024
     libvirt.cpus = 2
   end

--- a/configure.ac
+++ b/configure.ac
@@ -77,10 +77,10 @@ PKG_CHECK_MODULES([LIBNL3], libnl-3.0 >= 3.2.28 libnl-route-3.0 >= 3.2.28,
 	LIBS="$LIBS $LIBNL3_LIBS"],
   [ AC_MSG_ERROR([minimum version of libnl-3 is 3.2.28]) ])
 
-PKG_CHECK_MODULES([ROFL], rofl_common >= 0.11.2,
+PKG_CHECK_MODULES([ROFL], rofl_common >= 0.12.0,
   [ CPPFLAGS="$CPPFLAGS $ROFL_CFLAGS"
 	LIBS="$LIBS $ROFL_LIBS" ],
-  [ AC_MSG_ERROR([minimum version of rofl_common is 0.11.2]) ])
+  [ AC_MSG_ERROR([minimum version of rofl_common is 0.12.0]) ])
 
 PKG_CHECK_MODULES([ROFL_OFDPA], rofl_ofdpa >= 0.8,
   [ CPPFLAGS="$CPPFLAGS $ROFL_OFDPA_CFLAGS"

--- a/src/roflibs/netlink/tap_manager.cpp
+++ b/src/roflibs/netlink/tap_manager.cpp
@@ -56,7 +56,7 @@ void tap_io::handle_read_event(rofl::cthread &thread, int fd) {
 
     ssize_t n_bytes = read(fd, pkt->soframe(), pkt->length());
 
-    // error occured (or non-blocking)
+    // error occurred (or non-blocking)
     if (n_bytes < 0) {
       switch (errno) {
       case EAGAIN:
@@ -64,7 +64,7 @@ void tap_io::handle_read_event(rofl::cthread &thread, int fd) {
                    << ": EAGAIN XXX not implemented packet is dropped";
         cpacketpool::get_instance().release_pkt(pkt);
       default:
-        LOG(ERROR) << __FUNCTION__ << ": unknown error occured";
+        LOG(ERROR) << __FUNCTION__ << ": unknown error occurred";
         cpacketpool::get_instance().release_pkt(pkt);
       }
     } else {
@@ -119,7 +119,7 @@ void tap_io::tx() {
       default:
         // will drop packets
         release_packets(out_queue);
-        LOG(ERROR) << __FUNCTION__ << ": unknown error occured rc=" << rc
+        LOG(ERROR) << __FUNCTION__ << ": unknown error occurred rc=" << rc
                    << " errno=" << errno << " '" << strerror(errno);
         return;
       }

--- a/src/roflibs/of-dpa/cbasebox.cpp
+++ b/src/roflibs/of-dpa/cbasebox.cpp
@@ -34,6 +34,9 @@ void cbasebox::handle_dpt_open(rofl::crofdpt &dpt) {
     return;
   }
 
+  // set max queue size in rofl
+  dpt.set_conn(rofl::cauxid(0)).set_txqueue_max_size(128 * 1024);
+
   dpt.send_features_request(rofl::cauxid(0));
   dpt.send_desc_stats_request(rofl::cauxid(0), 0);
   dpt.send_port_desc_stats_request(rofl::cauxid(0), 0);
@@ -92,7 +95,7 @@ void cbasebox::handle_conn_negotiation_failed(rofl::crofdpt &dpt,
   LOG(ERROR) << __FUNCTION__ << ": XXX not implemented";
 }
 
-void cbasebox::handle_conn_congestion_occured(rofl::crofdpt &dpt,
+void cbasebox::handle_conn_congestion_occurred(rofl::crofdpt &dpt,
                                               const rofl::cauxid &auxid) {
   LOG(ERROR) << __FUNCTION__ << ": XXX not implemented";
 }

--- a/src/roflibs/of-dpa/cbasebox.hpp
+++ b/src/roflibs/of-dpa/cbasebox.hpp
@@ -78,7 +78,7 @@ protected:
   void handle_conn_negotiation_failed(rofl::crofdpt &dpt,
                                       const rofl::cauxid &auxid) override;
 
-  void handle_conn_congestion_occured(rofl::crofdpt &dpt,
+  void handle_conn_congestion_occurred(rofl::crofdpt &dpt,
                                       const rofl::cauxid &auxid) override;
 
   void handle_conn_congestion_solved(rofl::crofdpt &dpt,


### PR DESCRIPTION
* updated configure.ac & Vagrantfile
* renaming of function to adapt to rofl-common 0.12.0
* typos corrected
* make use of `set_txqueue_max_size` of rofl 0.12.0 to increase tx queue size