### PR TITLE
nl_l3: fix vrf on bonds

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1729,12 +1729,23 @@ void nl_l3::vrf_attach(rtnl_link *old_link, rtnl_link *new_link) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->remove_ingress_vlan(nl->get_port_id(link.get()), vid, true);
+
+    auto members = nl->get_bond_members_by_lag(link.get());
+    for (auto mem : members) {
+      vlan->remove_ingress_vlan(mem, vid, true);
+    }
   }
 
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->add_vlan(link.get(), vid, true, vrf_id);
+
+    auto members = nl->get_bond_members_by_lag(link.get());
+    for (auto mem : members) {
+      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
+      vlan->add_vlan(_link.get(), vid, true, vrf_id);
+    }
   }
 }
 
@@ -1754,12 +1765,23 @@ void nl_l3::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->remove_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf_id);
+
+    auto members = nl->get_bond_members_by_lag(link.get());
+    for (auto mem : members) {
+      vlan->remove_ingress_vlan(mem, vid, true, vrf_id);
+    }
   }
 
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->add_vlan(link.get(), vid, true);
+
+    auto members = nl->get_bond_members_by_lag(link.get());
+    for (auto mem : members) {
+      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
+      vlan->add_vlan(_link.get(), vid, true);
+    }
   }
 }
 


### PR DESCRIPTION
Since we add vlan entries for all bond slaves, we also need to make sure
their vlan entries have the same vrf action.

Fixes (un)setting vrf for bond interfaces.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>