### PR TITLE
nl_l3: do not create termination after registering link local addresses;

### DIFF
--- a/examples/bridging/trunk/cntl_trunk_script.sh
+++ b/examples/bridging/trunk/cntl_trunk_script.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+PORTA=${PORTA:-port31}
+PORTB=${PORTB:-port32}
+PORTC=${PORTC:-port33}
+PORTD=${PORTD:-port34}
+BRIDGE=${BRIDGE:-swbridge}
+
+function setup() {
+  ip link add name ${BRIDGE} type bridge vlan_filtering 1
+  ip link set ${BRIDGE} up
+
+  # port 1
+  ip link set ${PORTA} master ${BRIDGE}
+  ip link set ${PORTA} up
+
+  # port 2
+  ip link set ${PORTB} master ${BRIDGE}
+  ip link set ${PORTB} up
+
+  # port 3
+  ip link set ${PORTC} master ${BRIDGE}
+  ip link set ${PORTC} up
+
+  # port 4
+  ip link set ${PORTD} master ${BRIDGE}
+  ip link set ${PORTD} up
+
+  # Trunk port vids
+  bridge vlan add vid 123 dev ${PORTC}
+  bridge vlan add vid 124 dev ${PORTD}
+
+  # Access port vids
+  bridge vlan add vid 123 dev ${PORTA} pvid
+  bridge vlan add vid 124 dev ${PORTB} pvid
+}
+
+setup

--- a/examples/bridging/trunk/cntl_trunk_script.sh
+++ b/examples/bridging/trunk/cntl_trunk_script.sh
@@ -33,12 +33,12 @@ function setup() {
   ip link set ${PORTD} up
 
   # Trunk port vids
-  bridge vlan add vid 123 dev ${PORTC}
-  bridge vlan add vid 124 dev ${PORTD}
+  bridge vlan add vid 133 dev ${PORTC}
+  bridge vlan add vid 134 dev ${PORTD}
 
   # Access port vids
-  bridge vlan add vid 123 dev ${PORTA} pvid
-  bridge vlan add vid 124 dev ${PORTB} pvid
+  bridge vlan add vid 131 dev ${PORTA} pvid
+  bridge vlan add vid 132 dev ${PORTB} pvid
 }
 
 setup

--- a/examples/bridging/trunk/cntl_trunk_script.sh
+++ b/examples/bridging/trunk/cntl_trunk_script.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-PORTA=${PORTA:-port31}
-PORTB=${PORTB:-port32}
-PORTC=${PORTC:-port33}
-PORTD=${PORTD:-port34}
+# Bridging and Trunking test setup script
+
+# This script configures trunk and access ports on the bridge
+# Access Ports: Bridge Interfaces configured with ONLY PVID (native VLAN).
+# Trunk Ports: Bridge Interfaces configured with more than one VLAN.
+
+PORTA=${PORTA:-port31} # Access ports
+PORTB=${PORTB:-port32} # Access ports
+PORTC=${PORTC:-port33} # Trunk ports
+PORTD=${PORTD:-port34} # Trunk ports
 BRIDGE=${BRIDGE:-swbridge}
 
 function setup() {

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -627,7 +627,7 @@ void cnetlink::route_addr_apply(const nl_obj &obj) {
       l3->add_l3_addr(ADDR_CAST(obj.get_new_obj()));
       break;
     case AF_INET6:
-      l3->add_l3_addr_v6(ADDR_CAST(obj.get_new_obj()));
+      l3->add_l3_addr(ADDR_CAST(obj.get_new_obj()));
       break;
     default:
       LOG(ERROR) << __FUNCTION__ << ": unsupported family " << family;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -287,8 +287,9 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
       LOG(ERROR) << __FUNCTION__
                  << ": could not add unicast route ipv6_dst=" << ipv6_dst
                  << ", mask=" << mask;
-      return rv;
     }
+
+    return rv;
   }
 
   uint16_t vid = vlan->get_vid(link);

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -249,6 +249,7 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
     }
   }
 
+  LOG(FATAL);
   return rv;
 }
 
@@ -455,6 +456,7 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
     return rv;
   }
 
+#if 0
   // XXX TODO is this still needed?
   rv = vlan->add_vlan(link.get(), vid, tagged);
   if (rv < 0) {
@@ -462,6 +464,7 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
                << " on link " << OBJ_CAST(link.get());
     return rv;
   }
+#endif
 
   rv = add_l3_egress(ifindex, vid, s_mac, d_mac, l3_interface_id);
   if (rv < 0) {

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -39,10 +39,8 @@ public:
   int init() noexcept;
 
   int add_l3_addr(struct rtnl_addr *a);
-  int add_l3_addr_v6(struct rtnl_addr *a);
   int del_l3_addr(struct rtnl_addr *a);
-
-  int add_lo_addr_v6(struct rtnl_addr *a);
+  int add_lo_addr(struct rtnl_addr *a);
 
   int add_l3_neigh(struct rtnl_neigh *n);
   int update_l3_neigh(struct rtnl_neigh *n_old, struct rtnl_neigh *n_new);

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -195,7 +195,7 @@ std::vector<uint16_t> nl_vlan::get_bridge_vids(rtnl_link *link) {
   }
 
   auto ret = rtnl_link_bridge_get_port_vlan(*it);
-  if(!ret)
+  if (!ret)
     return std::vector<uint16_t>();
 
   return parse_vlan_bitmap(ret->vlan_bitmap);

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -24,8 +24,6 @@ public:
   int add_vlan(rtnl_link *link, uint16_t vid, bool tagged, uint16_t vrf_id = 0);
   int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged,
                   uint16_t vrf_id = 0);
-  int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
-                          uint16_t vrf_id = 0);
 
   uint16_t get_vid(rtnl_link *link);
   std::vector<uint16_t> get_bridge_vids(rtnl_link *link);

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -28,6 +28,7 @@ public:
                           uint16_t vrf_id = 0);
 
   uint16_t get_vid(rtnl_link *link);
+  std::vector<uint16_t> get_bridge_vids(rtnl_link *link);
 
   bool is_vid_valid(uint16_t vid) const {
     if (vid < vid_low || vid > vid_high)

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1327,7 +1327,7 @@ int controller::ingress_port_vlan_add(uint32_t port, uint16_t vid, bool pvid,
                                     dpt.get_version(), port, vid, vrf_id));
       dpt.send_flow_mod_message(
           rofl::cauxid(0),
-          fm_driver.enable_port_pvid_ingress(dpt.get_version(), port, vid));
+          fm_driver.enable_port_pvid_ingress(dpt.get_version(), port, vid, vrf_id));
     } else {
       dpt.send_flow_mod_message(rofl::cauxid(0),
                                 fm_driver.enable_port_vid_ingress(

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -256,7 +256,7 @@ void controller::handle_error_message(rofl::crofdpt &dpt,
           << " pkt received: " << std::endl
           << msg;
 
-  LOG(WARNING) << __FUNCTION__ << ": not implemented";
+  LOG(WARNING) << __FUNCTION__ << msg;
 }
 
 void controller::handle_port_desc_stats_reply(
@@ -1325,9 +1325,9 @@ int controller::ingress_port_vlan_add(uint32_t port, uint16_t vid, bool pvid,
       dpt.send_flow_mod_message(rofl::cauxid(0),
                                 fm_driver.enable_port_vid_ingress(
                                     dpt.get_version(), port, vid, vrf_id));
-      dpt.send_flow_mod_message(
-          rofl::cauxid(0),
-          fm_driver.enable_port_pvid_ingress(dpt.get_version(), port, vid, vrf_id));
+      dpt.send_flow_mod_message(rofl::cauxid(0),
+                                fm_driver.enable_port_pvid_ingress(
+                                    dpt.get_version(), port, vid, vrf_id));
     } else {
       dpt.send_flow_mod_message(rofl::cauxid(0),
                                 fm_driver.enable_port_vid_ingress(


### PR DESCRIPTION
## Description
Adding a termination MAC entry after registering the link local address has a bug, where the wrong VID is discovered therefore writing the incorrect VLAN on the TMAC entry on the ASIC. 

This PR fixes VID discovery for the bridged ports, thus being able to write the correct VID. Also featured on this PR is a simplification of the addition of IP addresses, IPv4 and IPv6, and  

## Motivation and Context
See #234. 
It effects not only systemd-networkd but also iproute2.

Configuring access ports on the switch means adding the PVID on the following rule,

inPort = ABC (Physical)  vlanId:mask = 0x0000:0x1fff (VLAN 0) | GoTo = 20 (Termination MAC) newVlanId = 0x1064 (VLAN XXX) | priority = 3 hard_time = 0 idle_time = 0 cookie = 21,

where XXX is then the PVID for a specific port ABC.

This bug i that this rule was written correctly, but then overwritten by the re-addition of IP addresses, like the IPv6 link local. Since baseboxd also configures the VLAN entries on this case, it was re-writing the correct rule with the wrongly discovered VLAN id.

## How Has This Been Tested?
PR includes a script under bridging/trunk/cntl_trunk_script.sh
