### PR TITLE
OFDPA_OXM_ACTSET_OUTPUT = 43

### DIFF
--- a/src/of-dpa/ofdpa_datatypes.h
+++ b/src/of-dpa/ofdpa_datatypes.h
@@ -77,7 +77,7 @@ enum ofdpa_match_exp_type {
   OFDPA_OXM_PROTECTION_INDEX = 21,
   OFDPA_OXM_MPLS_TYPE = 23,
   OFDPA_OXM_ALLOW_VLAN_TRANSLATION = 24,
-  OFDPA_OXM_ACTSET_OUTPUT = 41,
+  OFDPA_OXM_ACTSET_OUTPUT = 43,
 };
 
 /* Flow Table Id enumerator */


### PR DESCRIPTION
* the value of `OFDPA_OXM_ACTSET_OUTPUT` in the TTP seems to differ from ofagent, so we use 43 to be compatible to ofagent