### PR TITLE
Handle interface status changes

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -67,8 +67,6 @@ public:
   void start() noexcept;
   void stop() noexcept;
 
-  void port_status_changed(uint32_t, enum nbi::port_status) noexcept;
-
   static void nl_cb_v2(struct nl_cache *cache, struct nl_object *old_obj,
                        struct nl_object *new_obj, uint64_t diff, int action,
                        void *data);

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -57,7 +57,8 @@ void nbi_impl::port_notification(
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
-    } break;
+      }
+      break;
 
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
@@ -92,7 +93,7 @@ void nbi_impl::port_notification(
     default:
       break;
     }
-  }
+    }
   }
 }
 

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -49,17 +49,15 @@ void nbi_impl::port_notification(
 
   for (auto &&ntfy : notifications) {
     switch (ntfy.ev) {
-
-    case PORT_EVENT_MODIFY: {
+    case PORT_EVENT_MODIFY:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
         tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
+        break;
       }
-      break;
-
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
@@ -75,7 +73,6 @@ void nbi_impl::port_notification(
         break;
       }
       break;
-
     case PORT_EVENT_DEL:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
@@ -92,7 +89,6 @@ void nbi_impl::port_notification(
       break;
     default:
       break;
-    }
     }
   }
 }

--- a/src/netlink/nbi_impl.h
+++ b/src/netlink/nbi_impl.h
@@ -29,13 +29,14 @@ public:
   void resend_state() noexcept override;
   void
   port_notification(std::deque<port_notification_data> &) noexcept override;
-  void port_status_changed(uint32_t port, enum port_status) noexcept override;
   int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept override;
   int fdb_timeout(uint32_t port_id, uint16_t vid,
                   const rofl::caddress_ll &mac) noexcept override;
 
   // tap_callback
   int enqueue_to_switch(uint32_t port_id, struct basebox::packet *) override;
+
+  void netlink_state_running();
 
   std::shared_ptr<tap_manager> get_tapmanager() { return tap_man; }
 };

--- a/src/netlink/nbi_impl.h
+++ b/src/netlink/nbi_impl.h
@@ -36,8 +36,6 @@ public:
   // tap_callback
   int enqueue_to_switch(uint32_t port_id, struct basebox::packet *) override;
 
-  void netlink_state_running();
-
   std::shared_ptr<tap_manager> get_tapmanager() { return tap_man; }
 };
 

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -323,6 +323,7 @@ int tap_manager::change_port_status(const std::string name, bool status) {
 
   // Set flags
   error = ioctl(sockFd, SIOCSIFFLAGS, static_cast<void *>(&ifr));
+  close(sockFd);
   return error;
 }
 

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <glog/logging.h>
-#include <netlink/route/link.h>
-#include <utility>
 #include <net/if.h>
+#include <netlink/route/link.h>
 #include <sys/ioctl.h>
+#include <utility>
 
 #include "cnetlink.h"
 #include "ctapdev.h"
@@ -307,14 +307,14 @@ int tap_manager::change_port_status(const std::string name, bool status) {
   struct ifreq ifr;
   memset(&ifr, 0, sizeof(ifr));
 
-  std::lock_guard<std::mutex> lock{tn_mutex};
   strncpy(ifr.ifr_name, name.c_str(), IFNAMSIZ);
 
   // Get existing flags
   auto sockFd = socket(PF_INET, SOCK_DGRAM, 0);
   int error = ioctl(sockFd, SIOCGIFFLAGS, static_cast<void *>(&ifr));
   if (error) {
-    LOG(ERROR) << __FUNCTION << ": ioctl failed with error code " << error;
+    LOG(ERROR) << __FUNCTION__ << ": ioctl failed with error code " << error;
+    close(sockFd);
     return error;
   }
 
@@ -328,8 +328,7 @@ int tap_manager::change_port_status(const std::string name, bool status) {
   // Set flags
   error = ioctl(sockFd, SIOCSIFFLAGS, static_cast<void *>(&ifr));
   if (error) {
-    LOG(ERROR) << __FUNCTION << ": ioctl failed with error code " << error;
-    return error;
+    LOG(ERROR) << __FUNCTION__ << ": ioctl failed with error code " << error;
   }
 
   close(sockFd);

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -313,6 +313,10 @@ int tap_manager::change_port_status(const std::string name, bool status) {
   // Get existing flags
   auto sockFd = socket(PF_INET, SOCK_DGRAM, 0);
   int error = ioctl(sockFd, SIOCGIFFLAGS, static_cast<void *>(&ifr));
+  if (error) {
+    LOG(ERROR) << __FUNCTION << ": ioctl failed with error code " << error;
+    return error;
+  }
 
   // Mutate flags
   if (status) {
@@ -323,6 +327,11 @@ int tap_manager::change_port_status(const std::string name, bool status) {
 
   // Set flags
   error = ioctl(sockFd, SIOCSIFFLAGS, static_cast<void *>(&ifr));
+  if (error) {
+    LOG(ERROR) << __FUNCTION << ": ioctl failed with error code " << error;
+    return error;
+  }
+
   close(sockFd);
   return error;
 }

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -7,7 +7,6 @@
 #include <utility>
 #include <net/if.h>
 #include <sys/ioctl.h>
-#include <string>
 
 #include "cnetlink.h"
 #include "ctapdev.h"

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -5,6 +5,9 @@
 #include <glog/logging.h>
 #include <netlink/route/link.h>
 #include <utility>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <string>
 
 #include "cnetlink.h"
 #include "ctapdev.h"
@@ -289,6 +292,39 @@ int tap_manager::recreate_tapdev(int ifindex, const std::string &portname) {
   }
 
   return rv;
+}
+
+/* 
+ * Adds a function to set port state according to link state 
+ * Status is determined via the portstatus/port_desc_reply message 
+ * This function sets the state using ioctl since netlink apparently cannot
+ * handle setting these parameters
+ *
+ * @param name port name to be changed
+ * @param status interface status: 1=up / 0=down
+ * @return ioctl value from setting the flags
+ */
+int tap_manager::change_port_status(const std::string name, bool status) {
+  struct ifreq ifr;
+  memset(&ifr, 0, sizeof(ifr));
+
+  std::lock_guard<std::mutex> lock{tn_mutex};
+  strncpy(ifr.ifr_name, name.c_str(), IFNAMSIZ);
+
+  // Get existing flags
+  auto sockFd = socket(PF_INET, SOCK_DGRAM, 0);
+  int error = ioctl(sockFd, SIOCGIFFLAGS, static_cast<void*>(&ifr)); 
+
+  // Mutate flags
+  if (status) {
+    ifr.ifr_flags |= IFF_UP;     
+  } else {
+    ifr.ifr_flags &= ~IFF_UP;
+  }
+
+  // Set flags
+  error = ioctl(sockFd, SIOCSIFFLAGS, static_cast<void*>(&ifr));
+  return error;
 }
 
 } // namespace basebox

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -293,9 +293,9 @@ int tap_manager::recreate_tapdev(int ifindex, const std::string &portname) {
   return rv;
 }
 
-/* 
- * Adds a function to set port state according to link state 
- * Status is determined via the portstatus/port_desc_reply message 
+/*
+ * Adds a function to set port state according to link state
+ * Status is determined via the portstatus/port_desc_reply message
  * This function sets the state using ioctl since netlink apparently cannot
  * handle setting these parameters
  *
@@ -312,17 +312,17 @@ int tap_manager::change_port_status(const std::string name, bool status) {
 
   // Get existing flags
   auto sockFd = socket(PF_INET, SOCK_DGRAM, 0);
-  int error = ioctl(sockFd, SIOCGIFFLAGS, static_cast<void*>(&ifr)); 
+  int error = ioctl(sockFd, SIOCGIFFLAGS, static_cast<void *>(&ifr));
 
   // Mutate flags
   if (status) {
-    ifr.ifr_flags |= IFF_UP;     
+    ifr.ifr_flags |= IFF_UP;
   } else {
     ifr.ifr_flags &= ~IFF_UP;
   }
 
   // Set flags
-  error = ioctl(sockFd, SIOCSIFFLAGS, static_cast<void*>(&ifr));
+  error = ioctl(sockFd, SIOCSIFFLAGS, static_cast<void *>(&ifr));
   return error;
 }
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -76,6 +76,7 @@ public:
   int get_fd(uint32_t port_id) const noexcept;
 
   int change_port_status(const std::string name, bool status);
+
   // access from northbound (cnetlink)
   int tapdev_removed(int ifindex, const std::string &portname);
   void tapdev_ready(rtnl_link *link);

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -75,6 +75,7 @@ public:
 
   int get_fd(uint32_t port_id) const noexcept;
 
+  int change_port_status(const std::string name, bool status); 
   // access from northbound (cnetlink)
   int tapdev_removed(int ifindex, const std::string &portname);
   void tapdev_ready(rtnl_link *link);

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -75,7 +75,7 @@ public:
 
   int get_fd(uint32_t port_id) const noexcept;
 
-  int change_port_status(const std::string name, bool status); 
+  int change_port_status(const std::string name, bool status);
   // access from northbound (cnetlink)
   int tapdev_removed(int ifindex, const std::string &portname);
   void tapdev_ready(rtnl_link *link);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -240,10 +240,11 @@ void controller::handle_port_status(rofl::crofdpt &dpt,
   auto port = msg.get_port();
 
   bool status = (!(port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) &&
-                !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
+                 !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
 
-  ntfys.emplace_back(nbi::port_notification_data{(nbi::port_event)msg.get_reason(), port.get_port_no(),
-                                                 msg.get_port().get_name(), status});
+  ntfys.emplace_back(nbi::port_notification_data{
+      (nbi::port_event)msg.get_reason(), port.get_port_no(),
+      msg.get_port().get_name(), status});
   nb->port_notification(ntfys);
 }
 
@@ -275,7 +276,7 @@ void controller::handle_port_desc_stats_reply(
     const cofport &port = msg.get_ports().get_port(i);
 
     bool status = (!(port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) &&
-                  !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
+                   !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
 
     notifications.emplace_back(nbi::port_notification_data{
         nbi::PORT_EVENT_ADD, port.get_port_no(), port.get_name(), status});

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -237,42 +237,14 @@ void controller::handle_port_status(rofl::crofdpt &dpt,
           << msg;
 
   std::deque<nbi::port_notification_data> ntfys;
-  uint32_t port_no = msg.get_port().get_port_no();
+  auto port = msg.get_port();
 
-  auto status = (nbi::port_status)0;
-  if (msg.get_port().get_config() & rofl::openflow13::OFPPC_PORT_DOWN) {
-    status = (nbi::port_status)(status | nbi::PORT_STATUS_ADMIN_DOWN);
-  }
+  bool status = (!(port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) &&
+                !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
 
-  if (msg.get_port().get_state() & rofl::openflow13::OFPPS_LINK_DOWN) {
-    status = (nbi::port_status)(status | nbi::PORT_STATUS_LOWER_DOWN);
-  }
-
-  switch (msg.get_reason()) {
-  case rofl::openflow::OFPPR_MODIFY: {
-
-    try {
-      nb->port_status_changed(port_no, status);
-    } catch (std::out_of_range &e) {
-      LOG(WARNING) << __FUNCTION__
-                   << ": unknown port with OF portno=" << port_no;
-    }
-  } break;
-  case rofl::openflow::OFPPR_ADD:
-    ntfys.emplace_back(nbi::port_notification_data{nbi::PORT_EVENT_ADD, port_no,
-                                                   msg.get_port().get_name()});
-    nb->port_notification(ntfys);
-    nb->port_status_changed(port_no, status);
-    break;
-  case rofl::openflow::OFPPR_DELETE:
-    ntfys.emplace_back(nbi::port_notification_data{nbi::PORT_EVENT_DEL, port_no,
-                                                   msg.get_port().get_name()});
-    nb->port_notification(ntfys);
-    break;
-  default:
-    LOG(ERROR) << __FUNCTION__ << ": invalid port status";
-    break;
-  }
+  ntfys.emplace_back(nbi::port_notification_data{(nbi::port_event)msg.get_reason(), port.get_port_no(),
+                                                 msg.get_port().get_name(), status});
+  nb->port_notification(ntfys);
 }
 
 void controller::handle_error_message(rofl::crofdpt &dpt,
@@ -298,29 +270,20 @@ void controller::handle_port_desc_stats_reply(
 
   std::deque<struct nbi::port_notification_data> notifications;
   std::deque<std::pair<uint32_t, enum nbi::port_status>> stats;
+
   for (auto i : msg.get_ports().keys()) {
     const cofport &port = msg.get_ports().get_port(i);
+
+    bool status = (!(port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) &&
+                  !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
+
     notifications.emplace_back(nbi::port_notification_data{
-        nbi::PORT_EVENT_ADD, port.get_port_no(), port.get_name()});
-
-    auto status = (nbi::port_status)0;
-    if (port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) {
-      status = (nbi::port_status)(status | nbi::PORT_STATUS_ADMIN_DOWN);
-    }
-
-    if (port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN) {
-      status = (nbi::port_status)(status | nbi::PORT_STATUS_LOWER_DOWN);
-    }
-    stats.emplace_back(port.get_port_no(), status);
+        nbi::PORT_EVENT_ADD, port.get_port_no(), port.get_name(), status});
   }
 
   /* init 1:1 port mapping */
   try {
     nb->port_notification(notifications);
-
-    for (auto status : stats) {
-      nb->port_status_changed(status.first, status.second);
-    }
     LOG(INFO) << "ports initialized";
 
     bb_thread.add_timer(

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -270,7 +270,6 @@ void controller::handle_port_desc_stats_reply(
   using rofl::openflow::cofport;
 
   std::deque<struct nbi::port_notification_data> notifications;
-  std::deque<std::pair<uint32_t, enum nbi::port_status>> stats;
 
   for (auto i : msg.get_ports().keys()) {
     const cofport &port = msg.get_ports().get_port(i);

--- a/src/sai.h
+++ b/src/sai.h
@@ -230,8 +230,6 @@ public:
   virtual void resend_state() noexcept = 0;
   virtual void
   port_notification(std::deque<port_notification_data> &) noexcept = 0;
-  virtual void port_status_changed(uint32_t port,
-                                   enum port_status) noexcept = 0;
   virtual int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept = 0;
   virtual int fdb_timeout(uint32_t port_id, uint16_t vid,
                           const rofl::caddress_ll &mac) noexcept = 0;

--- a/src/sai.h
+++ b/src/sai.h
@@ -185,6 +185,7 @@ public:
   enum port_event {
     PORT_EVENT_ADD,
     PORT_EVENT_DEL,
+    PORT_EVENT_MODIFY,
   };
 
   enum port_status {
@@ -196,6 +197,7 @@ public:
     enum port_event ev;
     uint32_t port_id;
     std::string name;
+    bool status;
   };
 
   enum port_type {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the handling of the initial port status desc message, and subsequent port_status messages. 

The initial message contains the port description that is used to create the baseboxd interfaces, and has per-port config and state flags. These flags can be used to control the start up administrative state of a certain interface, via setting the ioctl SIOCGIFFLAGS to IFF_UP. This control is not exposed via netlink. 

These changes also remove any port handling from the cnetlink part, so all interface management is currently done by the tap_manager.

The port_status_changes function is also removed, optimizing the way southbound triggered interface changes are handled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently baseboxd interfaces do not reflect any physical or administrative state. Initial layer 1 connectivity must be checked on the switch via different tools, and pulling/inserting cables on the switch is not reflected on the switch.

Interface setup has as well been buggy for some time, due to https://github.com/bisdn/basebox/pull/233/files#diff-94cdbec815e0a3bb177160c90b055543L1233. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This PR has been tested by running baseboxd on the switch, pulling cables on the switch, and making sure the interfaces match.