### PR TITLE
Add Support for l3 Addresses on trunk interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -321,6 +321,28 @@ std::set<uint32_t> cnetlink::get_bond_members_by_lag(rtnl_link *bond_link) {
   return bond->get_members(bond_link);
 }
 
+int cnetlink::get_l3_addrs(struct rtnl_link *link,
+                           std::deque<rtnl_addr *> *addresses) {
+  return l3->get_l3_addrs(link, addresses);
+}
+
+int cnetlink::add_l3_addr(struct rtnl_addr *a) {
+  switch (rtnl_addr_get_family(a)) {
+  case AF_INET:
+    return l3->add_l3_addr(a);
+  case AF_INET6:
+    return l3->add_l3_addr_v6(a);
+  default:
+    LOG(ERROR) << __FUNCTION__
+               << ": unsupported family=" << rtnl_addr_get_family(a)
+               << " for address=" << OBJ_CAST(a);
+    break;
+  }
+  return -EINVAL;
+}
+
+int cnetlink::del_l3_addr(struct rtnl_addr *a) { return l3->del_l3_addr(a); }
+
 struct rtnl_neigh *cnetlink::get_neighbour(int ifindex,
                                            struct nl_addr *a) const {
   assert(ifindex);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -54,6 +54,10 @@ public:
    */
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
+  int get_l3_addrs(struct rtnl_link *link, std::deque<rtnl_addr *> *addresses);
+  int add_l3_addr(struct rtnl_addr *a);
+  int del_l3_addr(struct rtnl_addr *a);
+
   bool is_bridge_interface(rtnl_link *l) const;
   bool is_bridge_interface(int ifindex) const;
   bool is_bridge_configured(rtnl_link *l);

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -131,7 +131,6 @@ int nl_bond::add_lag(rtnl_link *bond) {
       swi->lag_remove(lag_id);
   }
 
-  add_l3_address(bond);
 #endif
 
   return rv;
@@ -258,6 +257,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   }
 
   // XXX FIXME check for vlan interfaces
+  add_l3_address(bond);
 #endif
 
   return rv;

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -257,6 +257,11 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   }
 
   // XXX FIXME check for vlan interfaces
+  // Adding an IP address here will ensure that every slave that is
+  // added will retry to add the address. It will not be written to the
+  // ASIC, but repeated messages will be seen
+  // This should be done in ::add_lag, but for currently unknown reasons
+  // this fails when the lag has no members yet. So keep it here for now.
   add_l3_address(bond);
 #endif
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -68,6 +68,14 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
   uint8_t o_mode, n_mode;
   uint32_t lag_id = nl->get_port_id(new_link);
 
+  if (lag_id == 0) {
+    rv = add_lag(new_link);
+    if (rv < 0)
+      return rv;
+
+    lag_id = rv;
+  }
+
   rv = rtnl_link_bond_get_mode(old_link, &o_mode);
   if (rv < 0) {
     VLOG(1) << __FUNCTION__ << ": failed to get mode for "
@@ -92,6 +100,8 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
 
     return 0;
   }
+
+  add_l3_address(new_link);
 #endif
 
   return 0;
@@ -127,6 +137,8 @@ int nl_bond::add_lag(rtnl_link *bond) {
     if (lag_id != rv_emp.first->second)
       swi->lag_remove(lag_id);
   }
+
+  add_l3_address(bond);
 #endif
 
   return rv;
@@ -303,6 +315,11 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
                  << OBJ_CAST(link);
   }
 
+  if (lm_rv->second.empty())
+    remove_l3_address(bond);
+
+  if (nl->is_bridge_interface(bond))
+    swi->ofdpa_stg_state_port_set(port_id, "forward");
 #endif
 
   return rv;
@@ -341,6 +358,48 @@ int nl_bond::update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave) {
                                   new_state == 0);
 #endif
   return 0;
+}
+
+int nl_bond::add_l3_address(rtnl_link *link) {
+  int rv = 0;
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
+  assert(link);
+
+  std::deque<rtnl_addr *> addresses;
+  nl->get_l3_addrs(link, &addresses);
+
+  for (auto i : addresses) {
+    LOG(INFO) << __FUNCTION__ << ": adding address=" << OBJ_CAST(i);
+
+    rv = nl->add_l3_addr(i);
+    if (rv < 0)
+      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 address " << OBJ_CAST(i)
+                 << " to " << OBJ_CAST(link);
+  }
+  LOG(INFO) << __FUNCTION__ << ": added l3 addresses to bond "
+            << OBJ_CAST(link);
+
+#endif
+  return rv;
+}
+
+int nl_bond::remove_l3_address(rtnl_link *link) {
+  int rv = 0;
+#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
+  assert(link);
+
+  std::deque<rtnl_addr *> addresses;
+  nl->get_l3_addrs(link, &addresses);
+
+  for (auto i : addresses) {
+    rv = nl->del_l3_addr(i);
+    if (rv < 0)
+      LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 address from "
+                 << OBJ_CAST(link);
+  }
+
+#endif
+  return rv;
 }
 
 } // namespace basebox

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -32,14 +32,7 @@ uint32_t nl_bond::get_lag_id(rtnl_link *bond) {
     return 0;
   }
 
-  auto rv_lm = lag_members.find(it->second);
-  if (rv_lm == lag_members.end()) {
-    VLOG(1) << ": no members in lag " << OBJ_CAST(bond);
-    return 0;
-  }
-
-  VLOG(3) << __FUNCTION__ << ": found id=" << rv_lm->first;
-  return rv_lm->first;
+  return it->second;
 }
 
 std::set<uint32_t> nl_bond::get_members(rtnl_link *bond) {

--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -50,6 +50,9 @@ public:
   int remove_lag_member(rtnl_link *link);
   int update_lag(rtnl_link *old_link, rtnl_link *new_link);
 
+  int add_l3_address(rtnl_link *link);
+  int remove_l3_address(rtnl_link *link);
+
   int update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave);
 
 private:

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -48,6 +48,8 @@ public:
   int update_l3_neigh(struct rtnl_neigh *n_old, struct rtnl_neigh *n_new);
   int del_l3_neigh(struct rtnl_neigh *n);
 
+  int get_l3_addrs(struct rtnl_link *link, std::deque<rtnl_addr *> *addresses);
+
   int add_l3_route(struct rtnl_route *r);
   int update_l3_route(struct rtnl_route *r_old, struct rtnl_route *r_new);
   int del_l3_route(struct rtnl_route *r);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1086,11 +1086,14 @@ int controller::l3_egress_create(uint32_t port, uint16_t vid,
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
     // TODO unfiltered interface
-    dpt.send_group_mod_message(
-        rofl::cauxid(0),
-        fm_driver.enable_group_l3_unicast(
-            dpt.get_version(), _egress_interface_id, src_mac, dst_mac,
-            fm_driver.group_id_l2_interface(port, vid), false));
+    uint32_t group_id = (nbi::get_port_type(port) == nbi::port_type_lag)
+                            ? fm_driver.group_id_l2_trunk_interface(port, vid)
+                            : fm_driver.group_id_l2_interface(port, vid);
+
+    dpt.send_group_mod_message(rofl::cauxid(0),
+                               fm_driver.enable_group_l3_unicast(
+                                   dpt.get_version(), _egress_interface_id,
+                                   src_mac, dst_mac, group_id, false));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1121,11 +1124,15 @@ int controller::l3_egress_update(uint32_t port, uint16_t vid,
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
     // TODO unfiltered interface
+
+    uint32_t group_id = (nbi::get_port_type(port) == nbi::port_type_lag)
+                            ? fm_driver.group_id_l2_trunk_interface(port, vid)
+                            : fm_driver.group_id_l2_interface(port, vid);
+
     dpt.send_group_mod_message(
         rofl::cauxid(0),
-        fm_driver.enable_group_l3_unicast(
-            dpt.get_version(), *l3_interface_id, src_mac, dst_mac,
-            fm_driver.group_id_l2_interface(port, vid), true));
+        fm_driver.enable_group_l3_unicast(dpt.get_version(), *l3_interface_id,
+                                          src_mac, dst_mac, group_id, true));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR aims to expand trunking support, allowing users to set l3 addresses on bond interfaces. Code added expands functionality in nl_bond class.

## Motivation and Context

Bonded interfaces also have support for IP addresses. Adding support to further L3 features, like routing daemons, requires that baseboxd correctly receives the bonding notifications, and translates this info to the switch.
 
## How Has This Been Tested?
Compiled with https://github.com/bisdn/rofl-ofdpa/pull/107.
Tests run:
  - bgp-ipv4-lacp
  - bgp-ipv4-active-backup
  - bgp-ipv6-lacp
  - bgp-ipv6-active-backup
  - ospf-ipv4-lacp
  - ospf-ipv4-active-backup
  - ospf-ipv6-lacp
  - ospf-ipv6-active-backup
  - eigrp-ipv4-lacp
  - eigrp-ipv4-active-backup
  - rip-ipv4-lacp
  - rip-ipv4-active-backup