### PR TITLE
bond: return correct id when creating a lag

### DIFF
--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -103,9 +103,10 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   auto lm_rv = lag_members.emplace(it->second, port_id);
   if (!lm_rv.second) {
     LOG(ERROR) << __FUNCTION__ << ": cannot add multiple ports to a lag";
+    return -EINVAL;
   }
 
-  swi->lag_add_member(it->second, port_id);
+  rv = swi->lag_add_member(it->second, port_id);
 
   return rv;
 }
@@ -130,7 +131,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     return -EINVAL;
   }
 
-  swi->lag_remove_member(it->second, port_id);
+  rv = swi->lag_remove_member(it->second, port_id);
   lag_members.erase(lm_rv);
 
   return rv;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -535,7 +535,7 @@ int controller::lag_create(uint32_t *lag_id) noexcept {
   }
 
   assert(lag_id);
-  *lag_id = _lag_id;
+  *lag_id = nbi::combine_port_type(_lag_id, nbi::port_type_lag);
 
   _lag_id++;
   return 0;

--- a/src/sai.h
+++ b/src/sai.h
@@ -196,6 +196,10 @@ public:
     SWITCH_STATE_FAILED,
   };
 
+  static uint32_t combine_port_type(uint16_t port_num, enum port_type type) {
+    return (uint32_t)port_num | type << 16;
+  }
+
   static enum port_type get_port_type(uint32_t port_id) {
     return static_cast<enum port_type>(port_id >> 16);
   }


### PR DESCRIPTION
The implementation on the controller side is currently rather a mock
since currently no real lags with multiple ports can be implemented.
Therefore this just prepares for the use of a real lag later on.