### PR TITLE
bug: fix late nexthop registration

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1681,35 +1681,6 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
     rtnl_neigh_put(n);
   }
 
-  // Drop entries from net_reachable_callback
-  for (auto cb = std::begin(net_resolved_callbacks);
-       cb != std::end(net_resolved_callbacks);) {
-    VLOG(1) << " CB TO DELETE " << cb->addr;
-#if 0
-    if (cb->ifindex == rtnl_neigh_get_ifindex(n) &&
-        nl_addr_cmp_prefix(cb->addr, rtnl_neigh_get_dst(n))) {
-
-      // query the kernel for the correct route matching the dst addr
-      nl_route_query rq;
-      auto rt = rq.query_route(cb->addr);
-
-      auto ad = rtnl_route_get_dst(rt);
-      nl_addr_set_prefixlen(
-          ad,
-          nl_addr_get_prefixlen(cb->addr)); // guarantee the correct prefixlen
-
-      add_l3_unicast_route(rt, true);
-      nl_object_put(
-          OBJ_CAST(rt)); // return object has to be freed using nl_object_put
-
-      cb = net_resolved_callbacks.erase(cb); // erase invalidates the pointer,
-                                             // so the value must be returned
-    } else {
-      ++cb;
-    }
-#endif
-  }
-
   return rv;
 }
 

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -27,6 +27,8 @@ struct net_params {
     nl_addr_put(addr);
   }
 
+  bool operator==(const int ifindex) const { return this->ifindex == ifindex; }
+
   nl_addr *addr;
   int ifindex;
 };


### PR DESCRIPTION
## Description
On route addition, if the next-hop would not be previously known then the route would be ignored by baseboxd, resulting in broken state. This fix rewrites this logic, by adding first the route pointing to the controller, storing it internally, to wait for proper registration. After adding the neighbour, the route will be updated to point to the correct output interface, and routing will continue as normal.

## Motivation and Context
This pull request will fix the bug reported in  #222, where routing will not work, in the case for unknown next-hops. 

## How Has This Been Tested?
The test was based on the script present  in #222, [Gist](https://gist.github.com/rubensfig/8f8ebd05444ac6b7709bf0d5ad5d6946)