### PR TITLE
tap_manager: set port speed on tap interfaces

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -38,6 +38,7 @@ void nbi_impl::port_notification(
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
         tap_man->change_port_status(ntfy.name, ntfy.status);
+	tap_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
@@ -49,6 +50,7 @@ void nbi_impl::port_notification(
       case nbi::port_type_physical:
         tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this);
         tap_man->change_port_status(ntfy.name, ntfy.status);
+        tap_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -11,6 +11,7 @@
 #include <mutex>
 
 #include "sai.h"
+#include <linux/ethtool.h>
 
 extern "C" {
 struct rtnl_link;
@@ -76,6 +77,7 @@ public:
   int get_fd(uint32_t port_id) const noexcept;
 
   int change_port_status(const std::string name, bool status);
+  int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
 
   // access from northbound (cnetlink)
   int tapdev_removed(int ifindex, const std::string &portname);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -239,10 +239,12 @@ void controller::handle_port_status(rofl::crofdpt &dpt,
 
   bool status = (!(port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) &&
                  !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
+  uint32_t speed = port.get_ethernet().get_curr_speed();
+  uint8_t duplex = get_duplex(port.get_ethernet().get_curr());
 
   ntfys.emplace_back(nbi::port_notification_data{
       (nbi::port_event)msg.get_reason(), port.get_port_no(),
-      msg.get_port().get_name(), status});
+      msg.get_port().get_name(), status, speed, duplex});
   nb->port_notification(ntfys);
 }
 
@@ -274,9 +276,12 @@ void controller::handle_port_desc_stats_reply(
 
     bool status = (!(port.get_config() & rofl::openflow13::OFPPC_PORT_DOWN) &&
                    !(port.get_state() & rofl::openflow13::OFPPS_LINK_DOWN));
+    uint32_t speed = port.get_ethernet().get_curr_speed();
+    uint8_t duplex = get_duplex(port.get_ethernet().get_curr());
 
-    notifications.emplace_back(nbi::port_notification_data{
-        nbi::PORT_EVENT_ADD, port.get_port_no(), port.get_name(), status});
+    notifications.emplace_back(
+        nbi::port_notification_data{nbi::PORT_EVENT_ADD, port.get_port_no(),
+                                    port.get_name(), status, speed, duplex});
   }
 
   /* init 1:1 port mapping */

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -22,6 +22,7 @@
 
 #include "sai.h"
 
+#define CHECK_BIT(var, pos) (((var) >> (pos)) & 1)
 namespace basebox {
 
 // forward declarations
@@ -303,6 +304,13 @@ private:
   bool connected;
   std::shared_ptr<ofdpa_client> ofdpa;
   uint16_t ofdpa_grpc_port;
+
+  uint8_t get_duplex(uint32_t current) {
+    if (CHECK_BIT(current, 0) or CHECK_BIT(current, 2) or CHECK_BIT(current, 4))
+      return 0;
+    else
+      return 1;
+  }
 
   enum timer_t {
     /* handle_timeout will be called as well from crofbase, hence we need some

--- a/src/sai.h
+++ b/src/sai.h
@@ -198,6 +198,8 @@ public:
     uint32_t port_id;
     std::string name;
     bool status;
+    uint32_t speed;
+    uint8_t duplex;
   };
 
   enum port_type {


### PR DESCRIPTION
## Motivation and Context

Link speed must be adapted to the correct reported speed from OFDPA. Currently the device is stuck at 10MB/s

```
ethtool port1 | grep Speed
        Speed: 10Mb/s
```

Link speed for tap interfaces looks to be set at https://elixir.bootlin.com/linux/latest/source/drivers/net/tun.c#L3519

ethtool is able to change the speed with the ioctl `ioctl(3, SIOCETHTOOL, 0x7ffe47542930)`

The link speed is already reported from the switch, so baseboxd is capable of setting this information in Linux.

ethtool command: `ethtool -s port1 speed=100`

## How Has This Been Tested?
In Basebox, run 

```
# client_drivshell port xe53 speed=10000
# client_drivshell port xe53 speed
PORT: Status (* indicates PHY link up)
 *xe53    (40G) 


# ethtool port54
Settings for port54:
        Supported ports: [ ]
        Supported link modes:   Not reported
        Supported pause frame use: No
        Supports auto-negotiation: No
        Supported FEC modes: Not reported
        Advertised link modes:  Not reported
        Advertised pause frame use: No
        Advertised auto-negotiation: No
        Advertised FEC modes: Not reported
        Speed: 10000Mb/s
        Duplex: Full
        Port: Twisted Pair
        PHYAD: 0
        Transceiver: internal
        Auto-negotiation: off
        MDI-X: Unknown
        Current message level: 0xffffffa1 (-95)
                               drv ifup tx_err tx_queued intr tx_done rx_status pktdata hw wol 0xffff8000
        Link detected: yes
```