### PR TITLE
Added STP configuration example files

### DIFF
--- a/examples/bridging/stp/01-server
+++ b/examples/bridging/stp/01-server
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+ip link add name br0 type bridge vlan_filtering 1 stp_state 1
+ip link set br0 up
+
+ip link add name br1 type bridge vlan_filtering 1 stp_state 1
+ip link set br1 up
+
+ip link set eno2 master br0
+ip link set eno2 up
+
+ip link set eno3 master br1
+ip link set eno3 up
+
+ip link add br0-veth1 type veth peer name br1-veth1
+ip link set br0-veth1 master br0
+ip link set br1-veth1 master br1
+ip link set br0-veth1 up
+ip link set br1-veth1 up
+

--- a/examples/bridging/stp/01-switch
+++ b/examples/bridging/stp/01-switch
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ip link add name br0 type bridge vlan_filtering 1 stp_state 1
+
+ip link set br0 up
+
+ip link set port2 master br0
+ip link set port2 up
+
+ip link set port3 master br0
+ip link set port3 up
+


### PR DESCRIPTION
Added example on how to setup a triangle topology between a switch with
one bridge and a server with two bridges, while configuring them to use
STP.

Port names in the examples are used between as4610-54t-2 and bbctrl01.

Signed-off-by: Ricardo Santos <ricardo.santos@bisdn.de>
