### PR TITLE
nbi_impl.h: remove missed prototype to fix compilation

### DIFF
--- a/src/netlink/nbi_impl.h
+++ b/src/netlink/nbi_impl.h
@@ -25,7 +25,6 @@ public:
 
   // nbi
   void register_switch(switch_interface *) noexcept override;
-  void switch_state_notification(enum switch_state) noexcept override;
   void resend_state() noexcept override;
   void
   port_notification(std::deque<port_notification_data> &) noexcept override;


### PR DESCRIPTION
Fixes the following build error:

 In file included from ../git/src/baseboxd.cc:10:
 ../git/src/netlink/nbi_impl.h:28:39: error: use of enum 'switch_state' without previous declaration
    void switch_state_notification(enum switch_state) noexcept override;
                                        ^~~~~~~~~~~~
 ../git/src/netlink/nbi_impl.h:28:8: error: 'void basebox::nbi_impl::switch_state_notification(int)' marked 'override', but does not override
    void switch_state_notification(enum switch_state) noexcept override;
         ^~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>