### PR TITLE
bond: expand bonding feature in baseboxd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,7 +153,6 @@ src_pb = protoc_gen.process(
   'src/grpc/proto/common/openconfig-interfaces.proto',
   'src/grpc/proto/statistics/statistics-service.proto',
   'src/grpc/proto/stp/openconfig-spanning-tree.proto',
-  'src/grpc/proto/trunk/trunk-interfaces.proto',
   preserve_path_from : meson.current_source_dir()+'/src/grpc/proto')
 
 src_grpc = grpc_gen.process(

--- a/meson.build
+++ b/meson.build
@@ -113,7 +113,7 @@ if not libnl.found()
 endif
 
 if cppc.has_header_symbol('netlink/route/link/bonding.h', 'rtnl_link_bond_get_mode', dependencies: libnl, required: false)
-  add_global_arguments('-DHAVE_RTNL_LINK_BOND_GET_MODE', 'cpp')
+  add_global_arguments('-DHAVE_RTNL_LINK_BOND_GET_MODE',  language: 'cpp')
 endif
 
 libnl_route = dependency('libnl-route-3.0', required: false)

--- a/meson.build
+++ b/meson.build
@@ -153,6 +153,7 @@ src_pb = protoc_gen.process(
   'src/grpc/proto/common/openconfig-interfaces.proto',
   'src/grpc/proto/statistics/statistics-service.proto',
   'src/grpc/proto/stp/openconfig-spanning-tree.proto',
+  'src/grpc/proto/trunk/trunk-interfaces.proto',
   preserve_path_from : meson.current_source_dir()+'/src/grpc/proto')
 
 src_grpc = grpc_gen.process(

--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,10 @@ if not libnl.found()
   libnl = cppc.find_library('libnl-3')
 endif
 
+if cppc.has_header_symbol('netlink/route/link/bonding.h', 'rtnl_link_bond_get_mode', dependencies: libnl, required: false)
+  add_global_arguments('-DHAVE_RTNL_LINK_BOND_GET_MODE', 'cpp')
+endif
+
 libnl_route = dependency('libnl-route-3.0', required: false)
 if not libnl_route.found()
   # find the lib without pkg-config

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1037,6 +1037,9 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
                 << rtnl_link_get_name(new_link);
       rtnl_link *_bond = get_link(rtnl_link_get_master(new_link), AF_UNSPEC);
       bond->add_lag_member(_bond, new_link);
+
+      LOG(INFO) << __FUNCTION__ << " set active member " << get_port_id(_bond)
+                << " port id " << rtnl_link_get_ifindex(new_link);
     } else if (lt_new == LT_VRF_SLAVE) {
       LOG(INFO) << __FUNCTION__ << ": link enslaved "
                 << rtnl_link_get_name(new_link) << " but not handled";

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -994,8 +994,10 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
 
   switch (lt_old) {
   case LT_BOND_SLAVE:
-    if (lt_new == LT_BOND_SLAVE) { // bond updated
+    if (lt_new == LT_BOND_SLAVE) { // bond slave updated
       bond->update_lag_member(old_link, new_link);
+    } else if (lt_new == LT_TUN) { // bond slave removed
+      bond->remove_lag_member(old_link);
     }
     break;
   case LT_BRIDGE_SLAVE: // a bridge slave was changed

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -996,7 +996,6 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
   case LT_BOND_SLAVE:
     if (lt_new == LT_BOND_SLAVE) { // bond updated
       bond->update_lag_member(old_link, new_link);
-    } else if (lt_new == LT_TUN) { // link released
     }
     break;
   case LT_BRIDGE_SLAVE: // a bridge slave was changed

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -47,6 +47,7 @@ public:
   struct rtnl_link *get_link(int ifindex, int family) const;
   void get_bridge_ports(int br_ifindex,
                         std::deque<rtnl_link *> *link_list) const noexcept;
+  std::set<uint32_t> get_bond_members_by_lag(rtnl_link *bond_link);
 
   /**
    * @return rtnl_neigh* which needs to be freed using rtnl_neigh_put
@@ -58,6 +59,7 @@ public:
   bool is_bridge_configured(rtnl_link *l);
   int get_port_id(rtnl_link *l) const;
   int get_port_id(int ifindex) const;
+  int get_ifindex_by_port_id(uint32_t port_id) const;
 
   nl_cache *get_cache(enum nl_cache_t id) { return caches[id]; }
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -64,38 +64,8 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
   VLOG(1) << __FUNCTION__ << ": updating bond interface ";
   int rv = 0;
 
-  uint32_t o_active, n_active;
   uint8_t o_mode, n_mode;
   uint32_t lag_id = nl->get_port_id(new_link);
-
-  rv = rtnl_link_bond_get_active_slave(old_link, &o_active);
-  if (rv < 0) {
-    VLOG(1) << __FUNCTION__ << ": failed to get active state for "
-            << OBJ_CAST(old_link);
-  }
-
-  rv = rtnl_link_bond_get_active_slave(new_link, &n_active);
-  if (rv < 0) {
-    VLOG(1) << __FUNCTION__ << ": failed to get active state for "
-            << OBJ_CAST(new_link);
-  }
-
-  if (o_active != n_active) {
-    rv = swi->lag_set_member_active(lag_id, nl->get_port_id(n_active), 1);
-    if (rv < 0) {
-      VLOG(1) << __FUNCTION__ << ": failed to set active state for "
-              << OBJ_CAST(new_link);
-    }
-
-    rv = swi->lag_set_member_active(lag_id, nl->get_port_id(o_active), 0);
-
-    if (rv < 0) {
-      VLOG(1) << __FUNCTION__ << ": failed to set active state for "
-              << OBJ_CAST(new_link);
-    }
-
-    return 0;
-  }
 
   rv = rtnl_link_bond_get_mode(old_link, &o_mode);
   if (rv < 0) {

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -247,6 +247,15 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   return rv;
 }
 
+int nl_bond::remove_lag_member(rtnl_link *link) {
+  assert(link);
+
+  int master_id = rtnl_link_get_master(link);
+  auto master = nl->get_link(master_id, AF_UNSPEC);
+
+  return remove_lag_member(master, link);
+}
+
 int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   int rv = 0;
   auto it = ifi2lag.find(rtnl_link_get_ifindex(bond));
@@ -274,6 +283,8 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
 }
 
 int nl_bond::update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave) {
+  assert(new_slave);
+
   int rv;
   uint8_t new_state;
   uint8_t old_state;

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <glog/logging.h>
 #include <netlink/route/link.h>
+#include <netlink/route/link/bonding.h>
 
 #include "cnetlink.h"
 #include "nl_output.h"
@@ -30,25 +31,98 @@ uint32_t nl_bond::get_lag_id(rtnl_link *bond) {
     return 0;
   }
 
-  // XXX currently we do not deal with a real lag since we just deal with
-  // a single port in the lag. Thus we just mimic the lag behaviour and map
-  // everything on the linux bond/team to the single physical port
   auto rv_lm = lag_members.find(it->second);
   if (rv_lm == lag_members.end()) {
     VLOG(1) << ": no members in lag " << OBJ_CAST(bond);
     return 0;
   }
 
-  VLOG(3) << __FUNCTION__ << ": found id=" << rv_lm->second;
-  return rv_lm->second;
+  VLOG(3) << __FUNCTION__ << ": found id=" << rv_lm->first;
+  return rv_lm->first;
+}
+
+std::set<uint32_t> nl_bond::get_members(rtnl_link *bond) {
+  auto it = ifi2lag.find(rtnl_link_get_ifindex(bond));
+  if (it == ifi2lag.end()) {
+    LOG(WARNING) << __FUNCTION__ << ": lag does not exist for "
+                 << OBJ_CAST(bond);
+    return {};
+  }
+
+  auto mem_it = lag_members.find(it->second);
+  if (mem_it == lag_members.end()) {
+    LOG(WARNING) << __FUNCTION__ << ": lag does not exist for "
+                 << OBJ_CAST(bond);
+    return {};
+  }
+
+  return mem_it->second;
+}
+
+int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
+  VLOG(1) << __FUNCTION__ << ": updating bond interface ";
+  int rv = 0;
+
+  uint8_t state;
+  uint32_t o_active;
+  uint32_t n_active;
+  uint8_t o_mode;
+  uint8_t n_mode;
+  uint32_t lag_id = nl->get_port_id(new_link);
+
+  rtnl_link_bond_get_active_slave(old_link, &o_active);
+  rtnl_link_bond_get_active_slave(new_link, &n_active);
+
+  if (o_active == 0 || n_active == 0) {
+    VLOG(1) << __FUNCTION__ << ": no active bond slave";
+    return 0;
+  }
+
+  if (o_active != n_active) {
+    rv = swi->lag_set_active_member(lag_id, nl->get_port_id(n_active), 1);
+    if (rv < 0) {
+      VLOG(1) << __FUNCTION__ << ": failed to set active state for "
+              << OBJ_CAST(new_link);
+    }
+
+    rv = swi->lag_set_active_member(lag_id, nl->get_port_id(o_active), 0);
+
+    if (rv < 0) {
+      VLOG(1) << __FUNCTION__ << ": failed to set active state for "
+              << OBJ_CAST(new_link);
+    }
+
+    return 0;
+  }
+
+  rtnl_link_bond_get_mode(old_link, &o_mode);
+  rtnl_link_bond_get_mode(new_link, &n_mode);
+
+  if (o_mode != n_mode) {
+    VLOG(1) << __FUNCTION__ << ": bond mode updated "
+            << static_cast<uint32_t>(n_mode);
+    rv = swi->lag_set_mode(lag_id, n_mode);
+
+    if (rv < 0) {
+      VLOG(1) << __FUNCTION__ << ": failed to set active state for "
+              << OBJ_CAST(new_link);
+    }
+
+    return 0;
+  }
+
+  return 0;
 }
 
 int nl_bond::add_lag(rtnl_link *bond) {
   uint32_t lag_id = 0;
   int rv = 0;
+  uint8_t mode;
+
+  rtnl_link_bond_get_mode(bond, &mode);
 
   assert(bond);
-  rv = swi->lag_create(&lag_id);
+  rv = swi->lag_create(&lag_id, rtnl_link_get_name(bond), mode);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed to create lag for "
                << OBJ_CAST(bond);
@@ -99,6 +173,8 @@ int nl_bond::remove_lag(rtnl_link *bond) {
 int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   int rv = 0;
   uint32_t lag_id;
+  uint8_t state = 0;
+
   auto it = ifi2lag.find(rtnl_link_get_ifindex(bond));
   if (it == ifi2lag.end()) {
     VLOG(1) << __FUNCTION__ << ": no lag_id found creating new for "
@@ -119,13 +195,24 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
     return -EINVAL;
   }
 
-  auto lm_rv = lag_members.emplace(lag_id, port_id);
-  if (!lm_rv.second) {
-    LOG(ERROR) << __FUNCTION__ << ": cannot add multiple ports to a lag";
-    return -EINVAL;
+  auto mem_it = lag_members.find(it->second);
+  if (mem_it == lag_members.end()) { // No ports in lag
+    std::set<uint32_t> members;
+    members.insert(port_id);
+    auto lm_rv = lag_members.emplace(lag_id, members);
+  } else {
+    mem_it->second.insert(port_id);
+  }
+
+  rv = rtnl_link_bond_slave_get_state(link, &state);
+  if (rv < 0) {
+    VLOG(1) << __FUNCTION__ << ": failed to get slave state for "<<  OBJ_CAST(link);
   }
 
   rv = swi->lag_add_member(lag_id, port_id);
+
+  VLOG(1) << " SET ACTIVE MEMBER " << lag_id << " " << port_id << " " << static_cast<uint32_t>(state);
+  rv = swi->lag_set_active_member(lag_id, port_id, state == 0);
 
   if (rtnl_link_get_master(bond)) {
     // check bridge attachement
@@ -166,6 +253,37 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   lag_members.erase(lm_rv);
 
   return rv;
+}
+
+int nl_bond::update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave) {
+  int rv;
+  uint8_t new_state;
+  uint8_t old_state;
+
+  int n_master_id = rtnl_link_get_master(new_slave);
+  int o_master_id = rtnl_link_get_master(old_slave);
+  auto new_master = nl->get_link(n_master_id, AF_UNSPEC);
+  auto old_master = nl->get_link(o_master_id, AF_UNSPEC);
+  auto port_id = nl->get_port_id(new_slave);
+
+  if (old_master != new_master || new_master == 0) {
+    return -EINVAL;
+  }
+
+  rv = rtnl_link_bond_slave_get_state(new_slave, &new_state);
+  if (rv != 0) {
+    VLOG(1) << __FUNCTION__ << ": failed to get state";
+    return -EINVAL;
+  }
+  rtnl_link_bond_slave_get_state(old_slave, &old_state);
+  if (rv != 0) {
+    VLOG(1) << __FUNCTION__ << ": failed to get state";
+    return -EINVAL;
+  }
+
+  rv = swi->lag_set_active_member(nl->get_port_id(new_master), port_id,
+                                  new_state == 0);
+  return 0;
 }
 
 } // namespace basebox

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -60,6 +60,7 @@ std::set<uint32_t> nl_bond::get_members(rtnl_link *bond) {
 }
 
 int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   VLOG(1) << __FUNCTION__ << ": updating bond interface ";
   int rv = 0;
 
@@ -120,6 +121,7 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
 
     return 0;
   }
+#endif
 
   return 0;
 }
@@ -127,6 +129,7 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
 int nl_bond::add_lag(rtnl_link *bond) {
   uint32_t lag_id = 0;
   int rv = 0;
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   uint8_t mode;
 
   rtnl_link_bond_get_mode(bond, &mode);
@@ -153,11 +156,13 @@ int nl_bond::add_lag(rtnl_link *bond) {
     if (lag_id != rv_emp.first->second)
       swi->lag_remove(lag_id);
   }
+#endif
 
   return rv;
 }
 
 int nl_bond::remove_lag(rtnl_link *bond) {
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   int rv = 0;
   auto it = ifi2lag.find(rtnl_link_get_ifindex(bond));
 
@@ -176,12 +181,14 @@ int nl_bond::remove_lag(rtnl_link *bond) {
   }
 
   ifi2lag.erase(it);
+#endif
 
   return 0;
 }
 
 int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   int rv = 0;
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   uint32_t lag_id;
   uint8_t state = 0;
 
@@ -243,6 +250,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   }
 
   // XXX FIXME check for vlan interfaces
+#endif
 
   return rv;
 }
@@ -258,6 +266,7 @@ int nl_bond::remove_lag_member(rtnl_link *link) {
 
 int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   int rv = 0;
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   auto it = ifi2lag.find(rtnl_link_get_ifindex(bond));
   if (it == ifi2lag.end()) {
     LOG(FATAL) << __FUNCTION__ << ": no lag_id found for " << OBJ_CAST(bond);
@@ -278,11 +287,13 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
 
   rv = swi->lag_remove_member(it->second, port_id);
   lag_members.erase(lm_rv);
+#endif
 
   return rv;
 }
 
 int nl_bond::update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave) {
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   assert(new_slave);
 
   int rv;
@@ -312,6 +323,7 @@ int nl_bond::update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave) {
 
   rv = swi->lag_set_member_active(nl->get_port_id(new_master), port_id,
                                   new_state == 0);
+#endif
   return 0;
 }
 

--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -47,6 +47,7 @@ public:
   int remove_lag(rtnl_link *bond);
   int add_lag_member(rtnl_link *bond, rtnl_link *link);
   int remove_lag_member(rtnl_link *bond, rtnl_link *link);
+  int remove_lag_member(rtnl_link *link);
   int update_lag(rtnl_link *old_link, rtnl_link *new_link);
 
   int update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave);

--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -31,6 +31,12 @@ public:
    * @returns id > 0 if found, 0 if not found
    */
   uint32_t get_lag_id(rtnl_link *bond);
+  /**
+   * returns the members of the lag
+   *
+   * @returns id > 0 if found, 0 if not found
+   */
+  std::set<uint32_t> get_members(rtnl_link *bond);
 
   /**
    * create a new lag
@@ -38,17 +44,19 @@ public:
    * @returns <0 on error, lag_id on success
    */
   int add_lag(rtnl_link *bond);
-
   int remove_lag(rtnl_link *bond);
   int add_lag_member(rtnl_link *bond, rtnl_link *link);
   int remove_lag_member(rtnl_link *bond, rtnl_link *link);
+  int update_lag(rtnl_link *old_link, rtnl_link *new_link);
+
+  int update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave);
 
 private:
   switch_interface *swi;
   cnetlink *nl;
 
   std::map<int, uint32_t> ifi2lag;
-  std::map<int, uint32_t> lag_members;
+  std::map<int, std::set<uint32_t>> lag_members;
 };
 
 } // namespace basebox

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -623,7 +623,6 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh) {
 
   nl_addr *mac = rtnl_neigh_get_lladdr(neigh);
   int vlan = rtnl_neigh_get_vlan(neigh);
-  bool lag = nbi::get_port_type(port) == nbi::port_type_lag;
 
   bool permanent = true;
 
@@ -645,7 +644,7 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh) {
             << rtnl_link_get_name(bridge) << " on port=" << port
             << " vlan=" << (unsigned)vlan << ", permanent=" << permanent;
   LOG(INFO) << __FUNCTION__ << ": object: " << OBJ_CAST(neigh);
-  sw->l2_addr_add(port, vlan, _mac, true, permanent, lag);
+  sw->l2_addr_add(port, vlan, _mac, true, permanent);
 }
 
 void nl_bridge::remove_neigh_from_fdb(rtnl_neigh *neigh) {

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -383,9 +383,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
               VLOG(3) << __FUNCTION__ << ": add vid=" << vid
                       << " on pport_no=" << pport_no
                       << " link: " << OBJ_CAST(_link);
-              bool lag = nbi::get_port_type(pport_no) == nbi::port_type_lag;
-              sw->egress_bridge_port_vlan_add(pport_no, vid, egress_untagged,
-                                              lag);
+              sw->egress_bridge_port_vlan_add(pport_no, vid, egress_untagged);
               sw->ingress_port_vlan_add(pport_no, vid,
                                         new_br_vlan->pvid == vid);
             }

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -150,7 +150,6 @@ void nl_bridge::add_interface(rtnl_link *link) {
   // configure bond slaves
   auto members = nl->get_bond_members_by_lag(link);
   for (auto mem : members) {
-    VLOG(1) << " MEMBER ID " << mem;
     auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
     update_vlans(nullptr, _link.get());
   }

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -44,7 +44,12 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged,
   }
 
   // setup egress interface
-  rv = swi->egress_port_vlan_add(port_id, vid, !tagged);
+  auto type = nbi::get_port_type(port_id);
+  if (type == nbi::port_type_lag) {
+    rv = swi->egress_port_vlan_add(port_id, vid, !tagged);
+  } else {
+    rv = swi->egress_port_vlan_add(port_id, vid, !tagged);
+  }
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -44,12 +44,7 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged,
   }
 
   // setup egress interface
-  auto type = nbi::get_port_type(port_id);
-  if (type == nbi::port_type_lag) {
-    rv = swi->egress_port_vlan_add(port_id, vid, !tagged);
-  } else {
-    rv = swi->egress_port_vlan_add(port_id, vid, !tagged);
-  }
+  rv = swi->egress_port_vlan_add(port_id, vid, !tagged);
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -603,6 +603,16 @@ int controller::lag_set_member_active(uint32_t lag_id, uint32_t port_id,
   }
   int rv = 0;
 
+  if(lag_id == 0) {
+    LOG(ERROR) << __FUNCTION__ << ": invalid lag_id";
+    return -EAGAIN;
+  }
+
+  if(port_id == 0) {
+    LOG(ERROR) << __FUNCTION__ << ": invalid port_id";
+    return -EAGAIN;
+  }
+
   rv = ofdpa->OfdpaTrunkPortMemberActiveSet(port_id, lag_id, active);
 
   return rv;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -518,7 +518,6 @@ int controller::lag_create(uint32_t *lag_id, std::string name,
   _lag_id++;
 
   rv = ofdpa->OfdpaTrunkCreate(*lag_id, name, mode);
-  VLOG(1) << " TRUNK CREATE " << rv;
   return rv;
 }
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -499,6 +499,8 @@ int controller::lag_create(uint32_t *lag_id, std::string name,
     return -EAGAIN;
   }
 
+  int rv = 0;
+
   // XXX TODO this needs to be improved, we could use the maximum number of
   // ports as lag_id and have an efficient lookup which id is free. for now
   // 2^16-1 lag ids should be sufficient.
@@ -515,9 +517,8 @@ int controller::lag_create(uint32_t *lag_id, std::string name,
   *lag_id = nbi::combine_port_type(_lag_id, nbi::port_type_lag);
   _lag_id++;
 
-  ofdpa->OfdpaTrunkCreate(*lag_id, name, mode);
-
-  return 0;
+  rv = ofdpa->OfdpaTrunkCreate(*lag_id, name, mode);
+  return rv;
 }
 
 int controller::lag_remove(uint32_t lag_id) noexcept {
@@ -543,6 +544,7 @@ int controller::lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept {
     return -EAGAIN;
   }
 
+  int rv = 0;
   if (nbi::get_port_type(lag_id) != nbi::port_type_lag) {
     LOG(ERROR) << __FUNCTION__ << ": invalid lag_id " << std::showbase
                << std::hex << lag_id;
@@ -558,9 +560,8 @@ int controller::lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept {
 
   it->second.emplace(port_id);
 
-  ofdpa->OfdpaTrunkPortMemberSet(port_id, lag_id);
-
-  return 0;
+  rv = ofdpa->OfdpaTrunkPortMemberSet(port_id, lag_id);
+  return rv;
 }
 
 int controller::lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept {
@@ -599,10 +600,11 @@ int controller::lag_set_member_active(uint32_t lag_id, uint32_t port_id,
     VLOG(1) << __FUNCTION__ << ": not connected";
     return -EAGAIN;
   }
+  int rv = 0;
 
-  ofdpa->OfdpaTrunkPortMemberActiveSet(port_id, lag_id, active);
+  rv = ofdpa->OfdpaTrunkPortMemberActiveSet(port_id, lag_id, active);
 
-  return 0;
+  return rv;
 }
 
 int controller::lag_set_mode(uint32_t lag_id, uint8_t mode) noexcept {
@@ -610,9 +612,10 @@ int controller::lag_set_mode(uint32_t lag_id, uint8_t mode) noexcept {
     VLOG(1) << __FUNCTION__ << ": not connected";
     return -EAGAIN;
   }
+  int rv = 0;
 
-  ofdpa->ofdpaTrunkPortPSCSet(lag_id, mode);
-  return 0;
+  rv = ofdpa->ofdpaTrunkPortPSCSet(lag_id, mode);
+  return rv;
 }
 
 int controller::overlay_tunnel_add(uint32_t tunnel_id) noexcept {
@@ -1625,7 +1628,8 @@ int controller::egress_port_vlan_drop_accept_all(uint32_t port) noexcept {
   return rv;
 }
 
-int controller::egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept {
+int controller::egress_port_vlan_add(uint32_t port, uint16_t vid,
+                                     bool untagged) noexcept {
   int rv = 0;
   try {
     // create filtered egress interface

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -557,7 +557,7 @@ int controller::lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept {
 
   it->second.emplace(port_id);
 
-  rv = ofdpa->OfdpaTrunkPortMemberSet(port_id, lag_id);
+  rv = ofdpa->OfdpaPortTrunkGroupSet(port_id, lag_id);
   return rv;
 }
 
@@ -589,7 +589,7 @@ int controller::lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept {
     return -EINVAL;
   }
 
-  rv = ofdpa->OfdpaTrunkPortMemberSet(port_id, 0);
+  rv = ofdpa->OfdpaPortTrunkGroupSet(port_id, 0);
   return rv;
 }
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -690,10 +690,11 @@ int controller::l2_addr_remove_all_in_vlan(uint32_t port,
 
 int controller::l2_addr_add(uint32_t port, uint16_t vid,
                             const rofl::caddress_ll &mac, bool filtered,
-                            bool permanent, bool lag) noexcept {
+                            bool permanent) noexcept {
   int rv = 0;
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
+    bool lag = nbi::get_port_type(port) == nbi::port_type_lag;
 
     if (!permanent)
       fm_driver.set_idle_timeout(300);
@@ -1643,9 +1644,8 @@ int controller::egress_port_vlan_add(uint32_t port, uint16_t vid,
     // create filtered egress interface
     rofl::crofdpt &dpt = set_dpt(dptid, true);
     rofl::openflow::cofgroupmod gm;
-    bool lag = nbi::get_port_type(port) == nbi::port_type_lag;
 
-    if (lag) {
+    if (nbi::get_port_type(port) == nbi::port_type_lag) {
       gm = fm_driver.enable_group_l2_trunk_interface(dpt.get_version(), port,
                                                      vid, untagged);
     } else {

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -526,16 +526,13 @@ int controller::lag_remove(uint32_t lag_id) noexcept {
     VLOG(1) << __FUNCTION__ << ": not connected";
     return -EAGAIN;
   }
-  // currently we don't have a real lag implementation
-  // otherwise we should release the resoucres on the switch
-
   auto rv = lag.erase(nbi::get_port_num(lag_id));
   if (rv != 1) {
     LOG(WARNING) << __FUNCTION__ << ": rv=" << rv
                  << " entries in lag map were removed";
   }
 
-  return 0;
+  return ofdpa->OfdpaTrunkDelete(lag_id);
 }
 
 int controller::lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept {
@@ -569,6 +566,7 @@ int controller::lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept {
     VLOG(1) << __FUNCTION__ << ": not connected";
     return -EAGAIN;
   }
+  int rv = 0;
 
   if (nbi::get_port_type(lag_id) != nbi::port_type_lag) {
     LOG(ERROR) << __FUNCTION__ << ": invalid lag_id " << std::showbase
@@ -591,7 +589,8 @@ int controller::lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept {
     return -EINVAL;
   }
 
-  return 0;
+  rv = ofdpa->OfdpaTrunkPortMemberSet(port_id, 0);
+  return rv;
 }
 
 int controller::lag_set_member_active(uint32_t lag_id, uint32_t port_id,
@@ -602,18 +601,17 @@ int controller::lag_set_member_active(uint32_t lag_id, uint32_t port_id,
   }
   int rv = 0;
 
-  if(lag_id == 0) {
+  if (lag_id == 0) {
     LOG(ERROR) << __FUNCTION__ << ": invalid lag_id";
-    return -EAGAIN;
+    return -EINVAL;
   }
 
-  if(port_id == 0) {
+  if (port_id == 0) {
     LOG(ERROR) << __FUNCTION__ << ": invalid port_id";
-    return -EAGAIN;
+    return -EINVAL;
   }
 
   rv = ofdpa->OfdpaTrunkPortMemberActiveSet(port_id, lag_id, active);
-
   return rv;
 }
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -518,6 +518,7 @@ int controller::lag_create(uint32_t *lag_id, std::string name,
   _lag_id++;
 
   rv = ofdpa->OfdpaTrunkCreate(*lag_id, name, mode);
+  VLOG(1) << " TRUNK CREATE " << rv;
   return rv;
 }
 

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -242,7 +242,8 @@ public:
   int egress_port_vlan_accept_all(uint32_t port) noexcept override;
   int egress_port_vlan_drop_accept_all(uint32_t port) noexcept override;
 
-  int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept override;
+  int egress_port_vlan_add(uint32_t port, uint16_t vid,
+                           bool untagged) noexcept override;
   int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept override;
 
   int add_l2_overlay_flood(uint32_t tunnel_id,
@@ -250,7 +251,8 @@ public:
   int del_l2_overlay_flood(uint32_t tunnel_id,
                            uint32_t lport_id) noexcept override;
 
-  int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept override;
+  int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,
+                                  bool untagged) noexcept override;
   int egress_bridge_port_vlan_remove(uint32_t port,
                                      uint16_t vid) noexcept override;
   int set_egress_tpid(uint32_t port) noexcept override;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -140,17 +140,22 @@ protected:
 
 public:
   // switch_interface
-  int lag_create(uint32_t *lag_id) noexcept override;
+  int lag_create(uint32_t *lag_id, std::string name,
+                 uint8_t mode) noexcept override;
   int lag_remove(uint32_t lag_id) noexcept override;
   int lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept override;
   int lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept override;
+  int lag_set_active_member(uint32_t lag_id, uint32_t port_id,
+                            uint8_t active) noexcept override;
+  int lag_set_mode(uint32_t lag_id, uint8_t mode) noexcept override;
 
   int overlay_tunnel_add(uint32_t tunnel_id) noexcept override;
   int overlay_tunnel_remove(uint32_t tunnel_id) noexcept override;
 
   int l2_addr_remove_all_in_vlan(uint32_t port, uint16_t vid) noexcept override;
   int l2_addr_add(uint32_t port, uint16_t vid, const rofl::caddress_ll &mac,
-                  bool filtered, bool permanent) noexcept override;
+                  bool filtered, bool permanent,
+                  bool lag = false) noexcept override;
   int l2_addr_remove(uint32_t port, uint16_t vid,
                      const rofl::caddress_ll &mac) noexcept override;
 
@@ -237,8 +242,8 @@ public:
   int egress_port_vlan_accept_all(uint32_t port) noexcept override;
   int egress_port_vlan_drop_accept_all(uint32_t port) noexcept override;
 
-  int egress_port_vlan_add(uint32_t port, uint16_t vid,
-                           bool untagged) noexcept override;
+  int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
+                           bool lag = false) noexcept override;
   int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept override;
 
   int add_l2_overlay_flood(uint32_t tunnel_id,
@@ -246,8 +251,8 @@ public:
   int del_l2_overlay_flood(uint32_t tunnel_id,
                            uint32_t lport_id) noexcept override;
 
-  int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,
-                                  bool untagged) noexcept override;
+  int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
+                                  bool is_lag = false) noexcept override;
   int egress_bridge_port_vlan_remove(uint32_t port,
                                      uint16_t vid) noexcept override;
   int set_egress_tpid(uint32_t port) noexcept override;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -154,8 +154,7 @@ public:
 
   int l2_addr_remove_all_in_vlan(uint32_t port, uint16_t vid) noexcept override;
   int l2_addr_add(uint32_t port, uint16_t vid, const rofl::caddress_ll &mac,
-                  bool filtered, bool permanent,
-                  bool lag = false) noexcept override;
+                  bool filtered, bool permanent) noexcept override;
   int l2_addr_remove(uint32_t port, uint16_t vid,
                      const rofl::caddress_ll &mac) noexcept override;
 

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -145,7 +145,7 @@ public:
   int lag_remove(uint32_t lag_id) noexcept override;
   int lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept override;
   int lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept override;
-  int lag_set_active_member(uint32_t lag_id, uint32_t port_id,
+  int lag_set_member_active(uint32_t lag_id, uint32_t port_id,
                             uint8_t active) noexcept override;
   int lag_set_mode(uint32_t lag_id, uint8_t mode) noexcept override;
 
@@ -242,8 +242,7 @@ public:
   int egress_port_vlan_accept_all(uint32_t port) noexcept override;
   int egress_port_vlan_drop_accept_all(uint32_t port) noexcept override;
 
-  int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
-                           bool lag = false) noexcept override;
+  int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept override;
   int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept override;
 
   int add_l2_overlay_flood(uint32_t tunnel_id,
@@ -251,8 +250,7 @@ public:
   int del_l2_overlay_flood(uint32_t tunnel_id,
                            uint32_t lport_id) noexcept override;
 
-  int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
-                                  bool is_lag = false) noexcept override;
+  int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept override;
   int egress_bridge_port_vlan_remove(uint32_t port,
                                      uint16_t vid) noexcept override;
   int set_egress_tpid(uint32_t port) noexcept override;

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -302,8 +302,7 @@ ofdpa_client::OfdpaTrunkCreate(uint32_t lag_id, std::string name,
 
   request.set_name(name);
   request.set_lag_id(lag_id);
-  request.set_lag_type(
-      (::trunk::Interface_Trunk_Description::LagType)mode);
+  request.set_lag_type((::trunk::Interface_Trunk_Description::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkCreate(&context, request, &response);
   if (not rv.ok()) {
@@ -314,9 +313,17 @@ ofdpa_client::OfdpaTrunkCreate(uint32_t lag_id, std::string name,
 }
 
 ofdpa::OfdpaStatus::OfdpaStatusCode
-ofdpa_client::OfdpaTrunkDelete(uint32_t lag_id, std::string name) {
+ofdpa_client::OfdpaTrunkDelete(uint32_t lag_id) {
   ::OfdpaStatus response;
   ::ClientContext context;
+  ::trunk::Interface_Trunk_Description request;
+
+  request.set_lag_id(lag_id);
+
+  ::Status rv = stub_->ofdpaTrunkDelete(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
 
   return response.status();
 }
@@ -365,8 +372,7 @@ ofdpa_client::ofdpaTrunkPortPSCSet(uint32_t lag_id, uint8_t mode) {
   ::trunk::Interface_Trunk_Description request;
 
   request.set_lag_id(lag_id);
-  request.set_lag_type(
-      (::trunk::Interface_Trunk_Description::LagType)mode);
+  request.set_lag_type((::trunk::Interface_Trunk_Description::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkPortPSCSet(&context, request, &response);
   if (not rv.ok()) {

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -298,12 +298,12 @@ ofdpa_client::OfdpaTrunkCreate(uint32_t lag_id, std::string name,
                                uint8_t mode) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::openconfig_interfaces::Interfaces_Interface request;
+  ::trunk::Interface_Trunk_Description request;
 
   request.set_name(name);
-  request.mutable_aggregation()->mutable_state()->set_lag_id(lag_id);
-  request.mutable_aggregation()->mutable_state()->set_lag_type(
-      (::openconfig_interfaces::Interface_Aggregation_State::LagType)mode);
+  request.set_lag_id(lag_id);
+  request.set_lag_type(
+      (::trunk::Interface_Trunk_Description::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkCreate(&context, request, &response);
   if (not rv.ok()) {
@@ -325,7 +325,7 @@ ofdpa::OfdpaStatus::OfdpaStatusCode
 ofdpa_client::OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::openconfig_interfaces::Interface_Aggregation_State request;
+  ::trunk::Interface_Trunk_Description request;
 
   request.set_lag_id(trunk_id);
   request.set_member(port_id);
@@ -343,7 +343,7 @@ ofdpa_client::OfdpaTrunkPortMemberActiveSet(uint32_t port_id, uint32_t trunk_id,
                                             uint32_t active) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::openconfig_interfaces::Interface_Aggregation_State request;
+  ::trunk::Interface_Trunk_Description request;
 
   request.set_lag_id(trunk_id);
   request.set_member(port_id);
@@ -362,11 +362,11 @@ ofdpa::OfdpaStatus::OfdpaStatusCode
 ofdpa_client::ofdpaTrunkPortPSCSet(uint32_t lag_id, uint8_t mode) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::openconfig_interfaces::Interface_Aggregation_State request;
+  ::trunk::Interface_Trunk_Description request;
 
   request.set_lag_id(lag_id);
   request.set_lag_type(
-      (::openconfig_interfaces::Interface_Aggregation_State::LagType)mode);
+      (::trunk::Interface_Trunk_Description::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkPortPSCSet(&context, request, &response);
   if (not rv.ok()) {

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -293,4 +293,86 @@ ofdpa_client::ofdpaStgStatePortSet(uint32_t port_id, std::string state) {
   return response.status();
 }
 
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::OfdpaTrunkCreate(uint32_t lag_id, std::string name,
+                               uint8_t mode) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::openconfig_interfaces::Interfaces_Interface request;
+
+  request.set_name(name);
+  request.mutable_aggregation()->mutable_state()->set_lag_id(lag_id);
+  request.mutable_aggregation()->mutable_state()->set_lag_type(
+      (::openconfig_interfaces::Interface_Aggregation_State::LagType)mode);
+
+  ::Status rv = stub_->ofdpaTrunkCreate(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::OfdpaTrunkDelete(uint32_t lag_id, std::string name) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::openconfig_interfaces::Interface_Aggregation_State request;
+
+  request.set_lag_id(trunk_id);
+  request.set_member(port_id);
+
+  ::Status rv = stub_->ofdpaTrunkPortMemberSet(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::OfdpaTrunkPortMemberActiveSet(uint32_t port_id, uint32_t trunk_id,
+                                            uint32_t active) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::openconfig_interfaces::Interface_Aggregation_State request;
+
+  request.set_lag_id(trunk_id);
+  request.set_member(port_id);
+  request.set_active(active);
+
+  ::Status rv =
+      stub_->ofdpaTrunkPortMemberActiveSet(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaTrunkPortPSCSet(uint32_t lag_id, uint8_t mode) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::openconfig_interfaces::Interface_Aggregation_State request;
+
+  request.set_lag_id(lag_id);
+  request.set_lag_type(
+      (::openconfig_interfaces::Interface_Aggregation_State::LagType)mode);
+
+  ::Status rv = stub_->ofdpaTrunkPortPSCSet(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+  return response.status();
+}
+
 } // namespace basebox

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -298,11 +298,11 @@ ofdpa_client::OfdpaTrunkCreate(uint32_t lag_id, std::string name,
                                uint8_t mode) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::trunk::Interface_Trunk_Description request;
+  ::TrunkCreate request;
 
   request.set_name(name);
   request.set_lag_id(lag_id);
-  request.set_lag_type((::trunk::Interface_Trunk_Description::LagType)mode);
+  request.set_lag_type((::TrunkCreate::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkCreate(&context, request, &response);
   if (not rv.ok()) {
@@ -332,7 +332,7 @@ ofdpa::OfdpaStatus::OfdpaStatusCode
 ofdpa_client::OfdpaPortTrunkGroupSet(uint32_t port_id, uint32_t trunk_id) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::trunk::Interface_Trunk_Description request;
+  ::TrunkGroupSet request;
 
   request.set_lag_id(trunk_id);
   request.set_member(port_id);
@@ -350,7 +350,7 @@ ofdpa_client::OfdpaTrunkPortMemberActiveSet(uint32_t port_id, uint32_t trunk_id,
                                             uint32_t active) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::trunk::Interface_Trunk_Description request;
+  ::PortMemberActiveSet request;
 
   request.set_lag_id(trunk_id);
   request.set_member(port_id);
@@ -369,10 +369,10 @@ ofdpa::OfdpaStatus::OfdpaStatusCode
 ofdpa_client::ofdpaTrunkPortPSCSet(uint32_t lag_id, uint8_t mode) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::trunk::Interface_Trunk_Description request;
+  ::PSC request;
 
   request.set_lag_id(lag_id);
-  request.set_lag_type((::trunk::Interface_Trunk_Description::LagType)mode);
+  request.set_lag_type((::PSC::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkPortPSCSet(&context, request, &response);
   if (not rv.ok()) {

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -302,7 +302,7 @@ ofdpa_client::OfdpaTrunkCreate(uint32_t lag_id, std::string name,
 
   request.set_name(name);
   request.set_lag_id(lag_id);
-  request.set_lag_type((::TrunkCreate::LagType)mode);
+  request.set_lag_type((::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkCreate(&context, request, &response);
   if (not rv.ok()) {
@@ -372,7 +372,7 @@ ofdpa_client::ofdpaTrunkPortPSCSet(uint32_t lag_id, uint8_t mode) {
   ::PSC request;
 
   request.set_lag_id(lag_id);
-  request.set_lag_type((::PSC::LagType)mode);
+  request.set_lag_type((::LagType)mode);
 
   ::Status rv = stub_->ofdpaTrunkPortPSCSet(&context, request, &response);
   if (not rv.ok()) {

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -316,9 +316,9 @@ ofdpa::OfdpaStatus::OfdpaStatusCode
 ofdpa_client::OfdpaTrunkDelete(uint32_t lag_id) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::trunk::Interface_Trunk_Description request;
+  ::PortNum request;
 
-  request.set_lag_id(lag_id);
+  request.set_port_num(lag_id);
 
   ::Status rv = stub_->ofdpaTrunkDelete(&context, request, &response);
   if (not rv.ok()) {
@@ -329,7 +329,7 @@ ofdpa_client::OfdpaTrunkDelete(uint32_t lag_id) {
 }
 
 ofdpa::OfdpaStatus::OfdpaStatusCode
-ofdpa_client::OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id) {
+ofdpa_client::OfdpaPortTrunkGroupSet(uint32_t port_id, uint32_t trunk_id) {
   ::OfdpaStatus response;
   ::ClientContext context;
   ::trunk::Interface_Trunk_Description request;
@@ -337,7 +337,7 @@ ofdpa_client::OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id) {
   request.set_lag_id(trunk_id);
   request.set_member(port_id);
 
-  ::Status rv = stub_->ofdpaTrunkPortMemberSet(&context, request, &response);
+  ::Status rv = stub_->ofdpaPortTrunkGroupSet(&context, request, &response);
   if (not rv.ok()) {
     return ofdpa::OfdpaStatus::OFDPA_E_RPC;
   }

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -8,7 +8,7 @@
 
 #include "api/ofdpa.grpc.pb.h"
 #include "stp/openconfig-spanning-tree.pb.h"
-#include "common/openconfig-interfaces.pb.h"
+#include "trunk/trunk-interfaces.pb.h"
 
 using grpc::Channel;
 

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -8,6 +8,7 @@
 
 #include "api/ofdpa.grpc.pb.h"
 #include "stp/openconfig-spanning-tree.pb.h"
+#include "common/openconfig-interfaces.pb.h"
 
 using grpc::Channel;
 
@@ -65,6 +66,20 @@ public:
 
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgStatePortSet(uint32_t port_id,
                                                            std::string state);
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  OfdpaTrunkCreate(uint32_t lag_id, std::string name, uint8_t mode);
+  ofdpa::OfdpaStatus::OfdpaStatusCode OfdpaTrunkDelete(uint32_t lag_id,
+                                                       std::string name);
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id);
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  OfdpaTrunkPortMemberActiveSet(uint32_t port_id, uint32_t trunk_id,
+                                uint32_t active);
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaTrunkPortPSCSet(uint32_t lag_id,
+                                                           uint8_t mode);
 
 private:
   ofdpa::OfdpaStatus::OfdpaStatusCode

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -72,7 +72,7 @@ public:
   ofdpa::OfdpaStatus::OfdpaStatusCode OfdpaTrunkDelete(uint32_t lag_id);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
-  OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id);
+  OfdpaPortTrunkGroupSet(uint32_t port_id, uint32_t trunk_id);
   ofdpa::OfdpaStatus::OfdpaStatusCode
   OfdpaTrunkPortMemberActiveSet(uint32_t port_id, uint32_t trunk_id,
                                 uint32_t active);

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -8,7 +8,6 @@
 
 #include "api/ofdpa.grpc.pb.h"
 #include "stp/openconfig-spanning-tree.pb.h"
-#include "trunk/trunk-interfaces.pb.h"
 
 using grpc::Channel;
 
@@ -71,8 +70,8 @@ public:
   OfdpaTrunkCreate(uint32_t lag_id, std::string name, uint8_t mode);
   ofdpa::OfdpaStatus::OfdpaStatusCode OfdpaTrunkDelete(uint32_t lag_id);
 
-  ofdpa::OfdpaStatus::OfdpaStatusCode
-  OfdpaPortTrunkGroupSet(uint32_t port_id, uint32_t trunk_id);
+  ofdpa::OfdpaStatus::OfdpaStatusCode OfdpaPortTrunkGroupSet(uint32_t port_id,
+                                                             uint32_t trunk_id);
   ofdpa::OfdpaStatus::OfdpaStatusCode
   OfdpaTrunkPortMemberActiveSet(uint32_t port_id, uint32_t trunk_id,
                                 uint32_t active);

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -69,8 +69,7 @@ public:
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   OfdpaTrunkCreate(uint32_t lag_id, std::string name, uint8_t mode);
-  ofdpa::OfdpaStatus::OfdpaStatusCode OfdpaTrunkDelete(uint32_t lag_id,
-                                                       std::string name);
+  ofdpa::OfdpaStatus::OfdpaStatusCode OfdpaTrunkDelete(uint32_t lag_id);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   OfdpaTrunkPortMemberSet(uint32_t port_id, uint32_t trunk_id);

--- a/src/sai.h
+++ b/src/sai.h
@@ -41,7 +41,7 @@ public:
   virtual int lag_remove(uint32_t lag_id) noexcept = 0;
   virtual int lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept = 0;
   virtual int lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept = 0;
-  virtual int lag_set_active_member(uint32_t lag_id, uint32_t port_id,
+  virtual int lag_set_member_active(uint32_t lag_id, uint32_t port_id,
                                     uint8_t active) noexcept = 0;
   virtual int lag_set_mode(uint32_t lag_id, uint8_t mode) noexcept = 0;
   /* @} */
@@ -158,13 +158,11 @@ public:
   virtual int egress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int egress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;
 
-  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
-                                   bool lag = false) noexcept = 0;
+  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept = 0;
   virtual int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept = 0;
 
   virtual int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,
-                                          bool untagged,
-                                          bool lag = false) noexcept = 0;
+                                          bool untagged) noexcept = 0;
   virtual int egress_bridge_port_vlan_remove(uint32_t port,
                                              uint16_t vid) noexcept = 0;
   /* @} */

--- a/src/sai.h
+++ b/src/sai.h
@@ -36,10 +36,14 @@ public:
   } sai_port_stat_t;
 
   /* @ LAG { */
-  virtual int lag_create(uint32_t *lag_id) noexcept = 0;
+  virtual int lag_create(uint32_t *lag_id, std::string name,
+                         uint8_t mode) noexcept = 0;
   virtual int lag_remove(uint32_t lag_id) noexcept = 0;
   virtual int lag_add_member(uint32_t lag_id, uint32_t port_id) noexcept = 0;
   virtual int lag_remove_member(uint32_t lag_id, uint32_t port_id) noexcept = 0;
+  virtual int lag_set_active_member(uint32_t lag_id, uint32_t port_id,
+                                    uint8_t active) noexcept = 0;
+  virtual int lag_set_mode(uint32_t lag_id, uint8_t mode) noexcept = 0;
   /* @} */
 
   /* @ tunnel overlay { */
@@ -52,7 +56,7 @@ public:
                                          uint16_t vid) noexcept = 0;
   virtual int l2_addr_add(uint32_t port, uint16_t vid,
                           const rofl::caddress_ll &mac, bool filtered,
-                          bool permanent) noexcept = 0;
+                          bool permanent, bool lag) noexcept = 0;
   virtual int l2_addr_remove(uint32_t port, uint16_t vid,
                              const rofl::caddress_ll &mac) noexcept = 0;
 
@@ -154,12 +158,13 @@ public:
   virtual int egress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int egress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;
 
-  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid,
-                                   bool untagged) noexcept = 0;
+  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
+                                   bool lag = false) noexcept = 0;
   virtual int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept = 0;
 
   virtual int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,
-                                          bool untagged) noexcept = 0;
+                                          bool untagged,
+                                          bool lag = false) noexcept = 0;
   virtual int egress_bridge_port_vlan_remove(uint32_t port,
                                              uint16_t vid) noexcept = 0;
   /* @} */

--- a/src/sai.h
+++ b/src/sai.h
@@ -158,7 +158,8 @@ public:
   virtual int egress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int egress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;
 
-  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged) noexcept = 0;
+  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid,
+                                   bool untagged) noexcept = 0;
   virtual int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept = 0;
 
   virtual int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,

--- a/src/sai.h
+++ b/src/sai.h
@@ -56,7 +56,7 @@ public:
                                          uint16_t vid) noexcept = 0;
   virtual int l2_addr_add(uint32_t port, uint16_t vid,
                           const rofl::caddress_ll &mac, bool filtered,
-                          bool permanent, bool lag) noexcept = 0;
+                          bool permanent) noexcept = 0;
   virtual int l2_addr_remove(uint32_t port, uint16_t vid,
                              const rofl::caddress_ll &mac) noexcept = 0;
 


### PR DESCRIPTION
## Description
The current bonding support in baseboxd does not implement the correct calls to the OF-DPA environment. This PR adds the necessary calls to the switch so that trunk ports can be handled in ASIC.

This PR adds as well the necessary changes to baseboxd to support enslaving bond interfaces to VLAN aware bridges.

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
