### PR TITLE
Add STP support

### DIFF
--- a/examples/bridging/stp/01-server
+++ b/examples/bridging/stp/01-server
@@ -8,8 +8,8 @@ PORTB=${PORTA:-eno3}
 ip link add name ${BRIDGE0} type bridge vlan_filtering 1 stp_state 1
 ip link set ${BRIDGE0} up
 
-ip link add name ${BRIDGE0} type bridge vlan_filtering 1 stp_state 1
-ip link set ${BRIDGE0} up
+ip link add name ${BRIDGE1} type bridge vlan_filtering 1 stp_state 1
+ip link set ${BRIDGE1} up
 
 ip link set ${PORTA} master ${BRIDGE0}
 ip link set ${PORTA} up

--- a/examples/bridging/stp/01-server
+++ b/examples/bridging/stp/01-server
@@ -1,20 +1,26 @@
 #!/bin/bash
 
-ip link add name br0 type bridge vlan_filtering 1 stp_state 1
-ip link set br0 up
+BRIDGE0=${BRIDGE0:-stpbridge0}
+BRIDGE1=${BRIDGE1:-stpbridge1}
+PORTA=${PORTA:-eno2}
+PORTB=${PORTA:-eno3}
 
-ip link add name br1 type bridge vlan_filtering 1 stp_state 1
-ip link set br1 up
+ip link add name ${BRIDGE0} type bridge vlan_filtering 1 stp_state 1
+ip link set ${BRIDGE0} up
 
-ip link set eno2 master br0
-ip link set eno2 up
+ip link add name ${BRIDGE0} type bridge vlan_filtering 1 stp_state 1
+ip link set ${BRIDGE0} up
 
-ip link set eno3 master br1
-ip link set eno3 up
+ip link set ${PORTA} master ${BRIDGE0}
+ip link set ${PORTA} up
 
-ip link add br0-veth1 type veth peer name br1-veth1
-ip link set br0-veth1 master br0
-ip link set br1-veth1 master br1
-ip link set br0-veth1 up
-ip link set br1-veth1 up
+ip link set ${PORTB} master ${BRIDGE1}
+ip link set ${PORTB} up
+
+ip link add ${BRIDGE0}-veth1 type veth peer name ${BRIDGE1}-veth1
+ip link set ${BRIDGE0}-veth1 master ${BRIDGE0}
+ip link set ${BRIDGE0}br1-veth1 master ${BRIDGE1}
+
+ip link set ${BRIDGE0}-veth1 up
+ip link set ${BRIDGE1}-veth1 up
 

--- a/examples/bridging/stp/01-switch
+++ b/examples/bridging/stp/01-switch
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-ip link add name br0 type bridge vlan_filtering 1 stp_state 1
+BRIDGE=${BRIDGE:-swbridge}
+PORTA=${PORTA:-port2}
+PORTB=${PORTA:-port3}
 
-ip link set br0 up
+ip link add name swbridge type bridge vlan_filtering 1 stp_state 1
+ip link set swbridge up
 
-ip link set port2 master br0
-ip link set port2 up
+ip link set ${PORTA} master ${BRIDGE}
+ip link set ${PORTA} up
 
-ip link set port3 master br0
-ip link set port3 up
+ip link set ${PORTB} master ${BRIDGE}
+ip link set ${PORTB} up
 

--- a/meson.build
+++ b/meson.build
@@ -152,6 +152,7 @@ src_pb = protoc_gen.process(
   'src/grpc/proto/common/empty.proto',
   'src/grpc/proto/common/openconfig-interfaces.proto',
   'src/grpc/proto/statistics/statistics-service.proto',
+  'src/grpc/proto/stp/openconfig-spanning-tree.proto',
   preserve_path_from : meson.current_source_dir()+'/src/grpc/proto')
 
 src_grpc = grpc_gen.process(

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -191,11 +191,6 @@ void nl_bridge::update_interface(rtnl_link *old_link, rtnl_link *new_link) {
       state = "learn";
       break;
     default:
-      state = "";
-      break;
-    }
-
-    if (state == "") {
       VLOG(1) << __FUNCTION__ << ": stp state change not supported";
       return;
     }

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2115,7 +2115,6 @@ int controller::ofdpa_stg_state_port_set(uint32_t port_id,
     LOG(ERROR) << __FUNCTION__ << ": failed to set the STP state";
   }
 
-
   return rv;
 }
 } // namespace basebox

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2096,4 +2096,26 @@ int controller::tunnel_port_tenant_remove(uint32_t lport_id,
   return rv;
 }
 
+// TODO Unimplemented
+#if 0
+int controller::ofdpa_stg_create() noexcept { return 0; }
+int controller::ofdpa_stg_destroy() noexcept { return 0; }
+
+int controller::ofdpa_stg_vlan_add() noexcept { return 0; }
+
+int controller::ofdpa_stg_vlan_remove() noexcept { return 0; }
+#endif
+
+int controller::ofdpa_stg_state_port_set(uint32_t port_id,
+                                         std::string state) noexcept {
+  int rv;
+
+  rv = ofdpa->ofdpaStgStatePortSet(port_id, state);
+  if (rv < 0) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to set the STP state";
+  }
+
+
+  return rv;
+}
 } // namespace basebox

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -293,6 +293,18 @@ public:
   int tunnel_port_tenant_remove(uint32_t lport_id,
                                 uint32_t tunnel_id) noexcept override;
 
+  /* STP */
+#if 0 // TODO Unimplemented
+  int ofdpa_stg_create() noexcept override;
+  int ofdpa_stg_destroy() noexcept override;
+
+  int ofdpa_stg_vlan_add() noexcept override;
+  int ofdpa_stg_vlan_remove() noexcept override;
+#endif
+
+  int ofdpa_stg_state_port_set(uint32_t port_id,
+                               std::string state) noexcept override;
+
   /* print this */
   friend std::ostream &operator<<(std::ostream &os, const controller &box) {
     os << "<controller>" << std::endl;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -294,7 +294,15 @@ public:
                                 uint32_t tunnel_id) noexcept override;
 
   /* STP */
-#if 0 // TODO Unimplemented
+#if 0 
+  // TODO Unimplemented
+  // This set of functions is currently defined in our datamodel
+  // but no implementation. It is intented that these functions
+  // provide the Per VLAN STP functions
+  // The stg_create and stg_destroy functions implement creating 
+  // other Spanning Tree Groups/Instances
+  // the stg_vlan_add and stg_vlan_remove function implements adding/removing
+  // VLANS from a certain STG 
   int ofdpa_stg_create() noexcept override;
   int ofdpa_stg_destroy() noexcept override;
 

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -270,7 +270,6 @@ ofdpa_client::ofdpaTunnelPortTenantDelete(uint32_t port_id,
       stub_->ofdpaTunnelPortTenantDelete(&context, request, &response);
 
   if (not rv.ok()) {
-    // LOG status
     return ofdpa::OfdpaStatus::OFDPA_E_RPC;
   }
 
@@ -287,6 +286,9 @@ ofdpa_client::ofdpaStgStatePortSet(uint32_t port_id, std::string state) {
   request.set_port_state(state);
 
   ::Status rv = stub_->ofdpaStgStatePortSet(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
 
   return response.status();
 }

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -277,4 +277,18 @@ ofdpa_client::ofdpaTunnelPortTenantDelete(uint32_t port_id,
   return response.status();
 }
 
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaStgStatePortSet(uint32_t port_id, std::string state) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::openconfig_spanning_tree::Stp_Rstp_Interface_State request;
+
+  request.set_name(std::to_string(port_id));
+  request.set_port_state(state);
+
+  ::Status rv = stub_->ofdpaStgStatePortSet(&context, request, &response);
+
+  return response.status();
+}
+
 } // namespace basebox

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "api/ofdpa.grpc.pb.h"
+#include "stp/openconfig-spanning-tree.pb.h"
 
 using grpc::Channel;
 
@@ -53,6 +54,15 @@ public:
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelPortTenantDelete(uint32_t port_id, uint32_t tunnel_id);
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgCreate();
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgDestroy();
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanAdd();
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanRemove();
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgStatePortSet(uint32_t port_id,
+                                                           std::string state);
 
 private:
   ofdpa::OfdpaStatus::OfdpaStatusCode

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -55,11 +55,13 @@ public:
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelPortTenantDelete(uint32_t port_id, uint32_t tunnel_id);
 
+#if 0
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgCreate();
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgDestroy();
 
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanAdd();
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanRemove();
+#endif
 
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgStatePortSet(uint32_t port_id,
                                                            std::string state);

--- a/src/sai.h
+++ b/src/sai.h
@@ -217,6 +217,19 @@ public:
   virtual int tunnel_port_tenant_remove(uint32_t port_id,
                                         uint32_t tunnel_id) noexcept = 0;
   /* @} */
+
+  /* @ STP  { */
+#if 0 // TODO Unimplemented
+  virtual int ofdpa_stg_create() noexcept = 0;
+  virtual int ofdpa_stg_destroy() noexcept = 0;
+
+  virtual int ofdpa_stg_vlan_add() noexcept = 0;
+  virtual int ofdpa_stg_vlan_remove() noexcept = 0;
+#endif
+
+  virtual int ofdpa_stg_state_port_set(uint32_t port_id,
+                                       std::string state) noexcept = 0;
+  /* @} */
 };
 
 class nbi {

--- a/src/sai.h
+++ b/src/sai.h
@@ -219,7 +219,15 @@ public:
   /* @} */
 
   /* @ STP  { */
-#if 0 // TODO Unimplemented
+#if 0
+  // TODO Unimplemented
+  // This set of functions is currently defined in our datamodel
+  // but no implementation. It is intented that these functions
+  // provide the Per VLAN STP functions
+  // The stg_create and stg_destroy functions implement creating 
+  // other Spanning Tree Groups/Instances
+  // the stg_vlan_add and stg_vlan_remove function implements adding/removing
+  // VLANS from a certain STG 
   virtual int ofdpa_stg_create() noexcept = 0;
   virtual int ofdpa_stg_destroy() noexcept = 0;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current PR aims to add xSTP support to baseboxd. 

The Linux bridges already implement STP, and baseboxd must only be made aware of the TAP interface changes between the STP states.

When the STP state changes on a TAP interface, the resulting port state is then written to the ASIC via ofdpa-grpc, which interacts with the ASIC to set the correct port state.

## Motivation and Context

Adding STP support to baseboxd requires the following workflow:

```
STP port change
      +
      v
  +---+----+
  |baseboxd|
  +---+----+
      |
      | gRPC
      |
      v
+----------+
|ofdpa-grpc|
+----------+
```

[ofdpa-grpc](https://gitlab.bisdn.de/basebox/ofdpa-grpc) must be adapted to be able to interact with the SDK. 

OpenFlow does not natively expose the capability of changing STP port state, as such we are forced to extend the existing side-channel to set this capability directly on the SDK.

The STP state on the SDK can be manipulated by the following command,

```
accton-as4610:/home/basebox# client_drivshell port 4 stp=<state>
Calling ofdpaBcmCommand rpc with command = "port 4 stp ".
PORT: Status (* indicates PHY link up)
  ge3     ) STP(Block) 
Returned from ofdpaBcmCommand rpc with rc = 0.
```

ofdpa-grpc uses the services defined in [basebox-protobuf](https://github.com/bisdn/basebox-protobuf) to define an API. These services are based on the standardized datamodels from OpenConfig and IETF. Currently these services lack an API to represent STP state, which is why the [openconfig-spanning-tree.yang](https://github.com/openconfig/public/blob/master/release/models/stp/openconfig-spanning-tree.yang) is the proposed model to serve as a basis for this new API.

## How Has This Been Tested?
Tested these changes using latest ofdpa-grpc and the included bash scripts to setup bridges on a 4610 and one server.