### PR TITLE
show physical link state as carrier state on tap devices

### DIFF
--- a/src/netlink/ctapdev.cc
+++ b/src/netlink/ctapdev.cc
@@ -29,7 +29,7 @@ ctapdev::~ctapdev() { tap_close(); }
 
 void ctapdev::tap_open() {
   struct ifreq ifr;
-  int rc;
+  int rc, carrier = 0;
 
   if (fd != -1) {
     VLOG(1) << __FUNCTION__ << ": tapdev is already open using fd=" << fd;
@@ -50,6 +50,11 @@ void ctapdev::tap_open() {
                << " errno=" << errno << " reason: " << strerror(errno);
     close(fd);
     fd = -1;
+  }
+
+  if ((rc = ioctl(fd, TUNSETCARRIER, &carrier)) < 0) {
+    LOG(ERROR) << __FUNCTION__ << ": ioctl TUNSETCARRIER failed on fd=" << fd
+               << " errno=" << errno << " reason: " << strerror(errno);
   }
 
   LOG(INFO) << __FUNCTION__ << ": created tapdev " << devname << " fd=" << fd

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -51,7 +51,6 @@ void nbi_impl::port_notification(
           LOG(INFO) << __FUNCTION__ << ": port already exists";
           break;
         }
-        tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -47,10 +47,7 @@ void nbi_impl::port_notification(
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        if (tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this) == -EEXIST) {
-          LOG(INFO) << __FUNCTION__ << ": port already exists";
-          break;
-        }
+        tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this);
         tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       case nbi::port_type_vxlan:

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -37,7 +37,7 @@ void nbi_impl::port_notification(
     case PORT_EVENT_MODIFY:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        LOG(INFO) << __FUNCTION__ << ": port state changed, continuing";
+        tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
@@ -51,6 +51,7 @@ void nbi_impl::port_notification(
           LOG(INFO) << __FUNCTION__ << ": port already exists";
           break;
         }
+        tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -82,7 +82,6 @@ int tap_manager::create_tapdev(uint32_t port_id, const std::string &port_name,
   } else {
     VLOG(1) << __FUNCTION__ << ": " << port_name << " with port_id=" << port_id
             << " already existing";
-    r = -EEXIST;
   }
 
   return r;


### PR DESCRIPTION
Since Linux 5.0 it is possible to modify the carrier state of taptun devices, so let's use that to expose  the link state as carrier state and restore PORT_MODIFY handling.

## Description
By setting the carrier state on tap devices we can notify the system when a link is established or lost without touching the administrative state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changing the administrative state is inherently at conflict with any network management daemon controlling it. It will also override expected user behavior when intentionally setting a port down (next link up would set it up again).

So using the carrier state instead provides the link state on the correct channel, fixing/avoiding many of these issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

A version containing this change was installed on Agema 5648 (Tomahawk+), Agema AG7648 (Trident II), Accton AS4610-54T-2 (Helix 4), and I checked whether the link state is propagated properly. 

Agema AG7648 shows the issue that it does not provide link down events on link down. Only a link up will trigger a link down, then link up pair (the issue is in ASIC/SDK/OF-DPA, not baseboxd).

Agema AG5648 and Accton AS4610-54 both properly trigger PORT_MODIFY events with the expected contents.

Link down, administrative state down:
```
13: port7: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 2a:27:08:dc:11:c4 brd ff:ff:ff:ff:ff:ff
```

Link up, administrative state down:
```
13: port7: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT group default qlen 1000
    link/ether 2a:27:08:dc:11:c4 brd ff:ff:ff:ff:ff:ff
```

Link down, administrative state up:
```
13: port7: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT group default qlen 1000
    link/ether 2a:27:08:dc:11:c4 brd ff:ff:ff:ff:ff:ff
```

Link up, administrative state up:
```
13: port7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether 2a:27:08:dc:11:c4 brd ff:ff:ff:ff:ff:ff
```