### PR TITLE
update access ports

### DIFF
--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -64,6 +64,9 @@ public:
 
   bool is_port_flooding(rtnl_link *br_link) const;
 
+  int update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
+                          const uint32_t tunnel_id, bool add);
+
 private:
   void update_vlans(rtnl_link *, rtnl_link *);
 

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -1233,6 +1233,10 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
                   << ": create new enpoint with remote_ipv4=" << remote;
 
         rv = create_endpoint(link, br_link, remote);
+
+        // XXX FIXME update access ports
+        bridge->update_access_ports(link, br_link, tunnel_id, true);
+
       } else {
         // existing remote but new tunnel_id/vni on link
         rv = sw->tunnel_port_tenant_add(lport, tunnel_id);


### PR DESCRIPTION
In case a vxlan interface is attached without any endpoints the access
ports are not created. This PR transforms the access ports for this
case.