### PR TITLE
Fix lookup of L3 egress entries for SVIs

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1303,42 +1303,6 @@ void nl_l3::notify_on_nh_resolved(struct net_params p) noexcept {
   net_resolved_callbacks.emplace_back(p);
 }
 
-int nl_l3::get_l3_interface_id(rtnl_neigh *n, uint32_t *l3_interface_id,
-                               uint32_t vid) {
-  assert(l3_interface_id);
-
-  struct nl_addr *d_mac = rtnl_neigh_get_lladdr(n);
-  int ifindex = rtnl_neigh_get_ifindex(n);
-  auto link = nl->get_link_by_ifindex(ifindex);
-
-  if (link == nullptr)
-    return -EINVAL;
-
-  if (!vid)
-    vid = vlan->get_vid(link.get());
-  auto s_mac = rtnl_link_get_addr(link.get());
-  uint32_t port_id = nl->get_port_id(ifindex);
-  rofl::caddress_ll src_mac = libnl_lladdr_2_rofl(s_mac);
-  rofl::caddress_ll dst_mac = libnl_lladdr_2_rofl(d_mac);
-  auto needle = std::make_tuple(port_id, vid, src_mac, dst_mac);
-
-  auto it = l3_interface_mapping.equal_range(needle);
-
-  if (it.first == l3_interface_mapping.end()) {
-    return -ENODATA;
-  }
-
-  for (auto i = it.first; i != it.second; ++i) {
-    if (i->first == needle) {
-      *l3_interface_id = i->second.l3_interface_id;
-      return 0;
-    }
-  }
-
-  // not found either
-  return -ENODATA;
-}
-
 int nl_l3::get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
                                const struct nl_addr *d_mac,
                                uint32_t *l3_interface_id, uint16_t vid) {

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1336,7 +1336,7 @@ int nl_l3::get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
     if (i->first == needle) {
       *l3_interface_id = i->second.l3_interface_id;
 
-      LOG(INFO) << __FUNCTION__ << ": l3_interface_id " << *l3_interface_id
+      VLOG(2) << __FUNCTION__ << ": l3_interface_id " << *l3_interface_id
                 << " found for port " << port_id << ", src_mac " << src_mac
                 << ", dst_mac " << dst_mac << ", vid " << vid;
       return 0;

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -69,8 +69,6 @@ public:
   void notify_on_nh_resolved(struct net_params p) noexcept;
 
 private:
-  int get_l3_interface_id(rtnl_neigh *n, uint32_t *l3_interface_id,
-                          uint32_t vid = 0);
   int get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
                           const struct nl_addr *d_mac,
                           uint32_t *l3_interface_id, uint16_t vid = 0);

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -71,6 +71,9 @@ public:
 private:
   int get_l3_interface_id(rtnl_neigh *n, uint32_t *l3_interface_id,
                           uint32_t vid = 0);
+  int get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
+                          const struct nl_addr *d_mac,
+                          uint32_t *l3_interface_id, uint16_t vid = 0);
 
   int add_l3_termination(uint32_t port_id, uint16_t vid,
                          const rofl::caddress_ll &mac, int af) noexcept;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR aims to fix the creation of the key tuple used to identify L3 egress group entries added to a SVI. Instead of using both source and destination MAC addresses from the L2 neighbor, we now get these values from the SVI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding a route via a next-hop IP located in a SVI results in the corresponding table 30 routing entry being sent to the controller, due to the key used to lookup the corresponding l3 egress group not being created correctly. Fixes https://github.com/bisdn/basebox/issues/275

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See https://github.com/bisdn/basebox/issues/275 for a testing use case. With this PR, the routing entries are sent to the next-hop L3 egress group (and not to the controller)
