### PR TITLE
RFC: Buildsystem: build in docker on travis

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -8,4 +8,4 @@ srpm:
 		git checkout -b copr; \
 	fi
 
-	make -C $(dir $(spec))/ outdir=$(outdir) spec=$(spec)
+	make -C $(dir $(spec)) outdir="$(outdir)" spec="$(spec)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,24 @@ dist: trusty
 language: cpp
 sudo: required
 
-addons:
-  apt:
-    packages:
-    - clang-format-5.0
-    sources:
-    - llvm-toolchain-trusty-5.0
-    - ubuntu-toolchain-r-test
+services:
+  - docker
+
+env:
+  - BUILDER="docker.io/toanju/builder:28"
+before_install:
+  - docker pull $BUILDER
 
 script:
-- find . -regex '.*\.\(hh?\|cc?\|hpp\|cpp\)$' | xargs clang-format-5.0 -i -style=file -fallback-style=llvm
-- git diff --exit-code
+  - docker run -v "$PWD":/workdir:Z --rm --name builder -dti $BUILDER /bin/bash
+  - docker exec builder find . -regex '.*\.\(hh?\|cc?\|hpp\|cpp\)$' | xargs docker exec builder clang-format -i -style=file -fallback-style=llvm
+  - docker exec builder git diff --exit-code
+  - docker exec builder dnf -y copr enable bisdn/rofl
+  - docker exec builder dnf -y copr enable bisdn/rofl-testing
+  - docker exec builder dnf -y copr enable bisdn/baseboxd
+  - docker exec builder dnf -y copr enable bisdn/baseboxd-testing
+  - docker exec builder make -C ./pkg/testing/rpm/ spec
+  - docker exec builder dnf -y builddep ./pkg/testing/rpm/baseboxd.spec
+  - docker exec builder ./autogen.sh
+  - docker exec builder ./configure
+  - docker exec builder make -j

--- a/pkg/testing/rpm/Makefile
+++ b/pkg/testing/rpm/Makefile
@@ -8,12 +8,16 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 BASEDIR := "$(CURDIR)/../../../"
 
-build: clean
+build: clean dist spec
+	# srpm
+	rpmbuild -bs ./baseboxd.spec --define "_sourcedir $(CURDIR)" --define "_srcrpmdir $(outdir)"
+
+dist:
 	# clean copy to not affect the current workdir
 	(cd $(CURDIR) && git clone --recursive $(BASEDIR) baseboxd-$(COMMIT) -b $(BRANCH))
-
 	tar czf baseboxd-$(SHORTCOMMIT).tar.gz baseboxd-$(COMMIT)
 
+spec:
 	# create spec
 	FULLVERSION=$(FULLVERSION) \
 	  VERSION=$(VERSION) \
@@ -22,10 +26,7 @@ build: clean
 	  SHORTCOMMIT=$(SHORTCOMMIT) \
 	  envsubst < ./baseboxd.spec.envsubst > ./baseboxd.spec
 
-	# srpm
-	rpmbuild -bs ./baseboxd.spec --define "_sourcedir $(CURDIR)" --define "_srcrpmdir $(outdir)"
-
 clean:
 	rm -rf baseboxd-* baseboxd.spec
 
-.PHONY: build clean
+.PHONY: build clean spec dist


### PR DESCRIPTION
Test the build in a recent docker build environment (currently F28). To
simplify dependency installation the testing spec file is being used and
therefor the Makefile was separated to support this.