### PR TITLE
make multicast support optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,10 @@ if not libnl.found()
   libnl = cppc.find_library('libnl-3')
 endif
 
+if cppc.has_header('netlink/route/mdb.h', dependencies: libnl, required: false)
+  add_global_arguments('-DHAVE_NETLINK_ROUTE_MDB_H',  language: 'cpp')
+endif
+
 if cppc.has_header_symbol('netlink/route/link/bonding.h', 'rtnl_link_bond_get_mode', dependencies: libnl, required: false)
   add_global_arguments('-DHAVE_RTNL_LINK_BOND_GET_MODE',  language: 'cpp')
 endif

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -18,7 +18,9 @@
 #include <netlink/route/link/bonding.h>
 #include <netlink/route/link/vlan.h>
 #include <netlink/route/link/vxlan.h>
+#ifdef HAVE_NETLINK_ROUTE_MDB_H
 #include <netlink/route/mdb.h>
+#endif
 #include <netlink/route/neighbour.h>
 #include <netlink/route/route.h>
 #include <systemd/sd-daemon.h>
@@ -159,6 +161,7 @@ void cnetlink::init_caches() {
     LOG(FATAL) << __FUNCTION__ << ": add route/neigh to cache mngr";
   }
 
+#ifdef HAVE_NETLINK_ROUTE_MDB_H
   /* init mdb cache */
   rc = rtnl_mdb_alloc_cache_flags(sock_mon, &caches[NL_MDB_CACHE],
                                   NL_CACHE_AF_ITER);
@@ -172,6 +175,7 @@ void cnetlink::init_caches() {
     LOG(FATAL) << __FUNCTION__
                << ": nl_cache_mngr_add_cache_v2: add route/mdb to cache mngr";
   }
+#endif
 
   try {
     thread.add_read_fd(this, nl_cache_mngr_get_fd(mngr), true, false);
@@ -450,10 +454,12 @@ void cnetlink::handle_wakeup(rofl::cthread &thread) {
     case RTM_DELADDR:
       route_addr_apply(obj);
       break;
+#ifdef HAVE_NETLINK_ROUTE_MDB_H
     case RTM_NEWMDB:
     case RTM_DELMDB:
       route_mdb_apply(obj);
       break;
+#endif
     default:
       LOG(ERROR) << __FUNCTION__ << ": unexpected netlink type "
                  << obj.get_msg_type();

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -836,6 +836,7 @@ void nl_bridge::clear_tpid_entries() {
 
 int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
   int rv = 0;
+#ifdef HAVE_NETLINK_ROUTE_MDB_H
   std::deque<struct rtnl_mdb_entry *> mdb;
   uint32_t bridge = rtnl_mdb_get_ifindex(mdb_entry);
 
@@ -920,12 +921,14 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
     VLOG(2) << __FUNCTION__ << ": mdb entry added, port" << port_id
             << " grp= " << addr;
   }
+#endif
 
   return rv;
 }
 
 int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
   int rv = 0;
+#ifdef HAVE_NETLINK_ROUTE_MDB_H
   uint32_t bridge = rtnl_mdb_get_ifindex(mdb_entry);
 
   if (!is_bridge_interface(nl->get_link_by_ifindex(bridge).get())) {
@@ -1007,6 +1010,7 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
     VLOG(2) << __FUNCTION__ << ": mdb entry removed, port" << port_id
             << " grp= " << addr;
   }
+#endif
 
   return rv;
 }


### PR DESCRIPTION
## Description

Instead of requiring a patches libnl, detect multicast support and only
enable the code for it when found.

## Motivation and Context

Our multicast pull request has not been merged yet, and even if it does it will take a while until updated libnl versions will trickle down to distributions. To make it easier to build and test baseboxd with a system libnl, make the multicast functionality optional and dependent on libnl mdb support present.

## How Has This Been Tested?

Build baseboxd with a patched libnl, checked that it references in rtnl_mdb_* symbols.

Build baseboxd without a patched libnl, checked that it does not reference rtnl_mdb_* symbols.