### PR TITLE
api: api cleanup

### DIFF
--- a/src/basebox_api.cc
+++ b/src/basebox_api.cc
@@ -28,7 +28,7 @@ void ApiServer::runGRPCServer() {
 
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(stats);
-  server = builder.BuildAndStart();
+  std::unique_ptr<::grpc::Server> server = builder.BuildAndStart();
   LOG(INFO) << "gRPC server listening on " << server_address;
   server->Wait();
 }

--- a/src/basebox_api.h
+++ b/src/basebox_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <grpc++/server.h>
+#include <memory>
 
 namespace basebox {
 
@@ -22,7 +22,6 @@ public:
 
 private:
   NetworkStats *stats;
-  std::unique_ptr<::grpc::Server> server;
 };
 
 } // namespace basebox


### PR DESCRIPTION
This removes grpc relations from the basebox api header files.