### PR TITLE
add clang-tidy target

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,modernize-use-nullptr,modernize-use-auto'
+Checks:          '-*,modernize-*'
 WarningsAsErrors: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,68 @@
+---
+Checks:          '-*,modernize-use-nullptr,modernize-use-auto'
+WarningsAsErrors: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           '0'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           '0'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           '0'
+  - key:             modernize-use-using.IgnoreMacros
+    value:           '1'
+...
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ need the following dependencies installed:
 #### Build system
 
 * [meson](https://gitub.com/mesonbuild/meson/)
+* [clang-format](https://clang.llvm.org/docs/ClangFormat.html) for code formatting
+* [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) for linting (optionally)
 
 #### Libraries
 

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,8 @@ conf_data.set('PACKAGE_VERSION', meson.project_version())
 cppc = meson.get_compiler('cpp')
 
 clang_format = find_program('clang-format', required: false, native: true)
+clang_tidy_script = find_program('run-clang-tidy.py', required: false)
+clang_tidy = find_program('clang-tidy', required: false)
 
 protoc = find_program('protoc')
 protobuf = dependency('protobuf')
@@ -167,6 +169,24 @@ if clang_format.found()
 else
   run_target('clang-format',
     command: [ 'echo', 'install', 'clang-format', '&&', 'false' ])
+endif
+
+if clang_tidy.found()
+  if clang_tidy_script.found()
+    # prefer script with parallel execution
+    run_target(
+      'clang-tidy',
+      command: [ 'scripts/run-clang-tidy-script.sh' ] )
+  else
+    run_target(
+      'clang-tidy',
+      command: [
+          clang_tidy, '-fix', '-p', meson.build_root(),
+      ] + sources)
+  endif
+else
+  run_target('clang-tidy',
+    command: [ 'echo', 'install', 'clang-tidy', '&&', 'false' ])
 endif
 
 executable('baseboxd',

--- a/scripts/run-clang-tidy-script.sh
+++ b/scripts/run-clang-tidy-script.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd ${MESON_SOURCE_ROOT}/scripts
+run-clang-tidy.py -p ${MESON_BUILD_ROOT} -fix -format -header-filter='^((?!\.pb).)*\.h$' '^((?!pb).)*\.cc$'

--- a/src/basebox_grpc_statistics.cc
+++ b/src/basebox_grpc_statistics.cc
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <glog/logging.h>
+#include <utility>
 #include <vector>
 
 #include "basebox_grpc_statistics.h"
@@ -18,7 +19,7 @@ using openconfig_interfaces::Interfaces_Interface;
 
 NetworkStats::NetworkStats(std::shared_ptr<switch_interface> swi,
                            std::shared_ptr<tap_manager> tap_man)
-    : swi(swi), tap_man(tap_man) {}
+    : swi(std::move(swi)), tap_man(std::move(tap_man)) {}
 
 ::grpc::Status NetworkStats::GetStatistics(
     __attribute__((unused))::grpc::ServerContext *context,

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -97,9 +97,9 @@ void cnetlink::init_caches() {
   }
 
   nl_socket_modify_cb(sock_mon, NL_CB_OVERRUN, NL_CB_CUSTOM,
-                      nl_overrun_handler_verbose, NULL);
+                      nl_overrun_handler_verbose, nullptr);
   nl_socket_modify_cb(sock_mon, NL_CB_INVALID, NL_CB_CUSTOM,
-                      nl_invalid_handler_verbose, NULL);
+                      nl_invalid_handler_verbose, nullptr);
 
   int rc = nl_cache_mngr_alloc(sock_mon, NETLINK_ROUTE, NL_AUTO_PROVIDE, &mngr);
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -269,7 +269,7 @@ void cnetlink::get_bridge_ports(int br_ifindex,
   nl_cache_foreach_filter(caches[NL_LINK_CACHE], OBJ_CAST(filter.get()),
                           [](struct nl_object *obj, void *arg) {
                             assert(arg);
-                            std::deque<rtnl_link *> *list =
+                            auto *list =
                                 static_cast<std::deque<rtnl_link *> *>(arg);
 
                             VLOG(3) << __FUNCTION__ << ": found bridge port "

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -381,14 +381,14 @@ std::deque<rtnl_neigh *> nl_bridge::get_fdb_entries_of_port(rtnl_link *br_port,
   rtnl_neigh_set_family(filter.get(), AF_BRIDGE);
 
   std::deque<rtnl_neigh *> neighs;
-  nl_cache_foreach_filter(
-      nl->get_cache(cnetlink::NL_NEIGH_CACHE), OBJ_CAST(filter.get()),
-      [](struct nl_object *o, void *arg) {
-        std::deque<rtnl_neigh *> *neighs = (std::deque<rtnl_neigh *> *)arg;
-        neighs->push_back(NEIGH_CAST(o));
-        VLOG(3) << "needs to be updated " << o;
-      },
-      &neighs);
+  nl_cache_foreach_filter(nl->get_cache(cnetlink::NL_NEIGH_CACHE),
+                          OBJ_CAST(filter.get()),
+                          [](struct nl_object *o, void *arg) {
+                            auto *neighs = (std::deque<rtnl_neigh *> *)arg;
+                            neighs->push_back(NEIGH_CAST(o));
+                            VLOG(3) << "needs to be updated " << o;
+                          },
+                          &neighs);
 
   return neighs;
 }
@@ -547,7 +547,7 @@ int nl_bridge::learn_source_mac(rtnl_link *br_link, packet *p) {
   }
 
   // parse ether frame and check for vid
-  vlan_hdr *hdr = reinterpret_cast<basebox::vlan_hdr *>(p->data);
+  auto *hdr = reinterpret_cast<basebox::vlan_hdr *>(p->data);
   uint16_t vid = 0;
 
   // XXX TODO maybe move this to the utils to have a std lib for parsing the

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstring>
 #include <map>
+#include <utility>
 
 #include <glog/logging.h>
 #include <netlink/route/link.h>
@@ -24,7 +25,8 @@ namespace basebox {
 
 nl_bridge::nl_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
                      cnetlink *nl, std::shared_ptr<nl_vxlan> vxlan)
-    : bridge(nullptr), sw(sw), tap_man(tap_man), nl(nl), vxlan(vxlan),
+    : bridge(nullptr), sw(sw), tap_man(std::move(tap_man)), nl(nl),
+      vxlan(std::move(vxlan)),
       l2_cache(nl_cache_alloc(nl_cache_ops_lookup("route/neigh")),
                nl_cache_free) {
   memset(&empty_br_vlan, 0, sizeof(rtnl_link_bridge_vlan));

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 
 #include <glog/logging.h>
 #include <netlink/route/addr.h>
@@ -25,8 +26,8 @@
 namespace std {
 
 template <> struct hash<rofl::caddress_ll> {
-  typedef rofl::caddress_ll argument_type;
-  typedef std::size_t result_type;
+  using argument_type = rofl::caddress_ll;
+  using result_type = std::size_t;
   result_type operator()(argument_type const &lla) const noexcept {
     return std::hash<uint64_t>{}(lla.get_mac());
   }
@@ -52,7 +53,7 @@ std::unordered_multimap<
     l3_interface_mapping;
 
 nl_l3::nl_l3(std::shared_ptr<nl_vlan> vlan, cnetlink *nl)
-    : sw(nullptr), vlan(vlan), nl(nl) {}
+    : sw(nullptr), vlan(std::move(vlan)), nl(nl) {}
 
 rofl::caddress_ll libnl_lladdr_2_rofl(const struct nl_addr *lladdr) {
   // XXX check for family
@@ -829,12 +830,12 @@ void nl_l3::register_switch_interface(switch_interface *sw) { this->sw = sw; }
 
 void nl_l3::notify_on_net_reachable(net_reachable *f,
                                     struct net_params p) noexcept {
-  net_callbacks.push_back(std::make_pair(f, p));
+  net_callbacks.emplace_back(f, p);
 }
 
 void nl_l3::notify_on_nh_reachable(nh_reachable *f,
                                    struct nh_params p) noexcept {
-  nh_callbacks.push_back(std::make_pair(f, p));
+  nh_callbacks.emplace_back(f, p);
 }
 
 int nl_l3::del_l3_egress(int ifindex, uint16_t vid, const struct nl_addr *s_mac,

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -91,8 +91,7 @@ int nl_l3::init() noexcept {
       [](struct nl_object *obj, void *arg) {
         VLOG(3) << __FUNCTION__ << " : found configured loopback " << obj;
 
-        std::list<struct rtnl_addr *> *add_list =
-            static_cast<std::list<struct rtnl_addr *> *>(arg);
+        auto *add_list = static_cast<std::list<struct rtnl_addr *> *>(arg);
 
         add_list->emplace_back(ADDR_CAST(obj));
       },

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -9,6 +9,7 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 
 #include <netlink/cache.h>
 #include <netlink/route/link.h>
@@ -112,8 +113,8 @@ struct endpoint_tunnel_port {
 namespace std {
 
 template <> struct hash<basebox::pport_vlan> {
-  typedef basebox::pport_vlan argument_type;
-  typedef std::size_t result_type;
+  using argument_type = basebox::pport_vlan;
+  using result_type = std::size_t;
   result_type operator()(argument_type const &v) const noexcept {
     size_t seed = 0;
     hash_combine(seed, v.pport);
@@ -123,8 +124,8 @@ template <> struct hash<basebox::pport_vlan> {
 };
 
 template <> struct hash<basebox::tunnel_nh> {
-  typedef basebox::tunnel_nh argument_type;
-  typedef std::size_t result_type;
+  using argument_type = basebox::tunnel_nh;
+  using result_type = std::size_t;
   result_type operator()(argument_type const &v) const noexcept {
     size_t seed = 0;
     hash_combine(seed, v.smac);
@@ -135,8 +136,8 @@ template <> struct hash<basebox::tunnel_nh> {
 };
 
 template <> struct hash<basebox::endpoint_port> {
-  typedef basebox::endpoint_port argument_type;
-  typedef std::size_t result_type;
+  using argument_type = basebox::endpoint_port;
+  using result_type = std::size_t;
   result_type operator()(argument_type const &v) const noexcept {
     size_t seed = 0;
     hash_combine(seed, v.local_ipv4);
@@ -186,7 +187,7 @@ static struct access_tunnel_port get_access_tunnel_port(uint32_t pport,
 }
 
 nl_vxlan::nl_vxlan(std::shared_ptr<nl_l3> l3, cnetlink *nl)
-    : sw(nullptr), bridge(nullptr), l3(l3), nl(nl) {}
+    : sw(nullptr), bridge(nullptr), l3(std::move(l3)), nl(nl) {}
 
 int nl_vxlan::init() {
   nl_cache *c = nl->get_cache(cnetlink::NL_LINK_CACHE);

--- a/src/netlink/tap_io.cc
+++ b/src/netlink/tap_io.cc
@@ -100,7 +100,7 @@ void tap_io::handle_read_event(rofl::cthread &thread, int fd) {
 
   VLOG(4) << __FUNCTION__ << ": read on fd=" << fd << ", max_len=" << len;
 
-  packet *pkt = (packet *)std::malloc(len);
+  auto *pkt = (packet *)std::malloc(len);
 
   if (pkt == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": no mem left";

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -4,6 +4,7 @@
 
 #include <glog/logging.h>
 #include <netlink/route/link.h>
+#include <utility>
 
 #include "cnetlink.h"
 #include "ctapdev.h"
@@ -13,7 +14,7 @@
 namespace basebox {
 
 tap_manager::tap_manager(std::shared_ptr<cnetlink> nl)
-    : io(new tap_io()), nl(nl) {}
+    : io(new tap_io()), nl(std::move(nl)) {}
 
 tap_manager::~tap_manager() {
   std::map<uint32_t, ctapdev *> ddevs;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -220,7 +220,7 @@ void controller::handle_port_status(rofl::crofdpt &dpt,
   std::deque<nbi::port_notification_data> ntfys;
   uint32_t port_no = msg.get_port().get_port_no();
 
-  enum nbi::port_status status = (nbi::port_status)0;
+  auto status = (nbi::port_status)0;
   if (msg.get_port().get_config() & rofl::openflow13::OFPPC_PORT_DOWN) {
     status = (nbi::port_status)(status | nbi::PORT_STATUS_ADMIN_DOWN);
   }
@@ -284,7 +284,7 @@ void controller::handle_port_desc_stats_reply(
     notifications.emplace_back(nbi::port_notification_data{
         nbi::PORT_EVENT_ADD, port.get_port_no(), port.get_name()});
 
-    enum nbi::port_status status = (nbi::port_status)0;
+    auto status = (nbi::port_status)0;
     if (port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) {
       status = (nbi::port_status)(status | nbi::PORT_STATUS_ADMIN_DOWN);
     }
@@ -442,7 +442,7 @@ int controller::enqueue(uint32_t port_id, packet *pkt) noexcept {
   int rv = 0;
 
   assert(pkt && "invalid enque");
-  struct ethhdr *eth = (struct ethhdr *)pkt->data;
+  auto *eth = (struct ethhdr *)pkt->data;
 
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);


### PR DESCRIPTION
Run `ninja -C .build clang-tidy` to run clang-tidy on the source files. This depends on clang-tidy and runs faster when [run-clang-tidy.py](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py) is in your PATH.