### PR TITLE
nl_l3: proper handling of termination mac

### DIFF
--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -62,6 +62,11 @@ public:
   void notify_on_nh_reachable(nh_reachable *f, struct nh_params p) noexcept;
 
 private:
+  int add_l3_termination(uint32_t port_id, uint16_t vid,
+                         const rofl::caddress_ll &mac, int af) noexcept;
+  int del_l3_termination(uint32_t port_id, uint16_t vid,
+                         const rofl::caddress_ll &mac, int af) noexcept;
+
   int add_l3_unicast_route(rtnl_route *r);
   int del_l3_unicast_route(rtnl_route *r);
 


### PR DESCRIPTION
Currently the deletion of an ip address leads to deletion of the
termination mac and therefore deleteion of an ip address may lead to
invalid bahaviour. This PR adds proper handling of the mac addresses by
tracking the port,vid,mac and ether type.