### PR TITLE
fix compilation with gRPC v1.22.0 and newer

### DIFF
--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -8,9 +8,7 @@
 
 #include "api/ofdpa.grpc.pb.h"
 
-namespace grpc {
-class Channel;
-}
+using grpc::Channel;
 
 namespace basebox {
 


### PR DESCRIPTION
fix compilation with gRPC v1.22.0 and newer

## Description

gRPC v1.22 moved the Channel implementation to its own class and changed
grpc::Channel to a typdef. This causes the following build failure:

```
In file included from ../git/src/of-dpa/controller.cc:16:
../git/src/of-dpa/ofdpa_client.h:12:7: error: using typedef-name 'grpc::Channel' after 'class'
   12 | class Channel;
      |       ^~~~~~~
In file included from /usr/include/grpcpp/grpcpp.h:52,
                 from /usr/include/grpc++/grpc++.h:26,
                 from ../git/src/of-dpa/controller.cc:13:
/usr/include/grpcpp/channel.h:26:30: note: 'grpc::Channel' has a previous declaration here
   26 | typedef ::grpc_impl::Channel Channel;
      |                              ^~~~~~~
```

Fix this by replacing the namespace declaration with using
grpc::Channel.

## Motivation and Context

Newer distributions may use newer gRPC versions (e.g. Fedora 32 uses 1.26, Yocto 3.1 / zeus uses 1.24.2).

## How Has This Been Tested?

booted AS4610 with gRPC 1.14.1 (Yocto thud/warrior) and checked output of client_flowtable_dump, booted AS4610 with gRPC 1.24.2 (yocto zeus) and checked output of client_flowtable_dump.