### PR TITLE
implement stp for bond interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -379,6 +379,12 @@ int cnetlink::get_port_id(rtnl_link *l) const {
     return 0;
   }
 
+  // resolve any br_link interfaces to their bridged interfaces
+  l = get_link(rtnl_link_get_ifindex(l), AF_UNSPEC);
+  if (l == nullptr) {
+    return 0;
+  }
+
   if (rtnl_link_is_vlan(l)) {
     ifindex = rtnl_link_get_link(l);
     // XXX FIXME vlan interface on bond not handled


### PR DESCRIPTION
Implement STP state support for bonded interfaces by passing on the state to the bonded interfaces.

## Description

The switch ASIC only supports setting STP state for physical ports, so we need to make sure that we propagate any STP state changes to the bonded interfaces. This also fixes an issue in get_port_id() that wasn't working with bridge interfaces for bond interfaces, only ones for tap interfaces.

## Motivation and Context

STP is essential in many use cases.

## How Has This Been Tested?

Ran a pipeline with the changes applied on the ag5648s.