### PR TITLE
Vlan refcount

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -442,6 +442,14 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
                << "; rv=" << rv;
   }
 
+  // del vlan
+  bool tagged = !!rtnl_link_is_vlan(link);
+  rv = vlan->remove_vlan(link, vid, tagged);
+  if (rv < 0) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to remove vlan id " << vid
+               << " (tagged=" << tagged << " to link " << OBJ_CAST(link);
+  }
+
   return rv;
 }
 

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -17,7 +17,7 @@ namespace basebox {
 
 nl_vlan::nl_vlan(cnetlink *nl) : swi(nullptr), nl(nl) {}
 
-int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) const {
+int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   assert(swi);
 
   VLOG(2) << __FUNCTION__ << ": add vid=" << vid << " tagged=" << tagged;
@@ -54,12 +54,17 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) const {
     return rv;
   }
 
-  // XXX TODO store the vlan interface usage?
+  auto key = std::make_pair(port_id, vid);
+  auto refcount = port_vlan.find(key);
+  if (refcount == port_vlan.end()) {
+    port_vlan.emplace(key, 1);
+  } else
+    refcount->second++;
 
   return rv;
 }
 
-int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) const {
+int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   assert(swi);
 
   if (!is_vid_valid(vid)) {
@@ -75,6 +80,15 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) const {
     VLOG(1) << __FUNCTION__ << ": unknown link " << OBJ_CAST(link);
     return -EINVAL;
   }
+
+  // check for refcount
+  auto key = std::make_pair(port_id, vid);
+  auto refcount = port_vlan.find(key);
+  if (refcount != port_vlan.end()){
+    refcount->second--;
+    return rv;
+  } else if (refcount->second == 1)
+    port_vlan.erase(refcount);
 
   // remove vid at ingress
   rv = swi->ingress_port_vlan_remove(port_id, vid, !tagged);

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <cstdint>
+#include <map>
 
 extern "C" {
 struct rtnl_link;
@@ -20,8 +21,8 @@ public:
 
   void register_switch_interface(switch_interface *swi) { this->swi = swi; }
 
-  int add_vlan(rtnl_link *link, uint16_t vid, bool tagged) const;
-  int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) const;
+  int add_vlan(rtnl_link *link, uint16_t vid, bool tagged);
+  int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged);
 
   uint16_t get_vid(rtnl_link *link);
 
@@ -35,6 +36,9 @@ private:
   static const uint16_t vid_low = 1;
   static const uint16_t vid_high = 0xfff;
   static const uint16_t default_vid = vid_low;
+
+  // ifindex - vlan - refcount
+  std::map<std::pair<uint32_t, uint16_t>, uint32_t> port_vlan;
 
   switch_interface *swi;
   cnetlink *nl;


### PR DESCRIPTION
Counting refcounts for VLANs allows us to remove the L3 address safely, without removing the VLAN entry