### PR TITLE
bond: allow late registration of bonds

### DIFF
--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -24,8 +24,20 @@ public:
 
   void register_switch_interface(switch_interface *swi) { this->swi = swi; }
 
+  /**
+   * returns the id of the lag
+   *
+   * @returns id > 0 if found, 0 if not found
+   */
   uint32_t get_lag_id(rtnl_link *bond);
+
+  /**
+   * create a new lag
+   *
+   * @returns <0 on error, lag_id on success
+   */
   int add_lag(rtnl_link *bond);
+
   int remove_lag(rtnl_link *bond);
   int add_lag_member(rtnl_link *bond, rtnl_link *link);
   int remove_lag_member(rtnl_link *bond, rtnl_link *link);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -531,7 +531,7 @@ int controller::lag_create(uint32_t *lag_id) noexcept {
 
   if (!_rv.second) {
     LOG(ERROR) << __FUNCTION__ << ": maximum number of lags were created.";
-    return -EEXIST;
+    return -EINVAL;
   }
 
   assert(lag_id);
@@ -545,7 +545,7 @@ int controller::lag_remove(uint32_t lag_id) noexcept {
   // currently we don't have a real lag implementation
   // otherwise we should release the resoucres on the switch
 
-  auto rv = lag.erase(lag_id);
+  auto rv = lag.erase(nbi::get_port_num(lag_id));
   if (rv != 1) {
     LOG(WARNING) << __FUNCTION__ << ": rv=" << rv
                  << " entries in lag map were removed";


### PR DESCRIPTION
In case a bond existed in the systemd during initialization we do not
create a bond internally. As soon as an interface is attached to these
bonds we now allow late bond registration.

Minor bug fixed in the deletion of a lag_id in the controller stub that
is so far not used to create lags on the switch.