### PR TITLE
Fix vrf segfault on deletion of VRFs

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -313,6 +313,7 @@ bool cnetlink::is_bridge_interface(int ifindex) const {
 }
 
 bool cnetlink::is_bridge_interface(rtnl_link *l) const {
+  assert(l);
 
   // is a vlan on top of the bridge?
   if (rtnl_link_is_vlan(l)) {

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1705,7 +1705,8 @@ uint16_t nl_l3::get_vrf_table_id(rtnl_link *link) {
   auto vrf = nl->get_link_by_ifindex(rtnl_link_get_master(link));
   if (vrf.get() && !rtnl_link_is_vrf(link) && rtnl_link_is_vrf(vrf.get())) {
     link = vrf.get();
-  } else if (!rtnl_link_is_vrf(link) && !vrf.get()) {
+// } else if (!rtnl_link_is_vrf(link) && !vrf.get()) {
+  } else {
     VLOG(2) << __FUNCTION__ << ": link=" << OBJ_CAST(link)
             << " is not a VRF interface ";
     return 0;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1170,6 +1170,10 @@ void nl_l3::get_nexthops_of_route(
     uint16_t pport_id = nl->get_port_id(ifindex);
     auto link = nl->get_link_by_ifindex(ifindex);
 
+    // Guarantee that the interface is found
+    if (!link.get())
+      continue;
+
     if (pport_id == 0 && !nl->is_bridge_interface(link.get())) {
       VLOG(1) << __FUNCTION__ << ": ignoring next hop " << nh;
       continue;
@@ -1705,7 +1709,6 @@ uint16_t nl_l3::get_vrf_table_id(rtnl_link *link) {
   auto vrf = nl->get_link_by_ifindex(rtnl_link_get_master(link));
   if (vrf.get() && !rtnl_link_is_vrf(link) && rtnl_link_is_vrf(vrf.get())) {
     link = vrf.get();
-// } else if (!rtnl_link_is_vrf(link) && !vrf.get()) {
   } else {
     VLOG(2) << __FUNCTION__ << ": link=" << OBJ_CAST(link)
             << " is not a VRF interface ";


### PR DESCRIPTION
## Description
* While verifying the next hop while adding/deleting routes, [link to code](https://github.com/bisdn/basebox/blob/1378c8ae78ff6f739e2a89974be85e7a94d428f0/src/netlink/nl_l3.cc#L1167), the correct link could in certain ocasions not be found. This would lead to crashes on the is_bridge_interface function call. 

* In [link to code](https://github.com/bisdn/basebox/pull/219/files#diff-3c368f43e25d51e19a158722ea158133L1708) all of the relevant checks have been done, so we can exit the function with a simple else condition.

## Motivation and Context
Two segfaults were found while testing the VRF feature. 
  * One was related to restarting the on-switch endpoint after VRF configuration, which would trigger route deletion leading to a crash. 
  * The other was running the VRF example script once, tearing it down, and running it again. The bridge interface would not be correctly handled in the get_vrf_table_id call, and baseboxd would then crash.

## How Has This Been Tested?
Using the VRF example script, testing with setting up the environment, tearing it down multiple times, and confirming the state on switch. As well restarting the switch endpoint after VRF config will correctly work now.