### PR TITLE
tap_man: avoid changing interface state on modify

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -52,7 +52,7 @@ void nbi_impl::port_notification(
     case PORT_EVENT_MODIFY:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        tap_man->change_port_status(ntfy.name, ntfy.status);
+        LOG(INFO) << __FUNCTION__ << ": port state changed, continuing";
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -58,10 +58,14 @@ void nbi_impl::port_notification(
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
         break;
       }
+      break;
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this);
+        if (tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this) == -EEXIST) {
+          LOG(INFO) << __FUNCTION__ << ": port already exists";
+          break;
+        }
         tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       case nbi::port_type_vxlan:

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -79,8 +79,9 @@ int tap_manager::create_tapdev(uint32_t port_id, const std::string &port_name,
       r = -EINVAL;
     }
   } else {
-    LOG(INFO) << __FUNCTION__ << ": " << port_name
+    VLOG(1) << __FUNCTION__ << ": " << port_name
               << " with port_id=" << port_id << " already existing";
+    r = -EEXIST;
   }
 
   return r;

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -79,8 +79,8 @@ int tap_manager::create_tapdev(uint32_t port_id, const std::string &port_name,
       r = -EINVAL;
     }
   } else {
-    VLOG(1) << __FUNCTION__ << ": " << port_name
-              << " with port_id=" << port_id << " already existing";
+    VLOG(1) << __FUNCTION__ << ": " << port_name << " with port_id=" << port_id
+            << " already existing";
     r = -EEXIST;
   }
 


### PR DESCRIPTION
## Description
This PR removes the modify port state capability from baseboxd. Due to not being able to accurately represent link admin and phy state, changing the port status on every notification will ensure that port configuration is removed, which brings the switch to a weird state on the retriggering of  the port state.

## Motivation and Context
Rebooting servers must not change port state on the switch, to avoid losing configuration.

## How Has This Been Tested?
Tested against BISDN Linux v2.1.0

```
10-swbridge.netdev
[NetDev]
Name=swbridge
Kind=bridge

[Bridge]
DefaultPVID=0
VLANFiltering=1
```
```
10-swbridge.network
[Match]
Name=swbridge

[BridgeVLAN]
VLAN=108
````
```
20-port1.network
[Match]
Name=port1

[Network]
Bridge=swbridge

[BridgeVLAN]
VLAN=108
```
```
20-port3.network
[Match]
Name=port3

[Network]
Bridge=swbridge

[BridgeVLAN]
PVID=108
EgressUntagged=108

```


