### PR TITLE
multicast: fix bugs with implementation

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1268,20 +1268,20 @@ std::deque<rtnl_neigh *> cnetlink::search_fdb(uint16_t vid, nl_addr *lladdr) {
 
 void cnetlink::route_mdb_apply(const nl_obj &obj) {
 
-  switch (obj.get_action()) {
-  case NL_ACT_NEW:
+  switch (obj.get_msg_type()) {
+  case RTM_NEWMDB:
     assert(obj.get_new_obj());
     LOG(INFO) << __FUNCTION__ << ": new mdb entry";
 
     if (bridge)
       bridge->mdb_entry_add(MDB_CAST(obj.get_new_obj()));
     break;
-  case NL_ACT_DEL:
+  case RTM_DELMDB:
     assert(obj.get_old_obj());
     LOG(INFO) << __FUNCTION__ << ": deleting mdb entry";
 
     if (bridge)
-      bridge->mdb_entry_remove(MDB_CAST(obj.get_old_obj()));
+      bridge->mdb_entry_remove(MDB_CAST(obj.get_new_obj()));
     break;
   default:
     LOG(ERROR) << __FUNCTION__ << ": invalid action " << obj.get_action();

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -806,6 +806,10 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
     uint32_t port_id = nl->get_port_id(port_ifindex);
     uint16_t vid = rtnl_mdb_entry_get_vid(i);
 
+    if (port_ifindex == get_ifindex()) {
+      return rv;
+    }
+
     auto addr = rtnl_mdb_entry_get_addr(i);
     if (rtnl_mdb_entry_get_proto(i) == ETH_P_IP) {
       rofl::caddress_in4 ipv4_dst = libnl_in4addr_2_rofl(addr, &rv);

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -835,6 +835,14 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
         return rv;
       }
     } else if (rtnl_mdb_entry_get_proto(i) == ETH_P_IPV6) {
+
+      // Is address Linklocal Multicast
+      auto p = nl_addr_alloc(16);
+      nl_addr_parse("ff02::/10", AF_INET6, &p);
+      std::unique_ptr<nl_addr, decltype(&nl_addr_put)> tm_addr(p, nl_addr_put);
+      if (!nl_addr_cmp_prefix(addr, tm_addr.get()))
+        return 0;
+
       struct in6_addr *v6_addr =
           (struct in6_addr *)nl_addr_get_binary_addr(addr);
 


### PR DESCRIPTION
prevent link local multicast to be configured on the switch

## Description
When initially developing multicast for baseboxd the structure of the libnl objects were unclear. As such, it was necessary to fix a couple problems with the implementation.

The change from executing on the libnl action (NL_ACT_NEW) to  acting on the message type, is to ensure that NL_ACT_CHANGE events correctly processed. 

We must also prevent the configuration of the link local multicast groups configured on IPv6 since these are not necessary for our purposes.

