### PR TITLE
properly fix race in port tap device creation on of connection

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -17,6 +17,7 @@ nbi_impl::nbi_impl(std::shared_ptr<cnetlink> nl,
                    std::shared_ptr<tap_manager> tap_man)
     : nl(nl), tap_man(tap_man) {
   nl->set_tapmanager(tap_man);
+  nl->start();
 }
 
 nbi_impl::~nbi_impl() { nl->stop(); }
@@ -31,12 +32,9 @@ void nbi_impl::register_switch(switch_interface *swi) noexcept {
 void nbi_impl::switch_state_notification(enum switch_state state) noexcept {
   switch (state) {
   case SWITCH_STATE_UP:
-    nl->start();
-    break;
   case SWITCH_STATE_DOWN:
   case SWITCH_STATE_FAILED:
   case SWITCH_STATE_UNKNOWN:
-    nl->stop();
     break;
   default:
     LOG(FATAL) << __FUNCTION__ << ": invalid state";

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -29,19 +29,6 @@ void nbi_impl::register_switch(switch_interface *swi) noexcept {
   nl->register_switch(swi);
 }
 
-void nbi_impl::switch_state_notification(enum switch_state state) noexcept {
-  switch (state) {
-  case SWITCH_STATE_UP:
-  case SWITCH_STATE_DOWN:
-  case SWITCH_STATE_FAILED:
-  case SWITCH_STATE_UNKNOWN:
-    break;
-  default:
-    LOG(FATAL) << __FUNCTION__ << ": invalid state";
-    break;
-  }
-}
-
 void nbi_impl::port_notification(
     std::deque<port_notification_data> &notifications) noexcept {
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -172,7 +172,6 @@ void controller::handle_features_reply(
     rofl::openflow::cofmsg_features_reply &msg) {
   VLOG(1) << __FUNCTION__ << ": dpt=" << dpt << " on auxid=" << auxid
           << ", msg: " << msg;
-  nb->switch_state_notification(nbi::SWITCH_STATE_UP);
 }
 
 void controller::handle_barrier_reply(
@@ -196,6 +195,7 @@ void controller::handle_desc_stats_reply(
 
   // TODO evaluate switch here?
 
+  nb->switch_state_notification(nbi::SWITCH_STATE_UP);
   dpt.send_port_desc_stats_request(rofl::cauxid(0), 0, 2);
 }
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -127,8 +127,6 @@ void controller::handle_dpt_close(const rofl::cdptid &dptid) {
   }
 
   this->dptid = rofl::cdptid(0);
-
-  nb->switch_state_notification(nbi::SWITCH_STATE_DOWN);
 }
 
 void controller::handle_conn_terminated(rofl::crofdpt &dpt,
@@ -195,7 +193,6 @@ void controller::handle_desc_stats_reply(
 
   // TODO evaluate switch here?
 
-  nb->switch_state_notification(nbi::SWITCH_STATE_UP);
   dpt.send_port_desc_stats_request(rofl::cauxid(0), 0, 2);
 }
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -206,13 +206,6 @@ public:
     port_type_lag = 2,
   };
 
-  enum switch_state {
-    SWITCH_STATE_UNKNOWN,
-    SWITCH_STATE_UP,
-    SWITCH_STATE_DOWN,
-    SWITCH_STATE_FAILED,
-  };
-
   static uint32_t combine_port_type(uint16_t port_num, enum port_type type) {
     return (uint32_t)port_num | type << 16;
   }
@@ -226,7 +219,6 @@ public:
   }
 
   virtual void register_switch(switch_interface *) noexcept = 0;
-  virtual void switch_state_notification(enum switch_state) noexcept = 0;
   virtual void resend_state() noexcept = 0;
   virtual void
   port_notification(std::deque<port_notification_data> &) noexcept = 0;


### PR DESCRIPTION
The fix in #254 was not enough due to a misunderstanding of how rofl-common works. So instead of trying to figure out the place where to enable netlink processing without missing messages, just enable it always.

## Description
Mostly see #254, but now enable when instantiating nbi_impl, instead of waiting for the signal that the switch is ready.

## Motivation and Context
See #254 

## How Has This Been Tested?
Two rounds of running the testing pipeline (with the pending carrier changes) on the ag7648, one round without the changes, build pipeline 9455 (currently running).
