### PR TITLE
Prevent VLAN unaware bridges from being configured

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -42,6 +42,10 @@ void nl_bridge::set_bridge_interface(rtnl_link *bridge) {
 
   this->bridge = bridge;
   nl_object_get(OBJ_CAST(bridge));
+
+  if (!get_vlan_filtering())
+    LOG(FATAL) << __FUNCTION__
+               << " unsupported: bridge configured with vlan_filtering 0";
 }
 
 bool nl_bridge::is_bridge_interface(rtnl_link *link) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a user tries to configure traditional bridges, and attach baseboxd's ports to it, the switch will accept it, but leads to errors, since this configuration is not currently supported in baseboxd. Therefore, reading the vlan_filtering option in the bridge interface sysfs is necessary to prevent misconfiguration. 

This PR also adds further exception handling to the functions introduced in #230,  set_egress_tpid, and delete_ingress_pid.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR aims to introduce a feature where baseboxd will prevent the user from configuring non-vlan aware bridges, since these can be created and used, but will lead to failures if that happens. 

## How Has This Been Tested?
The following list of commands should work correctly, resuming normal baseboxd's operation after.

```
ip link add swbridge type bridge vlan_filtering 1
ip link set port1 master swbridge
ip link delete swbridge
```

The following list of commands should now not work, causing baseboxd to log fatal the message: 
`unsupported: bridge configured with vlan_filtering 0`.

```
ip link add swbridge type bridge 
ip link set port1 master swbridge
ip link delete swbridge
```