### PR TITLE
.travis.yml: make sure we test the intended revision and not master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ jobs:
       services:
         - docker
       script:
-        - cd docker/from_source
-        - docker build .
+        - docker build -f docker/from_source/Dockerfile .

--- a/docker/from_source/Dockerfile
+++ b/docker/from_source/Dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:30
 LABEL maintainer="jan.klare@bisdn.de"
+ADD . / basebox/
 RUN dnf -y install dnf-plugins-core && \
     dnf -y install git && \
     dnf -y install clang && \
@@ -13,8 +14,8 @@ RUN dnf -y install dnf-plugins-core && \
     dnf -y copr enable bisdn/rofl-testing && \
     dnf -y copr enable bisdn/baseboxd && \
     dnf -y copr enable bisdn/baseboxd-testing && \
-    git clone --recursive https://github.com/bisdn/basebox.git && \
     cd basebox && \
+    git submodule update --init --recursive && \
     make -C ./pkg/testing/rpm/ spec && \
     dnf -y builddep ./pkg/testing/rpm/baseboxd.spec && \
     meson build && \


### PR DESCRIPTION
## Description

Instead of cloning within the container, just copy the currently checked
out sources into the container, which match the revision we want to
test. We still need to checkout the submodules.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

## Motivation and Context
This fixes travis always building master instead of the (PR) branch.

## How Has This Been Tested?

Travis does the testing for us ;-) (actually checking the travis build output and verifyfing the output contains the line "COMMIT=\<commit of this fix\>" appears in the log.