### PR TITLE
nl_l3: do not create termination after registering link local addresses

### DIFF
--- a/examples/bridging/trunk/cntl_trunk_script.sh
+++ b/examples/bridging/trunk/cntl_trunk_script.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+PORTA=${PORTA:-port31}
+PORTB=${PORTB:-port32}
+PORTC=${PORTC:-port33}
+PORTD=${PORTD:-port34}
+BRIDGE=${BRIDGE:-swbridge}
+
+function setup() {
+  ip link add name ${BRIDGE} type bridge vlan_filtering 1
+  ip link set ${BRIDGE} up
+
+  # port 1
+  ip link set ${PORTA} master ${BRIDGE}
+  ip link set ${PORTA} up
+
+  # port 2
+  ip link set ${PORTB} master ${BRIDGE}
+  ip link set ${PORTB} up
+
+  # port 3
+  ip link set ${PORTC} master ${BRIDGE}
+  ip link set ${PORTC} up
+
+  # port 4
+  ip link set ${PORTD} master ${BRIDGE}
+  ip link set ${PORTD} up
+
+  # Trunk port vids
+  bridge vlan add vid 123 dev ${PORTC}
+  bridge vlan add vid 124 dev ${PORTD}
+
+  # Access port vids
+  bridge vlan add vid 123 dev ${PORTA} pvid
+  bridge vlan add vid 124 dev ${PORTB} pvid
+}
+
+setup

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -312,6 +312,9 @@ bool cnetlink::is_bridge_interface(int ifindex) const {
 bool cnetlink::is_bridge_interface(rtnl_link *l) const {
   assert(l);
 
+  if (bridge && rtnl_link_get_master(l) == bridge->get_ifindex()) {
+    return true;
+  }
   // is a vlan on top of the bridge?
   if (rtnl_link_is_vlan(l)) {
     LOG(INFO) << __FUNCTION__ << ": vlan ok";

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -236,7 +236,10 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
     LOG(ERROR) << __FUNCTION__ << ": failed to setup l3 addr " << addr;
   }
 
-  if (!is_loopback && !is_bridge) {
+  // Avoid adding table VLAN entry for the following two cases
+  // Loopback: does not require entry on the Ingress table
+  // Bridges and Bridge Interfaces: Entry already set
+  if (!is_loopback && !is_bridge && !nl->is_bridge_interface(link)) {
     assert(ifindex);
     // add vlan
     bool tagged = !!rtnl_link_is_vlan(link);
@@ -324,7 +327,10 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
     return rv;
   }
 
-  if (!is_loopback) {
+  // Avoid adding table VLAN entry for the following two cases
+  // Loopback: does not require entry on the Ingress table
+  // Bridges and Bridge Interfaces: Entry already set
+  if (!is_loopback && !nl->is_bridge_interface(link)) {
     // add vlan
     bool tagged = !!rtnl_link_is_vlan(link);
     rv = vlan->add_vlan(link, vid, tagged);


### PR DESCRIPTION
## Description
Adding a termination MAC entry after registering the link local address has a bug, where the wrong VID is discovered therefore writing the incorrect VLAN on the TMAC entry on the ASIC. 

This PR fixes VID discovery for the bridged ports, thus being able to write the correct VID. Also featured on this PR is a simplification of the addition of IP addresses, IPv4 and IPv6, and  

## Motivation and Context
See #234. 
It effects not only systemd-networkd but also iproute2.

Configuring access ports on the switch means adding the PVID on the following rule,

inPort = ABC (Physical)  vlanId:mask = 0x0000:0x1fff (VLAN 0) | GoTo = 20 (Termination MAC) newVlanId = 0x1064 (VLAN XXX) | priority = 3 hard_time = 0 idle_time = 0 cookie = 21,

where XXX is then the PVID for a specific port ABC.

This bug i that this rule was written correctly, but then overwritten by the re-addition of IP addresses, like the IPv6 link local. Since baseboxd also configures the VLAN entries on this case, it was re-writing the correct rule with the wrongly discovered VLAN id.

## How Has This Been Tested?
PR includes a script under bridging/trunk/cntl_trunk_script.sh
