### PR TITLE
Add support for QnQ bridging with bond slave interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1285,6 +1285,22 @@ bool cnetlink::is_bridge_configured(rtnl_link *l) {
   return bridge->is_bridge_interface(l);
 }
 
+int cnetlink::set_bridge_port_vlan_tpid(rtnl_link *l) {
+  if (!bridge) {
+    return -EINVAL;
+  }
+
+  return bridge->set_vlan_proto(l);
+}
+
+int cnetlink::unset_bridge_port_vlan_tpid(rtnl_link *l) {
+  if (!bridge) {
+    return -EINVAL;
+  }
+
+  return bridge->delete_vlan_proto(l);
+}
+
 std::deque<rtnl_neigh *> cnetlink::search_fdb(uint16_t vid, nl_addr *lladdr) {
   std::deque<rtnl_link *> br_ports;
   get_bridge_ports(bridge->get_ifindex(), &br_ports);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -57,6 +57,8 @@ public:
   bool is_bridge_interface(rtnl_link *l) const;
   bool is_bridge_interface(int ifindex) const;
   bool is_bridge_configured(rtnl_link *l);
+  int set_bridge_port_vlan_tpid(rtnl_link *l);
+  int unset_bridge_port_vlan_tpid(rtnl_link *l);
   int get_port_id(rtnl_link *l) const;
   int get_port_id(int ifindex) const;
   int get_ifindex_by_port_id(uint32_t port_id) const;

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -872,7 +872,14 @@ void nl_bridge::clear_tpid_entries() {
   nl->get_bridge_ports(rtnl_link_get_ifindex(bridge), &bridge_ports);
 
   for (auto iface : bridge_ports)
-    sw->delete_egress_tpid(nl->get_port_id(iface));
+    if (auto port_id = nl->get_port_id(iface);
+        nbi::get_port_type(port_id) == nbi::port_type_lag) {
+      auto members = nl->get_bond_members_by_lag(iface);
+      for (auto i : members)
+        sw->delete_egress_tpid(i);
+    } else {
+      sw->delete_egress_tpid(port_id);
+    }
 }
 
 int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -151,11 +151,12 @@ void nl_bridge::add_interface(rtnl_link *link) {
   if (get_vlan_proto() == ETH_P_8021AD) {
     if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
       auto members = nl->get_bond_members_by_lag(link);
-      for (auto i : members)
-        sw->set_egress_tpid(i);
+      for (auto mem : members)
+        sw->set_egress_tpid(mem);
 
-    } else
+    } else {
       sw->set_egress_tpid(port_id);
+    }
   }
 }
 
@@ -241,11 +242,12 @@ void nl_bridge::delete_interface(rtnl_link *link) {
   if (get_vlan_proto() == ETH_P_8021AD) {
     if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
       auto members = nl->get_bond_members_by_lag(link);
-      for (auto i : members)
-        sw->delete_egress_tpid(i);
+      for (auto mem : members)
+        sw->delete_egress_tpid(mem);
 
-    } else
+    } else {
       sw->delete_egress_tpid(port_id);
+    }
   }
 
   // interface default is to STP state forward by default

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -62,6 +62,8 @@ public:
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
 
   uint32_t get_vlan_proto();
+  int set_vlan_proto(rtnl_link *link);
+  int delete_vlan_proto(rtnl_link *link);
   uint32_t get_vlan_filtering();
 
   void clear_tpid_entries();


### PR DESCRIPTION
## Description

This PR aims to add support for QnQ bridging with a bonded interface as a bridge slave. In OFDPA, we have to enable the physical bond slaves to output with QnQ packets. 

## Motivation and Context
Adding a bond interface to a bridge configured with `vlan_protocol 802.3ad` requires that the physical bond_slaves are configured in table 235 (Egress TPID). See https://github.com/bisdn/basebox/pull/230.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
