### PR TITLE
handling of ethernet multicast address group according to IEEE 802.1D

### DIFF
--- a/src/of-dpa/controller.cpp
+++ b/src/of-dpa/controller.cpp
@@ -1050,6 +1050,8 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
       dpt.send_flow_mod_message(rofl::cauxid(0),
                                 fm_driver.enable_policy_arp(dpt.get_version()));
     }
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.enable_policy_8021d(dpt.get_version()));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;


### PR DESCRIPTION
IEEE has defined a set of ethernet multicast group addresses for specific purposes (01-80-C2-XX-XX-XX). According to IEEE 802.1D, all addresses within range 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by switching devices. This PR adds a call to rofl_ofdpa::enable_policy_8021d() so that all ethernet frames from the specified range ethernet destination address range is redirected to the upper controller entity.