### PR TITLE
architectural rework to support additional ports

### DIFF
--- a/src/basebox_api.cc
+++ b/src/basebox_api.cc
@@ -1,5 +1,6 @@
 #include "basebox_api.h"
 #include "basebox_grpc_statistics.h"
+#include "sai.hpp"
 
 #include <glog/logging.h>
 #include <google/protobuf/repeated_field.h>
@@ -11,8 +12,9 @@
 
 namespace basebox {
 
-ApiServer::ApiServer(std::shared_ptr<switch_interface> swi)
-    : stats(new NetworkStats(swi)) {}
+ApiServer::ApiServer(std::shared_ptr<switch_interface> swi,
+                     std::shared_ptr<tap_manager> tap_man)
+    : stats(new NetworkStats(swi, tap_man)) {}
 
 ApiServer::~ApiServer() { delete stats; }
 

--- a/src/basebox_api.h
+++ b/src/basebox_api.h
@@ -1,15 +1,18 @@
 #pragma once
 
 #include <grpc++/server.h>
-#include "sai.hpp"
 
 namespace basebox {
 
+// forward declarations
 class NetworkStats;
+class switch_interface;
+class tap_manager;
 
 class ApiServer final {
 public:
-  ApiServer(std::shared_ptr<switch_interface> swi);
+  ApiServer(std::shared_ptr<switch_interface> swi,
+            std::shared_ptr<tap_manager> tap_man);
   void runGRPCServer();
   ~ApiServer();
 

--- a/src/basebox_grpc_statistics.h
+++ b/src/basebox_grpc_statistics.h
@@ -2,16 +2,21 @@
 
 #include <grpc++/grpc++.h>
 
-#include "sai.hpp"
 #include "services-definition.grpc.pb.h"
 
 namespace basebox {
+
+// forward declarations
+class switch_interface;
+class tap_manager;
 
 class NetworkStats final : public ::api::NetworkStatistics::Service {
 public:
   typedef ::api::Empty Empty;
 
-  NetworkStats(std::shared_ptr<switch_interface> swi);
+  NetworkStats(std::shared_ptr<switch_interface> swi,
+               std::shared_ptr<tap_manager> tap_man);
+
   virtual ~NetworkStats(){};
 
   ::grpc::Status
@@ -20,6 +25,7 @@ public:
 
 private:
   std::shared_ptr<switch_interface> swi;
+  std::shared_ptr<tap_manager> tap_man;
 };
 
 } // namespace basebox

--- a/src/netlink/cnetlink.hpp
+++ b/src/netlink/cnetlink.hpp
@@ -6,6 +6,7 @@
 
 #include <deque>
 #include <exception>
+#include <memory>
 #include <mutex>
 #include <tuple>
 
@@ -32,7 +33,15 @@ public:
   eNetLinkFailed(const std::string &__arg) : eNetLinkBase(__arg){};
 };
 
-class cnetlink : public rofl::cthread_env {
+// forward declaration
+class tap_manager;
+
+class cnetlink final : public rofl::cthread_env {
+
+  // non copyable
+  cnetlink(const cnetlink &other) = delete;
+  cnetlink &operator=(const cnetlink &) = delete;
+
   enum nl_cache_t {
     NL_ADDR_CACHE,
     NL_LINK_CACHE,
@@ -52,13 +61,11 @@ class cnetlink : public rofl::cthread_env {
   struct nl_sock *sock;
   struct nl_cache_mngr *mngr;
   std::vector<struct nl_cache *> caches;
-  std::map<std::string, uint32_t> registered_ports;
-  mutable std::mutex rp_mutex;
-  std::map<int, uint32_t> ifindex_to_registered_port;
-  std::map<uint32_t, int> registered_port_to_ifindex;
   std::deque<std::tuple<uint32_t, enum nbi::port_status, int>>
       port_status_changes;
   std::mutex pc_mutex;
+
+  std::shared_ptr<tap_manager> tap_man;
 
   ofdpa_bridge *bridge;
   int nl_proc_max;
@@ -81,10 +88,6 @@ class cnetlink : public rofl::cthread_env {
     EVENT_UPDATE_LINKS,
   };
 
-  cnetlink(switch_interface *);
-
-  ~cnetlink() override;
-
   int load_from_file(const std::string &path);
 
   void init_caches();
@@ -99,30 +102,19 @@ class cnetlink : public rofl::cthread_env {
 
   void handle_timeout(rofl::cthread &thread, uint32_t timer_id) override;
 
-  void link_created(rtnl_link *, uint32_t port_id) noexcept;
-  void link_updated(rtnl_link *old_link, rtnl_link *new_link,
-                    uint32_t port_id) noexcept;
-  void link_deleted(rtnl_link *, uint32_t port_id) noexcept;
+  void link_created(rtnl_link *) noexcept;
+  void link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept;
+  void link_deleted(rtnl_link *) noexcept;
 
   void neigh_ll_created(rtnl_neigh *neigh) noexcept;
   void neigh_ll_updated(rtnl_neigh *old_neigh, rtnl_neigh *new_neigh) noexcept;
   void neigh_ll_deleted(rtnl_neigh *neigh) noexcept;
 
 public:
+  cnetlink(switch_interface *swi, std::shared_ptr<tap_manager> tap_man);
+  ~cnetlink() override;
+
   struct rtnl_link *get_link_by_ifindex(int ifindex) const;
-
-  uint32_t get_port_id(int ifindex) const {
-    auto it = ifindex_to_registered_port.find(ifindex);
-    if (it == ifindex_to_registered_port.end()) {
-      return 0;
-    } else {
-      return it->second;
-    }
-  }
-
-  int get_ifindex(uint32_t port_id) const {
-    return registered_port_to_ifindex.at(port_id);
-  }
 
   void resend_state() noexcept;
 
@@ -134,17 +126,6 @@ public:
   static void nl_cb_v2(struct nl_cache *cache, struct nl_object *old_obj,
                        struct nl_object *new_obj, uint64_t diff, int action,
                        void *data);
-
-  static cnetlink &get_instance();
-
-  void register_link(uint32_t, std::string);
-
-  void unregister_link(uint32_t id, std::string port_name);
-
-  std::map<std::string, uint32_t> get_registered_ports() const {
-    std::lock_guard<std::mutex> lock(rp_mutex);
-    return registered_ports;
-  }
 
   void start() {
     if (running)

--- a/src/netlink/nbi_impl.hpp
+++ b/src/netlink/nbi_impl.hpp
@@ -7,14 +7,16 @@
 
 namespace basebox {
 
+class cnetlink;
 class tap_manager;
 
 class nbi_impl : public nbi, public switch_callback {
-  std::unique_ptr<tap_manager> tap_man;
+  std::shared_ptr<tap_manager> tap_man;
   switch_interface *swi;
+  std::unique_ptr<cnetlink> nl;
 
 public:
-  nbi_impl();
+  nbi_impl(std::shared_ptr<tap_manager> tap_man);
   virtual ~nbi_impl();
 
   // nbi

--- a/src/netlink/nl_bridge.hpp
+++ b/src/netlink/nl_bridge.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <list>
 #include <string>
+#include <memory>
 
 struct rtnl_link_bridge_vlan;
 struct rtnl_link;
@@ -17,10 +18,11 @@ struct nl_addr;
 namespace basebox {
 
 class switch_interface;
+class tap_manager;
 
 class ofdpa_bridge {
 public:
-  ofdpa_bridge(switch_interface *sw);
+  ofdpa_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man);
 
   virtual ~ofdpa_bridge();
 
@@ -28,17 +30,16 @@ public:
 
   bool has_bridge_interface() const { return bridge != nullptr; }
 
-  void add_interface(uint32_t port, rtnl_link *);
+  void add_interface(rtnl_link *);
 
-  void update_interface(uint32_t port, rtnl_link *old_link,
-                        rtnl_link *new_link);
+  void update_interface(rtnl_link *old_link, rtnl_link *new_link);
 
-  void delete_interface(uint32_t port, rtnl_link *);
+  void delete_interface(rtnl_link *);
 
-  void add_mac_to_fdb(const uint32_t port, uint16_t vlan, nl_addr *mac);
-  void add_mac_to_fdb(const uint32_t port, rtnl_neigh *, rtnl_link *);
+  void add_neigh_to_fdb(rtnl_neigh *);
+  void add_mac_to_fdb(rtnl_neigh *, rtnl_link *);
 
-  void remove_mac_from_fdb(const uint32_t port, rtnl_neigh *);
+  void remove_mac_from_fdb(rtnl_neigh *);
 
 private:
   void update_vlans(uint32_t port, const std::string &devname,
@@ -49,6 +50,8 @@ private:
   switch_interface *sw;
   bool ingress_vlan_filtered;
   bool egress_vlan_filtered;
+
+  std::shared_ptr<tap_manager> tap_man;
 };
 
 } /* namespace basebox */

--- a/src/netlink/nl_l3.hpp
+++ b/src/netlink/nl_l3.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 struct rtnl_addr;
 struct rtnl_neigh;
@@ -12,11 +13,14 @@ struct nl_addr;
 
 namespace basebox {
 
+class cnetlink;
 class switch_interface;
+class tap_manager;
 
 class nl_l3 {
 public:
-  nl_l3(switch_interface *sw);
+  nl_l3(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
+        cnetlink *nl);
   ~nl_l3() {}
 
   int add_l3_termination(struct rtnl_addr *a);
@@ -33,6 +37,8 @@ public:
 
 private:
   switch_interface *sw;
+  std::shared_ptr<tap_manager> tap_man;
+  cnetlink *nl;
 };
 
 } // namespace basebox

--- a/src/netlink/tap_manager.hpp
+++ b/src/netlink/tap_manager.hpp
@@ -80,11 +80,41 @@ public:
 
   int enqueue(uint32_t port_id, basebox::packet *pkt);
 
+  std::map<std::string, uint32_t> get_registered_ports() const {
+    std::lock_guard<std::mutex> lock(rp_mutex);
+    return tap_names;
+  }
+
+  uint32_t get_port_id(int ifindex) const noexcept {
+    auto it = ifindex_to_id.find(ifindex);
+    if (it == ifindex_to_id.end()) {
+      return 0;
+    } else {
+      return it->second;
+    }
+  }
+
+  int get_ifindex(uint32_t port_id) const noexcept {
+    auto it = id_to_ifindex.find(port_id);
+    if (it == id_to_ifindex.end()) {
+      return 0;
+    } else {
+      return it->second;
+    }
+  }
+
+  void tap_dev_ready(int ifindex, const std::string &name);
+
 private:
   tap_manager(const tap_manager &other) = delete; // non construction-copyable
   tap_manager &operator=(const tap_manager &) = delete; // non copyable
 
-  std::map<uint32_t, ctapdev *> devs;
+  std::map<uint32_t, ctapdev *> tap_devs; // southbound id:tap_device
+  mutable std::mutex rp_mutex;
+  std::map<std::string, uint32_t> tap_names;
+
+  std::map<int, uint32_t> ifindex_to_id;
+  std::map<uint32_t, int> id_to_ifindex;
 
   basebox::tap_io io;
 };


### PR DESCRIPTION
Currently we just listen to events on ports we learned from the switch
api. To support additional ports we move the mapping of ifindex to
port_id (presented from the southbound api) to the tap_manager. Due to
this work cnetlink is no longer a singleton instance.