### PR TITLE
Handle l3 interface id on bonds

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -258,11 +258,6 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
       bool tagged = !!rtnl_link_is_vlan(link);
 
       rv = vlan->add_vlan(_link.get(), vid, tagged, vrf_id);
-
-      auto addr = rtnl_link_get_addr(_link.get());
-      rofl::caddress_ll mac = libnl_lladdr_2_rofl(addr);
-
-      rv = add_l3_termination(mem, vid, mac, AF_INET);
     }
   }
 
@@ -353,6 +348,18 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed to add vlan id " << vid
                  << " (tagged=" << tagged << " to link " << OBJ_CAST(link);
+    }
+  }
+
+  if (auto members = nl->get_bond_members_by_lag(link); !members.empty()) {
+    VLOG(2) << __FUNCTION__ << ": configuring VLAN entry for bond slave "
+            << link;
+
+    for (auto mem : members) {
+      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
+      bool tagged = !!rtnl_link_is_vlan(link);
+
+      rv = vlan->add_vlan(_link.get(), vid, tagged);
     }
   }
 
@@ -483,6 +490,24 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
   }
 
   return rv;
+}
+
+int nl_l3::get_l3_addrs(struct rtnl_link *link,
+                        std::deque<rtnl_addr *> *addresses) {
+  std::unique_ptr<rtnl_addr, decltype(&rtnl_addr_put)> filter(rtnl_addr_alloc(),
+                                                              rtnl_addr_put);
+
+  rtnl_addr_set_ifindex(filter.get(), rtnl_link_get_ifindex(link));
+  rtnl_addr_set_family(filter.get(), AF_UNSPEC);
+
+  nl_cache_foreach_filter(
+      nl->get_cache(cnetlink::NL_ADDR_CACHE), OBJ_CAST(filter.get()),
+      [](struct nl_object *o, void *arg) {
+        auto *addr = (std::deque<rtnl_addr *> *)arg;
+        addr->push_back(ADDR_CAST(o));
+      },
+      addresses);
+  return 0;
 }
 
 int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
@@ -1211,6 +1236,7 @@ void nl_l3::get_nexthops_of_route(
   // verify next hop
   for (auto nh : _nhs) {
     auto ifindex = rtnl_route_nh_get_ifindex(nh);
+    auto addr = rtnl_route_nh_get_gateway(nh);
     uint16_t pport_id = nl->get_port_id(ifindex);
     auto link = nl->get_link_by_ifindex(ifindex);
 
@@ -1253,6 +1279,9 @@ int nl_l3::get_neighbours_of_route(
 
     if (!nh_addr)
       nh_addr = route_dst;
+
+    if(is_ipv6_link_local_address(nh_addr))
+      continue;
 
     if (nh_addr) {
       switch (nl_addr_get_family(nh_addr)) {

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -918,7 +918,8 @@ int nl_l3::add_l3_egress(int ifindex, const uint16_t vid,
   auto l3_if_tuple = std::make_tuple(port_id, vid, src_mac, dst_mac);
   auto it = l3_interface_mapping.equal_range(l3_if_tuple);
 
-  if (it.first == l3_interface_mapping.end()) {
+  rv = get_l3_interface_id(ifindex, s_mac, d_mac, l3_interface_id);
+  if (rv < 0) {
     rv = sw->l3_egress_create(port_id, vid, src_mac, dst_mac, l3_interface_id);
 
     if (rv < 0) {
@@ -931,16 +932,6 @@ int nl_l3::add_l3_egress(int ifindex, const uint16_t vid,
 
     l3_interface_mapping.emplace(
         std::make_pair(l3_if_tuple, l3_interface(*l3_interface_id)));
-  } else {
-    for (auto i = it.first; i != it.second; ++i) {
-      if (i->first == l3_if_tuple) {
-        if (l3_interface_id)
-          *l3_interface_id = i->second.l3_interface_id;
-        i->second.refcnt++;
-        rv = 0;
-        break;
-      }
-    }
   }
 
   return rv;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -600,6 +600,17 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
   if (n == nullptr)
     return -EINVAL;
 
+  // AF_INET6
+  addr = rtnl_neigh_get_dst(n);
+  auto p = nl_addr_alloc(16);
+  nl_addr_parse("fe80::/10", AF_INET6, &p);
+  std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
+
+  if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
+    VLOG(2) << __FUNCTION__ << ": skipping fe80::/10";
+    return 0;
+  }
+
   rv = add_l3_neigh_egress(n, &l3_interface_id, &vrf_id);
   LOG(INFO) << __FUNCTION__ << ": adding l3 neigh egress for neigh "
             << OBJ_CAST(n);
@@ -610,7 +621,6 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
     return rv;
   }
 
-  addr = rtnl_neigh_get_dst(n);
   if (family == AF_INET) {
     rofl::caddress_in4 ipv4_dst = libnl_in4addr_2_rofl(addr, &rv);
     if (rv < 0) {
@@ -620,15 +630,6 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
     rv = sw->l3_unicast_host_add(ipv4_dst, l3_interface_id, false, false,
                                  vrf_id);
   } else {
-    // AF_INET6
-    auto p = nl_addr_alloc(16);
-    nl_addr_parse("fe80::/10", AF_INET6, &p);
-    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
-
-    if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
-      VLOG(1) << __FUNCTION__ << ": skipping fe80::/10";
-      return 0;
-    }
     rofl::caddress_in6 ipv6_dst = libnl_in6addr_2_rofl(addr, &rv);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": could not parse addr " << addr;


### PR DESCRIPTION
Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
The interface to get_l3_interface_id was changed in #279, to fix lookups for the l3 interface ids necessary when configuring nexthops. The lookup code when adding l3 neighbors must also be expanded to support adding/updating bonded interfaces as the egress entry.

## Motivation and Context
This PR aims to fix problems wrt to adding routes pointing to the correct next hop. 

Depends on #270.

## How Has This Been Tested?
Tested with the static-route tests.
