### PR TITLE
QnQ Vlan support

### DIFF
--- a/examples/bridging/qnq/qnq_vlan_controller
+++ b/examples/bridging/qnq/qnq_vlan_controller
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Stag - 10 (bridge)
+# Ctag - 20 
+
+ip link add swbridge type bridge vlan_filtering 1 vlan_protocol 802.1ad
+
+ip link set port25 master swbridge
+ip link set port24 master swbridge
+
+bridge vlan add dev swbridge vid 10 self
+
+bridge vlan add dev port25 vid 10 # pvid untagged
+bridge vlan add dev port24 vid 10 # pvid untagged

--- a/examples/bridging/qnq/qnq_vlan_server
+++ b/examples/bridging/qnq/qnq_vlan_server
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+ip netns add qnqtest1
+ip netns add qnqtest2
+
+ip link set enp5s0f0 netns qnqtest1
+ip link set enp5s0f1 netns qnqtest2
+
+ip netns exec qnqtest1 ip link add link enp5s0f0 enp5s0f0.10 type vlan proto 802.1ad id 10
+# ip netns exec qnqtest1 ip link add link enp5s0f0 enp5s0f0.10 type vlan proto 802.1q id 10
+ip netns exec qnqtest1 ip link add link enp5s0f0.10 enp5s0f0.10.20 type vlan proto 802.1Q id 20
+
+ip netns exec qnqtest2 ip link add link enp5s0f1 enp5s0f1.10 type vlan proto 802.1ad id 10
+# ip netns exec qnqtest2 ip link add link enp5s0f1 enp5s0f1.10 type vlan proto 802.1q id 10
+ip netns exec qnqtest2 ip link add link enp5s0f1.10 enp5s0f1.10.20 type vlan proto 802.1Q id 20
+
+ip netns exec qnqtest1 ip l s up enp5s0f0
+ip netns exec qnqtest1 ip l s up enp5s0f0.10
+ip netns exec qnqtest1 ip l s up enp5s0f0.10.20
+
+ip netns exec qnqtest2 ip l s up enp5s0f1
+ip netns exec qnqtest2 ip l s up enp5s0f1.10
+ip netns exec qnqtest2 ip l s up enp5s0f1.10.20
+
+ip netns exec qnqtest1 ip a a 10.0.0.10/24 dev enp5s0f0.10.20
+ip netns exec qnqtest2 ip a a 10.0.0.11/24 dev enp5s0f1.10.20
+
+# ip netns exec qnqtest /bin/bash

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1049,6 +1049,7 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
     if (bridge && bridge->is_bridge_interface(link)) {
       LOG(INFO) << __FUNCTION__ << ": deleting bridge";
       vxlan->register_bridge(nullptr);
+      bridge->clear_tpid_entries(); // clear the Egress TPID table
       delete bridge;
       bridge = nullptr;
     }

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -64,20 +64,17 @@ cnetlink::~cnetlink() {
   nl_socket_free(sock_tx);
 }
 
-int cnetlink::load_from_file(const std::string &path) {
-  std::ifstream file;
-  int out = -1;
-  file.open(path);
+int cnetlink::load_from_file(const std::string &path, int base) {
+  std::ifstream file(path);
+  std::string out;
+
   if (file.is_open()) {
     while (!file.eof()) {
       file >> out;
     }
   }
-  if (out < 0) {
-    LOG(FATAL) << __FUNCTION__ << ": failed to load " << path;
-  }
 
-  return out;
+  return std::stoi(out, nullptr, base);
 }
 
 static int nl_overrun_handler_verbose(struct nl_msg *msg, void *arg) {
@@ -904,8 +901,10 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
                 << rtnl_link_get_name(link);
 
       bridge->add_interface(link);
+      bridge->get_vlan_proto();
     } catch (std::exception &e) {
       LOG(ERROR) << __FUNCTION__ << ": failed: " << e.what();
+      LOG(FATAL);
     }
     break;
   case LT_VXLAN: {

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -903,7 +903,6 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
       bridge->add_interface(link);
     } catch (std::exception &e) {
       LOG(ERROR) << __FUNCTION__ << ": failed: " << e.what();
-      LOG(FATAL);
     }
     break;
   case LT_VXLAN: {
@@ -1010,6 +1009,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     break;
   case LT_VRF: // No need to care about the vrf interface itself
   case LT_BOND:
+  case LT_BRIDGE:
   case LT_UNSUPPORTED:
     VLOG(2) << __FUNCTION__
             << ": ignoring update (not supported) of old_lt=" << lt_old

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -901,7 +901,6 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
                 << rtnl_link_get_name(link);
 
       bridge->add_interface(link);
-      bridge->get_vlan_proto();
     } catch (std::exception &e) {
       LOG(ERROR) << __FUNCTION__ << ": failed: " << e.what();
       LOG(FATAL);
@@ -1011,7 +1010,6 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     break;
   case LT_VRF: // No need to care about the vrf interface itself
   case LT_BOND:
-  case LT_BRIDGE:
   case LT_UNSUPPORTED:
     VLOG(2) << __FUNCTION__
             << ": ignoring update (not supported) of old_lt=" << lt_old

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -83,6 +83,8 @@ public:
 
   std::deque<rtnl_neigh *> search_fdb(uint16_t vid = 0,
                                       nl_addr *lladdr = nullptr);
+  int load_from_file(const std::string &path, int base=10);
+
 
 private:
   // non copyable
@@ -159,8 +161,6 @@ private:
     EVENT_NONE,
     EVENT_UPDATE_LINKS,
   };
-
-  int load_from_file(const std::string &path);
 
   void init_caches();
   void init_subsystems() noexcept;

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -83,8 +83,7 @@ public:
 
   std::deque<rtnl_neigh *> search_fdb(uint16_t vid = 0,
                                       nl_addr *lladdr = nullptr);
-  int load_from_file(const std::string &path, int base=10);
-
+  int load_from_file(const std::string &path, int base = 10);
 
 private:
   // non copyable

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -55,6 +55,11 @@ bool nl_bridge::is_bridge_interface(rtnl_link *link) {
   return true;
 }
 
+void nl_bridge::get_vlan_proto() {
+  std::string portname(rtnl_link_get_name(bridge));
+  nl->load_from_file("/sys/class/net/" + portname + "/bridge/vlan_protocol", 16);
+}
+
 static bool br_vlan_equal(const rtnl_link_bridge_vlan *lhs,
                           const rtnl_link_bridge_vlan *rhs) {
   assert(lhs);

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -56,6 +56,7 @@ public:
   int fdb_timeout(rtnl_link *br_link, uint16_t vid,
                   const rofl::caddress_ll &mac);
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
+  void get_vlan_proto();
 
   // XXX Improve cache search mechanism
   std::deque<rtnl_neigh *> get_fdb_entries_of_port(rtnl_link *br_port,

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -56,7 +56,8 @@ public:
   int fdb_timeout(rtnl_link *br_link, uint16_t vid,
                   const rofl::caddress_ll &mac);
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
-  void get_vlan_proto();
+  uint32_t  get_vlan_proto();
+  uint32_t  get_vlan_filtering();
 
   // XXX Improve cache search mechanism
   std::deque<rtnl_neigh *> get_fdb_entries_of_port(rtnl_link *br_port,

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -56,8 +56,11 @@ public:
   int fdb_timeout(rtnl_link *br_link, uint16_t vid,
                   const rofl::caddress_ll &mac);
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
-  uint32_t  get_vlan_proto();
-  uint32_t  get_vlan_filtering();
+
+  uint32_t get_vlan_proto();
+  uint32_t get_vlan_filtering();
+
+  void clear_tpid_entries();
 
   // XXX Improve cache search mechanism
   std::deque<rtnl_neigh *> get_fdb_entries_of_port(rtnl_link *br_port,

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1720,14 +1720,13 @@ int controller::egress_bridge_port_vlan_remove(uint32_t port,
   return rv;
 }
 
-int controller::egress_tpid_rewrite(uint32_t port) noexcept {
+int controller::set_egress_tpid(uint32_t port) noexcept {
   int rv = 0;
   try {
 
     rofl::crofdpt &dpt = set_dpt(dptid, true);
-    dpt.send_flow_mod_message(
-        rofl::cauxid(0),
-        fm_driver.write_vlan_tpid(dpt.get_version(), port, 0));
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.set_port_tpid(dpt.get_version(), port));
 
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
@@ -1736,6 +1735,20 @@ int controller::egress_tpid_rewrite(uint32_t port) noexcept {
   return rv;
 }
 
+int controller::delete_egress_tpid(uint32_t port) noexcept {
+  int rv = 0;
+  try {
+
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.remove_port_tpid(dpt.get_version(), port));
+
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  }
+  return rv;
+}
 int controller::subscribe_to(enum swi_flags flags) noexcept {
   int rv = 0;
   this->flags = this->flags | flags;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1720,6 +1720,22 @@ int controller::egress_bridge_port_vlan_remove(uint32_t port,
   return rv;
 }
 
+int controller::egress_tpid_rewrite(uint32_t port) noexcept {
+  int rv = 0;
+  try {
+
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0),
+        fm_driver.write_vlan_tpid(dpt.get_version(), port, 0));
+
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  }
+  return rv;
+}
+
 int controller::subscribe_to(enum swi_flags flags) noexcept {
   int rv = 0;
   this->flags = this->flags | flags;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -237,7 +237,8 @@ public:
                                   bool untagged) noexcept override;
   int egress_bridge_port_vlan_remove(uint32_t port,
                                      uint16_t vid) noexcept override;
-  int egress_tpid_rewrite(uint32_t port) noexcept override;
+  int set_egress_tpid(uint32_t port) noexcept override;
+  int delete_egress_tpid(uint32_t port) noexcept override;
 
   int get_statistics(uint64_t port_no, uint32_t number_of_counters,
                      const sai_port_stat_t *counter_ids,

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -237,6 +237,7 @@ public:
                                   bool untagged) noexcept override;
   int egress_bridge_port_vlan_remove(uint32_t port,
                                      uint16_t vid) noexcept override;
+  int egress_tpid_rewrite(uint32_t port) noexcept override;
 
   int get_statistics(uint64_t port_no, uint32_t number_of_counters,
                      const sai_port_stat_t *counter_ids,

--- a/src/sai.h
+++ b/src/sai.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public * License, v. 2.0. If a copy of the MPL was not distributed with this
+/* This Source Code Form is subject to the terms of the Mozilla Public * License, v. 2.0.
+ * If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #pragma once

--- a/src/sai.h
+++ b/src/sai.h
@@ -1,4 +1,4 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public *
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -1,5 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public * License, v. 2.0.
- * If a copy of the MPL was not distributed with this
+/* This Source Code Form is subject to the terms of the Mozilla Public *
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #pragma once

--- a/src/sai.h
+++ b/src/sai.h
@@ -1,5 +1,4 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
+/* This Source Code Form is subject to the terms of the Mozilla Public * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #pragma once
@@ -137,6 +136,7 @@ public:
                                           bool untagged) noexcept = 0;
   virtual int egress_bridge_port_vlan_remove(uint32_t port,
                                              uint16_t vid) noexcept = 0;
+  virtual int egress_tpid_rewrite(uint32_t port) noexcept = 0;
 
   virtual int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept = 0;
   virtual int subscribe_to(enum swi_flags flags) noexcept = 0;

--- a/src/sai.h
+++ b/src/sai.h
@@ -136,7 +136,8 @@ public:
                                           bool untagged) noexcept = 0;
   virtual int egress_bridge_port_vlan_remove(uint32_t port,
                                              uint16_t vid) noexcept = 0;
-  virtual int egress_tpid_rewrite(uint32_t port) noexcept = 0;
+  virtual int set_egress_tpid(uint32_t port) noexcept = 0;
+  virtual int delete_egress_tpid(uint32_t port) noexcept = 0;
 
   virtual int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept = 0;
   virtual int subscribe_to(enum swi_flags flags) noexcept = 0;


### PR DESCRIPTION
## Description
This PR adds support to QnQ aware switching. This feature will allow baseboxd to write to the correct OFDPA table, thus setting the correct egress TPID.

The changes in the controller class add a new pair of functions: set_egress_tpid and delete_egress_tpid. These functions have been added to rofl-ofdpa in https://github.com/bisdn/rofl-ofdpa/pull/102, and return the correct flow mod to the switch.

On the netlink part, when a bridge is added with the command `ip l a bridge (...) vlan_protocol 802.1ad`, and ports are subsequently added to it, the sysfs value for the vlan_protocol is read (stored in  /sys/class/net/ + bridge_portname + /bridge/vlan_protocol) to determine if the entry in the TPID table must be set. In the case of a 802.1Q bridge, nothing is set; on a 802.1AD. the TPID entry on the switch is enabled for the attached port.  

When the ports are removed from the bridge, the corresponding entry on the OFDPA tables are removed. When the bridge is removed, all of the ports configured on the bridge will have their entries removed from the tables.  

## Motivation and Context
QinQ VLANs, or 802.1ad is an extension to the VLAN standard that allows multiple VLAN tags to be attached to a single frame. Using stacked VLANs, providers are able to bundle traffic tagged with different VLAN into a single Service tag.

## How Has This Been Tested?
Testing has been based on the added scripts. By configuring the switch using the examples/bridging/qnq/qnq_vlan_controller script, and a server using the examples/bridging/qnq/qnq_vlan_server script, we are able to see that the entries are on the switch, and traffic is flowing as expected.
