### PR TITLE
systemd-service: remove network-online.target dependency

### DIFF
--- a/pkg/systemd/baseboxd.service
+++ b/pkg/systemd/baseboxd.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=baseboxd
 After=network.target
-After=network-online.target
-Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
This just causes trouble and can be omitted