### PR TITLE
l3: add ecmp

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -814,10 +814,9 @@ void cnetlink::route_route_apply(const nl_obj &obj) {
 
     switch (family = rtnl_route_get_family(ROUTE_CAST(obj.get_new_obj()))) {
     case AF_INET:
-      VLOG(2) << __FUNCTION__ << ": changed IPv4 route (not supported)";
-      break;
     case AF_INET6:
-      VLOG(2) << __FUNCTION__ << ": changed IPv6 route (not supported)";
+      l3->update_l3_route(ROUTE_CAST(obj.get_old_obj()),
+                          ROUTE_CAST(obj.get_new_obj()));
       break;
     default:
       LOG(WARNING) << __FUNCTION__ << ": family not supported: " << family;

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -5,8 +5,9 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 #include <deque>
+#include <memory>
+#include <set>
 
 #include "nl_l3_interfaces.h"
 
@@ -47,6 +48,7 @@ public:
   int del_l3_neigh(struct rtnl_neigh *n);
 
   int add_l3_route(struct rtnl_route *r);
+  int update_l3_route(struct rtnl_route *r_old, struct rtnl_route *r_new);
   int del_l3_route(struct rtnl_route *r);
 
   void get_nexthops_of_route(rtnl_route *route,
@@ -60,15 +62,29 @@ public:
 
   void notify_on_net_reachable(net_reachable *f, struct net_params p) noexcept;
   void notify_on_nh_reachable(nh_reachable *f, struct nh_params p) noexcept;
+  // void notify_on_nh_resovled(nh_resolved *f, struct nh_params p) noexcept;
 
 private:
+  int get_l3_interface_id(rtnl_neigh *n, uint32_t *l3_interface_id);
+
   int add_l3_termination(uint32_t port_id, uint16_t vid,
                          const rofl::caddress_ll &mac, int af) noexcept;
   int del_l3_termination(uint32_t port_id, uint16_t vid,
                          const rofl::caddress_ll &mac, int af) noexcept;
 
-  int add_l3_unicast_route(rtnl_route *r);
-  int del_l3_unicast_route(rtnl_route *r);
+  int add_l3_unicast_route(rtnl_route *r, bool update_route);
+  int update_l3_unicast_route(rtnl_route *r_old, rtnl_route *r_new);
+  int del_l3_unicast_route(rtnl_route *r, bool keep_route);
+
+  int add_l3_unicast_route(nl_addr *rt_dst, uint32_t l3_interface_id,
+                           bool is_ecmp, bool update_route);
+  int del_l3_unicast_route(nl_addr *rt_dst);
+
+  int add_l3_ecmp_route(rtnl_route *r,
+                        const std::set<uint32_t> &l3_interface_ids,
+                        bool update_route);
+  int del_l3_ecmp_route(rtnl_route *r,
+                        const std::set<uint32_t> &l3_interface_ids);
 
   int add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id);
   int del_l3_neigh_egress(struct rtnl_neigh *n);
@@ -78,9 +94,6 @@ private:
                     uint32_t *l3_interface_id);
   int del_l3_egress(int ifindex, uint16_t vid, const struct nl_addr *s_mac,
                     const struct nl_addr *d_mac);
-
-  int add_l3_unicast_host(const rofl::caddress_in4 &ipv4_dst,
-                          uint32_t l3_interface_id) const;
 
   bool is_link_local_address(const struct nl_addr *addr);
 

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -179,26 +179,34 @@ public:
   int l3_egress_remove(uint32_t l3_interface) noexcept override;
 
   int l3_unicast_host_add(const rofl::caddress_in4 &ipv4_dst,
-                          uint32_t l3_interface) noexcept override;
-  int l3_unicast_host_add(const rofl::caddress_in6 &ipv6_dst,
-                          uint32_t l3_interface) noexcept override;
-
+                          uint32_t l3_interface, bool is_ecmp,
+                          bool update_route) noexcept override;
   int l3_unicast_host_remove(
       const rofl::caddress_in4 &ipv4_dst) noexcept override;
+
+  int l3_unicast_host_add(const rofl::caddress_in6 &ipv6_dst,
+                          uint32_t l3_interface, bool is_ecmp,
+                          bool update_route) noexcept override;
   int l3_unicast_host_remove(
       const rofl::caddress_in6 &ipv6_dst) noexcept override;
 
   int l3_unicast_route_add(const rofl::caddress_in4 &ipv4_dst,
                            const rofl::caddress_in4 &mask,
-                           uint32_t l3_interface) noexcept override;
-  int l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
-                           const rofl::caddress_in6 &mask,
-                           uint32_t l3_interface) noexcept override;
-
+                           uint32_t l3_interface, bool is_ecmp,
+                           bool update_route) noexcept override;
   int l3_unicast_route_remove(const rofl::caddress_in4 &ipv4_dst,
                               const rofl::caddress_in4 &mask) noexcept override;
+
+  int l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
+                           const rofl::caddress_in6 &mask,
+                           uint32_t l3_interface, bool is_ecmp,
+                           bool update_route) noexcept override;
   int l3_unicast_route_remove(const rofl::caddress_in6 &ipv6_dst,
                               const rofl::caddress_in6 &mask) noexcept override;
+
+  int l3_ecmp_add(uint32_t l3_ecmp_id,
+                  const std::set<uint32_t> &l3_interfaces) noexcept override;
+  int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept override;
 
   int ingress_port_vlan_accept_all(uint32_t port) noexcept override;
   int ingress_port_vlan_drop_accept_all(uint32_t port) noexcept override;

--- a/src/sai.h
+++ b/src/sai.h
@@ -6,6 +6,7 @@
 
 #include <cinttypes>
 #include <deque>
+#include <set>
 
 #include <rofl/common/caddress.h>
 
@@ -77,29 +78,37 @@ public:
   virtual int l3_egress_remove(uint32_t l3_interface) noexcept = 0;
 
   virtual int l3_unicast_host_add(const rofl::caddress_in4 &ipv4_dst,
-                                  uint32_t l3_interface) noexcept = 0;
-  virtual int l3_unicast_host_add(const rofl::caddress_in6 &ipv6_dst,
-                                  uint32_t l3_interface) noexcept = 0;
-
+                                  uint32_t l3_interface, bool is_ecmp,
+                                  bool update_route) noexcept = 0;
   virtual int
   l3_unicast_host_remove(const rofl::caddress_in4 &ipv4_dst) noexcept = 0;
+
+  virtual int l3_unicast_host_add(const rofl::caddress_in6 &ipv6_dst,
+                                  uint32_t l3_interface, bool is_ecmp,
+                                  bool update_route) noexcept = 0;
   virtual int
   l3_unicast_host_remove(const rofl::caddress_in6 &ipv6_dst) noexcept = 0;
 
   virtual int l3_unicast_route_add(const rofl::caddress_in4 &ipv4_dst,
                                    const rofl::caddress_in4 &mask,
-                                   uint32_t l3_interface) noexcept = 0;
-  virtual int l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
-                                   const rofl::caddress_in6 &mask,
-                                   uint32_t l3_interface) noexcept = 0;
+                                   uint32_t l3_interface, bool is_ecmp,
+                                   bool update_route) noexcept = 0;
 
   virtual int
   l3_unicast_route_remove(const rofl::caddress_in4 &ipv4_dst,
                           const rofl::caddress_in4 &mask) noexcept = 0;
 
+  virtual int l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
+                                   const rofl::caddress_in6 &mask,
+                                   uint32_t l3_interface, bool is_ecmp,
+                                   bool update_route) noexcept = 0;
   virtual int
   l3_unicast_route_remove(const rofl::caddress_in6 &ipv6_dst,
                           const rofl::caddress_in6 &mask) noexcept = 0;
+
+  virtual int l3_ecmp_add(uint32_t l3_ecmp_id,
+                          const std::set<uint32_t> &l3_interfaces) noexcept = 0;
+  virtual int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept = 0;
 
   virtual int ingress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int ingress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;


### PR DESCRIPTION
All routes and host routes ecmp are with this PR ecmp ready. Currently
this is limited to existing neighbours. Furthermore this PR adds
handling to nexthop changes.
