### PR TITLE
cnetlink: fix several lookup issues

### DIFF
--- a/src/netlink/cnetlink.hpp
+++ b/src/netlink/cnetlink.hpp
@@ -42,6 +42,8 @@ public:
    */
   struct rtnl_link *get_link_by_ifindex(int ifindex) const;
   struct rtnl_link *get_link(int ifindex, int family) const;
+  void get_bridge_ports(int br_ifindex,
+                        std::deque<rtnl_link *> *link_list) const noexcept;
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
   bool is_bridge_interface(rtnl_link *l) const;
@@ -101,15 +103,14 @@ private:
       port_status_changes;
   std::mutex pc_mutex;
 
-  std::shared_ptr<tap_manager> tap_man;
-
-  nl_bridge *bridge;
   int nl_proc_max;
   bool running;
   bool rfd_scheduled;
   bool lo_processed;
   std::deque<nl_obj> nl_objs;
 
+  std::shared_ptr<tap_manager> tap_man;
+  nl_bridge *bridge;
   std::shared_ptr<nl_vlan> vlan;
   std::shared_ptr<nl_l3> l3;
 

--- a/src/netlink/netlink-utils.cpp
+++ b/src/netlink/netlink-utils.cpp
@@ -47,29 +47,4 @@ enum link_type kind_to_link_type(const char *type) noexcept {
   return LT_UNSUPPORTED;
 }
 
-void get_bridge_ports(int br_ifindex, struct nl_cache *link_cache,
-                      std::deque<rtnl_link *> *link_list) noexcept {
-  assert(link_cache);
-  assert(link_list);
-
-  std::unique_ptr<rtnl_link, void (*)(rtnl_link *)> filter(rtnl_link_alloc(),
-                                                           &rtnl_link_put);
-  assert(filter && "out of memory");
-
-  rtnl_link_set_family(filter.get(), AF_BRIDGE);
-  rtnl_link_set_master(filter.get(), br_ifindex);
-
-  nl_cache_foreach_filter(link_cache, OBJ_CAST(filter.get()),
-                          [](struct nl_object *obj, void *arg) {
-                            assert(arg);
-                            std::deque<rtnl_link *> *list =
-                                static_cast<std::deque<rtnl_link *> *>(arg);
-
-                            VLOG(3) << __FUNCTION__ << ": found bridge port "
-                                    << obj;
-                            list->push_back(LINK_CAST(obj));
-                          },
-                          link_list);
-}
-
 } // namespace basebox

--- a/src/netlink/netlink-utils.hpp
+++ b/src/netlink/netlink-utils.hpp
@@ -33,7 +33,4 @@ enum link_type {
 
 enum link_type kind_to_link_type(const char *type) noexcept;
 
-void get_bridge_ports(int br_ifindex, struct nl_cache *link_cache,
-                      std::deque<rtnl_link *> *link_list) noexcept;
-
 } // namespace basebox


### PR DESCRIPTION
Deleted links may be deleted already from the netlink caches since they were read from the the callback. In this patch this is fixed by checking as well the queue of read netlink objects.