### PR TITLE
fix: remove unsupported tx_errors from statistics

### DIFF
--- a/src/basebox_grpc_statistics.cc
+++ b/src/basebox_grpc_statistics.cc
@@ -54,12 +54,12 @@ NetworkStats::NetworkStats(std::shared_ptr<switch_interface> swi,
 
     state->mutable_counters()->set_in_discards(stats[4]);
     state->mutable_counters()->set_in_errors(stats[6] + stats[9]);
-    state->mutable_counters()->set_in_fcs_errors(stats[8] + stats[7]);
+    state->mutable_counters()->set_in_fcs_errors(stats[8]);
     state->mutable_counters()->set_in_octets(stats[2]);
     state->mutable_counters()->set_in_unicast_pkts(stats[0]);
 
     state->mutable_counters()->set_out_discards(stats[5]);
-    state->mutable_counters()->set_out_errors(stats[7] + stats[11]);
+    state->mutable_counters()->set_out_errors(stats[11]);
     state->mutable_counters()->set_out_octets(stats[3]);
     state->mutable_counters()->set_out_unicast_pkts(stats[1]);
   }

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1795,7 +1795,7 @@ int controller::get_statistics(uint64_t port_no, uint32_t number_of_counters,
       counters[i] = stats_array.get_port_stats(port_no).get_rx_errors();
       break;
     case (SAI_PORT_STAT_TX_ERRORS):
-      counters[i] = stats_array.get_port_stats(port_no).get_tx_errors();
+      counters[i] = 0; // tx_errors counters are not supported in OF-DPA
       break;
     case (SAI_PORT_STAT_RX_FRAME_ERR):
       counters[i] = stats_array.get_port_stats(port_no).get_rx_frame_err();


### PR DESCRIPTION
## Description
This PR aims to fix the wrong statistics reported from baseboxd. We have discovered that Openflow was carrying the wrong statistics for the tx_errors counter, which is apparently unsupported in OF-DPA. The fix was disabling this counter permanently.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required to export the correct port stats from baseboxd, solving the wrongly reported tx_errors.

## How Has This Been Tested?
Tested by attaching the controller to a GRPC interface, and querying the port stats. 
