### PR TITLE
baseboxd: add Multicast Support on bridges

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -35,6 +35,7 @@ public:
     NL_LINK_CACHE,
     NL_NEIGH_CACHE,
     NL_ROUTE_CACHE,
+    NL_MDB_CACHE,
     NL_MAX_CACHE,
   };
 
@@ -153,6 +154,7 @@ private:
   void route_link_apply(const nl_obj &obj);
   void route_neigh_apply(const nl_obj &obj);
   void route_route_apply(const nl_obj &obj);
+  void route_mdb_apply(const nl_obj &obj);
 
   enum cnetlink_event_t {
     EVENT_NONE,

--- a/src/netlink/netlink-utils.cc
+++ b/src/netlink/netlink-utils.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 
 #include <glog/logging.h>
+#include <linux/if_ether.h>
 #include <netlink/route/link.h>
 
 #include "netlink-utils.h"
@@ -108,6 +109,27 @@ uint64_t nlall2uint64(const nl_addr *a) noexcept {
   b_[1] = a_[4];
   b_[0] = a_[5];
   return b;
+}
+
+// Convert Multicast IPv4 addresses to MAC address
+// Multicast MAC address : 01:00:53:XX:XX:XX
+void multicast_ipv4_to_ll(const uint32_t addr, unsigned char *dst) noexcept {
+  dst[0] = 0x01;
+  dst[1] = 0x00;
+  dst[2] = 0x5e;
+  dst[3] = (addr >> 16) & 0x7f;
+  dst[4] = (addr >> 8) & 0xff;
+  dst[5] = addr & 0xff;
+}
+
+// Convert Multicast IPv6 addresses to MAC address
+// Multicast MAC address : 33:33:XX:XX:XX:XX
+void multicast_ipv6_to_ll(const struct in6_addr *addr,
+                          unsigned char *dst) noexcept {
+  dst[0] = 0x33;
+  dst[1] = 0x33;
+
+  memcpy(dst + 2, &addr->s6_addr32[3], sizeof(__u32));
 }
 
 } // namespace basebox

--- a/src/netlink/netlink-utils.h
+++ b/src/netlink/netlink-utils.h
@@ -13,12 +13,14 @@ struct rtnl_addr;
 struct rtnl_link;
 struct rtnl_neigh;
 struct rtnl_route;
+struct rtnl_mdb;
 }
 
 #define LINK_CAST(obj) reinterpret_cast<struct rtnl_link *>(obj)
 #define NEIGH_CAST(obj) reinterpret_cast<struct rtnl_neigh *>(obj)
 #define ROUTE_CAST(obj) reinterpret_cast<struct rtnl_route *>(obj)
 #define ADDR_CAST(obj) reinterpret_cast<struct rtnl_addr *>(obj)
+#define MDB_CAST(obj) reinterpret_cast<struct rtnl_mdb *>(obj)
 
 namespace basebox {
 
@@ -40,5 +42,8 @@ enum link_type {
 enum link_type get_link_type(rtnl_link *link) noexcept;
 
 uint64_t nlall2uint64(const nl_addr *a) noexcept;
+void multicast_ipv4_to_ll(const uint32_t addr, unsigned char *dst) noexcept;
+void multicast_ipv6_to_ll(const struct in6_addr *addr,
+                          unsigned char *dst) noexcept;
 
 } // namespace basebox

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -19,6 +19,7 @@ extern "C" {
 struct rtnl_link_bridge_vlan;
 struct rtnl_link;
 struct rtnl_neigh;
+struct rtnl_mdb;
 struct nl_addr;
 }
 
@@ -50,6 +51,9 @@ public:
 
   void add_neigh_to_fdb(rtnl_neigh *);
   void remove_neigh_from_fdb(rtnl_neigh *);
+
+  int mdb_entry_add(rtnl_mdb *mdb_entry);
+  int mdb_entry_remove(rtnl_mdb *mdb_entry);
 
   bool is_mac_in_l2_cache(rtnl_neigh *n);
   int learn_source_mac(rtnl_link *br_link, packet *p);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -778,7 +778,6 @@ int controller::l2_multicast_group_add(uint32_t port, uint16_t vid,
     // find grp/vlan combination
     auto it = std::find(mc_groups.begin(), mc_groups.end(), n_mcast);
 
-
     if (it != mc_groups.end()) { // if mmac does exist, update
       it->l2_interface.emplace(fm_driver.group_id_l2_interface(port, vid));
       index = it->index;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1746,7 +1746,7 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
     dpt.send_flow_mod_message(
         rofl::cauxid(0), fm_driver.enable_policy_ipv4_multicast(
                              dpt.get_version(), rofl::caddress_in4("224.0.0.0"),
-                             rofl::build_mask_in4(24)));
+                             rofl::build_mask_in4(4)));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -158,7 +158,19 @@ public:
                           bool permanent) noexcept override;
   int l2_overlay_addr_remove(uint32_t tunnel_id, uint32_t lport_id,
                              const rofl::cmacaddr &mac) noexcept override;
+  int l2_multicast_addr_add(uint32_t port, uint16_t vid,
+                            const rofl::caddress_ll &mac) noexcept override;
+  int l2_multicast_addr_remove(uint32_t port, uint16_t vid,
+                               const rofl::caddress_ll &mac) noexcept override;
 
+  /* @ Layer 2 Multicast { */
+  int l2_multicast_group_add(uint32_t port, uint16_t vid,
+                             rofl::caddress_ll mc_group) noexcept override;
+  int l2_multicast_group_remove(uint32_t port, uint16_t vid,
+                                rofl::caddress_ll mc_group) noexcept override;
+  /* @} */
+
+  // dmac = Multicast or Unicast MAC Address
   int l3_termination_add(uint32_t sport, uint16_t vid,
                          const rofl::caddress_ll &dmac) noexcept override;
   int l3_termination_add_v6(uint32_t sport, uint16_t vid,
@@ -290,12 +302,27 @@ private:
   rofl::cdptid dptid;
   rofl::openflow::rofl_ofdpa_fm_driver fm_driver;
   std::mutex l2_domain_mutex;
+  std::mutex multicast_groups_mutex;
+  std::mutex stats_mutex;
+  std::mutex conn_mutex;
+
   std::map<uint16_t, std::set<uint32_t>> l2_domain;
   std::map<uint16_t, std::set<uint32_t>> lag;
   std::map<uint16_t, std::set<uint32_t>> tunnel_dlf_flood;
-  std::mutex conn_mutex;
+
+  struct multicast_entry {
+    // mmac, vlan
+    std::tuple<rofl::caddress_ll, uint16_t> key;
+    int index;
+    std::set<uint32_t> l2_interface;
+
+    multicast_entry() {}
+    bool operator==(const struct multicast_entry c1) { return (c1.key == key); }
+  };
+  std::deque<struct multicast_entry>
+      mc_groups; // mac address, vlan , index, l2_interfaces
+
   rofl::cthread bb_thread;
-  std::mutex stats_mutex;
   rofl::openflow::cofportstatsarray stats_array;
   uint32_t egress_interface_id;
   std::set<uint32_t> freed_egress_interfaces_ids;

--- a/src/sai.h
+++ b/src/sai.h
@@ -35,14 +35,19 @@ public:
     SAI_PORT_STAT_COLLISIONS,
   } sai_port_stat_t;
 
+  /* @ LAG { */
   virtual int lag_create(uint32_t *lag_id) noexcept = 0;
   virtual int lag_remove(uint32_t lag_id) noexcept = 0;
   virtual int lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept = 0;
   virtual int lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept = 0;
+  /* @} */
 
+  /* @ tunnel overlay { */
   virtual int overlay_tunnel_add(uint32_t tunnel_id) noexcept = 0;
   virtual int overlay_tunnel_remove(uint32_t tunnel_id) noexcept = 0;
+  /* @} */
 
+  /* @ Layer 2 bridging { */
   virtual int l2_addr_remove_all_in_vlan(uint32_t port,
                                          uint16_t vid) noexcept = 0;
   virtual int l2_addr_add(uint32_t port, uint16_t vid,
@@ -56,7 +61,15 @@ public:
                                   bool permanent) noexcept = 0;
   virtual int l2_overlay_addr_remove(uint32_t tunnel_id, uint32_t lport_id,
                                      const rofl::cmacaddr &mac) noexcept = 0;
+  virtual int l2_multicast_addr_add(uint32_t port, uint16_t vid,
+                                    const rofl::caddress_ll &mac) noexcept = 0;
+  virtual int
+  l2_multicast_addr_remove(uint32_t port, uint16_t vid,
+                           const rofl::caddress_ll &mac) noexcept = 0;
+  /* @} */
 
+
+  /* @ termination MAC { */
   virtual int l3_termination_add(uint32_t sport, uint16_t vid,
                                  const rofl::caddress_ll &dmac) noexcept = 0;
   virtual int l3_termination_add_v6(uint32_t sport, uint16_t vid,
@@ -66,7 +79,9 @@ public:
   virtual int
   l3_termination_remove_v6(uint32_t sport, uint16_t vid,
                            const rofl::caddress_ll &dmac) noexcept = 0;
+  /* @} */
 
+  /* @ Layer 3 egress group { */
   virtual int l3_egress_create(uint32_t port, uint16_t vid,
                                const rofl::caddress_ll &src_mac,
                                const rofl::caddress_ll &dst_mac,
@@ -76,7 +91,9 @@ public:
                                const rofl::caddress_ll &dst_mac,
                                uint32_t *l3_interface_id) noexcept = 0;
   virtual int l3_egress_remove(uint32_t l3_interface) noexcept = 0;
+  /* @} */
 
+  /* @ Layer3 Unicast { */
   virtual int l3_unicast_host_add(const rofl::caddress_in4 &ipv4_dst,
                                   uint32_t l3_interface, bool is_ecmp,
                                   bool update_route,
@@ -109,18 +126,24 @@ public:
   virtual int l3_unicast_route_remove(const rofl::caddress_in6 &ipv6_dst,
                                       const rofl::caddress_in6 &mask,
                                       uint16_t vrf_id = 0) noexcept = 0;
+  /* @} */
 
+  /* @ Layer3 ECMP { */
   virtual int l3_ecmp_add(uint32_t l3_ecmp_id,
                           const std::set<uint32_t> &l3_interfaces) noexcept = 0;
   virtual int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept = 0;
+  /* @} */
 
+  /* @ Ingress port vlan  { */
   virtual int ingress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int ingress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;
   virtual int ingress_port_vlan_add(uint32_t port, uint16_t vid, bool pvid,
                                     uint16_t vrf_id = 0) noexcept = 0;
   virtual int ingress_port_vlan_remove(uint32_t port, uint16_t vid, bool pvid,
                                        uint16_t vrf_id = 0) noexcept = 0;
+  /* @} */
 
+  /* @ Egress port vlan  { */
   virtual int egress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int egress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;
 
@@ -128,18 +151,25 @@ public:
                                    bool untagged) noexcept = 0;
   virtual int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept = 0;
 
-  virtual int add_l2_overlay_flood(uint32_t tunnel_id,
-                                   uint32_t lport_id) noexcept = 0;
-  virtual int del_l2_overlay_flood(uint32_t tunnel_id,
-                                   uint32_t lport_id) noexcept = 0;
-
   virtual int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,
                                           bool untagged) noexcept = 0;
   virtual int egress_bridge_port_vlan_remove(uint32_t port,
                                              uint16_t vid) noexcept = 0;
+  /* @} */
+
+  /* @ Layer 2 overlay  { */
+  virtual int add_l2_overlay_flood(uint32_t tunnel_id,
+                                   uint32_t lport_id) noexcept = 0;
+  virtual int del_l2_overlay_flood(uint32_t tunnel_id,
+                                   uint32_t lport_id) noexcept = 0;
+  /* @} */
+
+  /* @ QnQ  { */
   virtual int set_egress_tpid(uint32_t port) noexcept = 0;
   virtual int delete_egress_tpid(uint32_t port) noexcept = 0;
+  /* @} */
 
+  /* @ control  { */
   virtual int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept = 0;
   virtual int subscribe_to(enum swi_flags flags) noexcept = 0;
 
@@ -148,7 +178,9 @@ public:
   virtual int get_statistics(uint64_t port_no, uint32_t number_of_counters,
                              const sai_port_stat_t *counter_ids,
                              uint64_t *counters) noexcept = 0;
+  /* @} */
 
+  /* @ tunnels  { */
   virtual int tunnel_tenant_create(uint32_t tunnel_id,
                                    uint32_t vni) noexcept = 0;
   virtual int tunnel_tenant_delete(uint32_t tunnel_id) noexcept = 0;
@@ -177,6 +209,7 @@ public:
                                      uint32_t tunnel_id) noexcept = 0;
   virtual int tunnel_port_tenant_remove(uint32_t port_id,
                                         uint32_t tunnel_id) noexcept = 0;
+  /* @} */
 };
 
 class nbi {

--- a/src/sai.h
+++ b/src/sai.h
@@ -68,6 +68,13 @@ public:
                            const rofl::caddress_ll &mac) noexcept = 0;
   /* @} */
 
+  /* @ Layer 2 Multicast { */
+  virtual int l2_multicast_group_add(uint32_t port, uint16_t vid,
+                                     rofl::caddress_ll mc_group) noexcept = 0;
+  virtual int
+  l2_multicast_group_remove(uint32_t port, uint16_t vid,
+                            rofl::caddress_ll mc_group) noexcept = 0;
+  /* @} */
 
   /* @ termination MAC { */
   virtual int l3_termination_add(uint32_t sport, uint16_t vid,


### PR DESCRIPTION
# Description

In order to develop multicast, baseboxd must be aware of the modifications in the Linux kernel bridge driver multicast database. 

This database tracks the multicast memberships of ports in a certain bridge. The following is the available data in this database. 

```
dev swbridge 
port port7 
grp 239.1.0.31 
state temp
vid 108
```

This database is filled either manually via 

```
bridge mdb add dev <bridge> port <port> vid <VLAN id> grp <multicast group>
```

or via the incoming IGMP/MLD notifications from the hosts. These protocols allow the router to know which multicast group a certain host is interested in joining. 

The Linux kernel has a notification system via Netlink that reports the changes in the multicast database over the [RTNLGRP_MDB](https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/rtnetlink.h#L711) multicast socket.

As such notifications such as RTM_NEWMDB, RTM_GETMDB can be processed in userspace and in baseboxd specifically. 

libn has a message caching mechanism that baseboxd is employing for Link, Address, Route and Neighbor notifications. The MDB cache is the new addition to both libnl and baseboxd that must be implemented. Refer to [libnl git PR](https://github.com/thom311/libnl/pull/234).

baseboxd is then able to obtain the relevant information from the Linux kernel, and translate it to the ASIC via OpenFlow.

OFDPA uses the following model: [rofl-ofdpa PR](https://github.com/bisdn/rofl-ofdpa/pull/104)

```
                                          / if match Unicast MAC   -> Unicast Routing (30)
Ingress VLAN (10) -> Termination MAC (20) -> if match Multicast MAC -> Multicast Routing (40)
                                          \ Default miss -> Bridging (50)
```

After matching on the Multicast Routing table there is an optional Openflow action to direct to a L3 Multicast Group. 
IP multicast packets are handled differently if they are switched (same VLAN) or routed(different VLAN). 
- Switched: cannot be output to IN_PORT (ingress port)
- Routed: must be allowed to egress via IN_PORT (ingress port)

OFDPA handles this split by chaining the L3 Multicast group to the respective L2 or L3 interface group entry. This decision where to the correctly forward the multicast driver is then based on the VLAN.