### PR TITLE
WIP: controller: expose controller error messages

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -256,7 +256,7 @@ void controller::handle_error_message(rofl::crofdpt &dpt,
           << " pkt received: " << std::endl
           << msg;
 
-  LOG(WARNING) << __FUNCTION__ << ": not implemented";
+  LOG(WARNING) << __FUNCTION__ << ": " << msg;
 }
 
 void controller::handle_port_desc_stats_reply(


### PR DESCRIPTION
## Description
This patch enables printing the error message that we obtain from the openflow channel.

In [rofl-common](https://github.com/bisdn/rofl-common/blob/21ad547f18895f4b818376b9fc896b34848f4a18/src/rofl/common/openflow/messages/cofmsg_error.h#L102) we have the handling of the message itself, by overloading the output operator. 

## Motivation and Context
By exposing errors from the switch we simplify the debugging process.  

## How Has This Been Tested?
This is a simply output patch, no test required.
