### PR TITLE
tap_manager: port id:ifindex mapping fixed

### DIFF
--- a/src/netlink/cnetlink.cpp
+++ b/src/netlink/cnetlink.cpp
@@ -738,6 +738,12 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
 void cnetlink::link_deleted(rtnl_link *link) noexcept {
   assert(link);
 
+  enum link_type lt = kind_to_link_type(rtnl_link_get_type(link));
+
+  if (lt == LT_TUN) {
+    tap_man->tap_dev_removed(rtnl_link_get_ifindex(link));
+  }
+
   try {
     if (bridge != nullptr && rtnl_link_get_family(link) == AF_BRIDGE) {
       bridge->delete_interface(link);

--- a/src/netlink/tap_manager.hpp
+++ b/src/netlink/tap_manager.hpp
@@ -104,6 +104,7 @@ public:
   }
 
   void tap_dev_ready(int ifindex, const std::string &name);
+  void tap_dev_removed(int ifindex);
 
 private:
   tap_manager(const tap_manager &other) = delete; // non construction-copyable
@@ -115,6 +116,7 @@ private:
 
   std::map<int, uint32_t> ifindex_to_id;
   std::map<uint32_t, int> id_to_ifindex;
+  std::deque<uint32_t> port_deleted;
 
   basebox::tap_io io;
 };


### PR DESCRIPTION
In case the datapath notifies a port removal and tries to add the port
again later this leads to a termination of the controller. The issue is
caused due to a not updated id:ifindex mapping which is fixed in the PR.

fixes f1d021e