### PR TITLE
bond: support late bridge attachemant

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -341,6 +341,7 @@ int cnetlink::get_port_id(rtnl_link *l) const {
 
   if (rtnl_link_is_vlan(l)) {
     ifindex = rtnl_link_get_link(l);
+    // XXX FIXME vlan interface on bond not handled
   } else if (rtnl_link_get_type(l) &&
              (0 == strcmp(rtnl_link_get_type(l), "bond") ||
               0 == strcmp(rtnl_link_get_type(l), "team"))) {

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -26,6 +26,8 @@ class nl_vxlan;
 class tap_manager;
 
 class cnetlink final : public rofl::cthread_env {
+  friend class nl_bond;
+
 public:
   enum nl_cache_t {
     NL_ADDR_CACHE,

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -35,6 +35,7 @@ uint32_t nl_bond::get_lag_id(rtnl_link *bond) {
     return 0;
   }
 
+  VLOG(3) << __FUNCTION__ << ": found id=" << rv_lm->second;
   return rv_lm->second;
 }
 
@@ -106,6 +107,18 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   }
 
   swi->lag_add_member(it->second, port_id);
+
+  if (rtnl_link_get_master(bond)) {
+    // check bridge attachement
+    auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
+    if (br_link) {
+      VLOG(2) << __FUNCTION__
+              << ": bond was already bridge slave: " << OBJ_CAST(br_link);
+      nl->link_created(br_link);
+    }
+  }
+
+  // XXX FIXME check for vlan interfaces
 
   return rv;
 }

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -214,7 +214,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
     }
 
   } else {
-    pport_no = nl->get_port_id(rtnl_link_get_ifindex(_link));
+    pport_no = nl->get_port_id(_link);
     if (pport_no == 0) {
       LOG(ERROR) << __FUNCTION__
                  << ": invalid pport_no=0 of link: " << OBJ_CAST(_link);


### PR DESCRIPTION
In case a bond interface was created before a port was enslaved the bond
can already be attached to a bridge and configured. So far the bridge
configuration was not possible. This PR adds support for this.