### PR TITLE
clean up and fix vlan handling for bonded interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -326,6 +326,10 @@ int cnetlink::get_l3_addrs(struct rtnl_link *link,
   return l3->get_l3_addrs(link, addresses);
 }
 
+std::set<uint32_t> cnetlink::get_bond_members_by_port_id(uint32_t port_id) {
+  return bond->get_members_by_port_id(port_id);
+}
+
 int cnetlink::add_l3_addr(struct rtnl_addr *a) {
   switch (rtnl_addr_get_family(a)) {
   case AF_INET:

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -977,7 +977,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
         LOG(INFO) << __FUNCTION__ << ": using bridge "
                   << OBJ_CAST(br_link.get());
 
-        bridge = new nl_bridge(this->swi, tap_man, this, vxlan);
+        bridge = new nl_bridge(this->swi, tap_man, this, vlan, vxlan);
         bridge->set_bridge_interface(br_link.get());
         vxlan->register_bridge(bridge);
       }

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -50,6 +50,8 @@ public:
   std::set<uint32_t> get_bond_members_by_lag(rtnl_link *bond_link);
   std::set<uint32_t> get_bond_members_by_port_id(uint32_t port_id);
 
+  void get_vlans(int ifindex, std::deque<uint16_t> *vid_list) const noexcept;
+
   /**
    * @return rtnl_neigh* which needs to be freed using rtnl_neigh_put
    */

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -48,6 +48,7 @@ public:
   void get_bridge_ports(int br_ifindex,
                         std::deque<rtnl_link *> *link_list) const noexcept;
   std::set<uint32_t> get_bond_members_by_lag(rtnl_link *bond_link);
+  std::set<uint32_t> get_bond_members_by_port_id(uint32_t port_id);
 
   /**
    * @return rtnl_neigh* which needs to be freed using rtnl_neigh_put

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -26,9 +26,13 @@ void nl_bond::clear() noexcept {
 uint32_t nl_bond::get_lag_id(rtnl_link *bond) {
   assert(bond);
 
-  auto it = ifi2lag.find(rtnl_link_get_ifindex(bond));
+  return get_lag_id(rtnl_link_get_ifindex(bond));
+}
+
+uint32_t nl_bond::get_lag_id(int ifindex) {
+  auto it = ifi2lag.find(ifindex);
   if (it == ifi2lag.end()) {
-    VLOG(1) << __FUNCTION__ << ": lag_id not found of lag " << OBJ_CAST(bond);
+    VLOG(1) << __FUNCTION__ << ": lag_id not found for if=" << ifindex;
     return 0;
   }
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -57,6 +57,17 @@ std::set<uint32_t> nl_bond::get_members(rtnl_link *bond) {
   return mem_it->second;
 }
 
+std::set<uint32_t> nl_bond::get_members_by_port_id(uint32_t port_id) {
+  auto mem_it = lag_members.find(port_id);
+  if (mem_it == lag_members.end()) {
+    LOG(WARNING) << __FUNCTION__ << ": lag does not exist for port_id="
+	         << port_id;
+    return {};
+  }
+
+  return mem_it->second;
+}
+
 int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
 #ifdef HAVE_RTNL_LINK_BOND_GET_MODE
   VLOG(1) << __FUNCTION__ << ": updating bond interface ";

--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -31,6 +31,7 @@ public:
    * @returns id > 0 if found, 0 if not found
    */
   uint32_t get_lag_id(rtnl_link *bond);
+  uint32_t get_lag_id(int ifindex);
   /**
    * returns the members of the lag
    *

--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -39,6 +39,8 @@ public:
    */
   std::set<uint32_t> get_members(rtnl_link *bond);
 
+  std::set<uint32_t> get_members_by_port_id(uint32_t port_id);
+
   /**
    * create a new lag
    *

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -30,9 +30,10 @@
 namespace basebox {
 
 nl_bridge::nl_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
-                     cnetlink *nl, std::shared_ptr<nl_vxlan> vxlan)
+                     cnetlink *nl, std::shared_ptr<nl_vlan> vlan,
+                     std::shared_ptr<nl_vxlan> vxlan)
     : bridge(nullptr), sw(sw), tap_man(std::move(tap_man)), nl(nl),
-      vxlan(std::move(vxlan)),
+      vlan(std::move(vlan)), vxlan(std::move(vxlan)),
       l2_cache(nl_cache_alloc(nl_cache_ops_lookup("route/neigh")),
                nl_cache_free) {
   memset(&empty_br_vlan, 0, sizeof(rtnl_link_bridge_vlan));

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -30,6 +30,7 @@ class caddress_ll;
 namespace basebox {
 
 class cnetlink;
+class nl_vlan;
 class nl_vxlan;
 class switch_interface;
 class tap_manager;
@@ -38,7 +39,8 @@ struct packet;
 class nl_bridge {
 public:
   nl_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
-            cnetlink *nl, std::shared_ptr<nl_vxlan> vxlan);
+            cnetlink *nl, std::shared_ptr<nl_vlan> vlan,
+            std::shared_ptr<nl_vxlan> vxlan);
 
   virtual ~nl_bridge();
 
@@ -94,6 +96,7 @@ private:
   switch_interface *sw;
   std::shared_ptr<tap_manager> tap_man;
   cnetlink *nl;
+  std::shared_ptr<nl_vlan> vlan;
   std::shared_ptr<nl_vxlan> vxlan;
   std::unique_ptr<nl_cache, decltype(&nl_cache_free)> l2_cache;
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -250,18 +250,6 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
     }
   }
 
-  if (auto members = nl->get_bond_members_by_lag(link); !members.empty()) {
-    VLOG(2) << __FUNCTION__ << ": configuring VLAN entry for bond slave "
-            << link;
-
-    for (auto mem : members) {
-      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
-      bool tagged = !!rtnl_link_is_vlan(link);
-
-      rv = vlan->add_vlan(_link.get(), vid, tagged, vrf_id);
-    }
-  }
-
   return rv;
 }
 
@@ -349,18 +337,6 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed to add vlan id " << vid
                  << " (tagged=" << tagged << " to link " << OBJ_CAST(link);
-    }
-  }
-
-  if (auto members = nl->get_bond_members_by_lag(link); !members.empty()) {
-    VLOG(2) << __FUNCTION__ << ": configuring VLAN entry for bond slave "
-            << OBJ_CAST(link);
-
-    for (auto mem : members) {
-      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
-      bool tagged = !!rtnl_link_is_vlan(link);
-
-      rv = vlan->add_vlan(_link.get(), vid, tagged);
     }
   }
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1784,12 +1784,11 @@ void nl_l3::vrf_attach(rtnl_link *old_link, rtnl_link *new_link) {
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
-    vlan->add_vlan(link.get(), vid, true, vrf_id);
+    vlan->add_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf_id);
 
     auto members = nl->get_bond_members_by_lag(link.get());
     for (auto mem : members) {
-      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
-      vlan->add_vlan(_link.get(), vid, true, vrf_id);
+      vlan->add_ingress_vlan(mem, vid, true, vrf_id);
     }
   }
 }
@@ -1805,6 +1804,7 @@ void nl_l3::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
   uint16_t vid = vlan->get_vid(new_link);
 
   uint16_t vrf_id = get_vrf_table_id(old_link);
+
   auto fdb_entries = nl->search_fdb(vid, nullptr);
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
@@ -1820,12 +1820,11 @@ void nl_l3::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
-    vlan->add_vlan(link.get(), vid, true);
+    vlan->add_ingress_vlan(nl->get_port_id(link.get()), vid, true);
 
     auto members = nl->get_bond_members_by_lag(link.get());
     for (auto mem : members) {
-      auto _link = nl->get_link_by_ifindex(nl->get_ifindex_by_port_id(mem));
-      vlan->add_vlan(_link.get(), vid, true);
+      vlan->add_ingress_vlan(mem, vid, true);
     }
   }
 }

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1750,22 +1750,12 @@ void nl_l3::vrf_attach(rtnl_link *old_link, rtnl_link *new_link) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->remove_ingress_vlan(nl->get_port_id(link.get()), vid, true);
-
-    auto members = nl->get_bond_members_by_lag(link.get());
-    for (auto mem : members) {
-      vlan->remove_ingress_vlan(mem, vid, true);
-    }
   }
 
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->add_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf_id);
-
-    auto members = nl->get_bond_members_by_lag(link.get());
-    for (auto mem : members) {
-      vlan->add_ingress_vlan(mem, vid, true, vrf_id);
-    }
   }
 }
 
@@ -1786,22 +1776,12 @@ void nl_l3::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->remove_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf_id);
-
-    auto members = nl->get_bond_members_by_lag(link.get());
-    for (auto mem : members) {
-      vlan->remove_ingress_vlan(mem, vid, true, vrf_id);
-    }
   }
 
   for (auto entry : fdb_entries) {
     auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
 
     vlan->add_ingress_vlan(nl->get_port_id(link.get()), vid, true);
-
-    auto members = nl->get_bond_members_by_lag(link.get());
-    for (auto mem : members) {
-      vlan->add_ingress_vlan(mem, vid, true);
-    }
   }
 }
 

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -67,6 +67,13 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged,
   return rv;
 }
 
+// add vid at ingress
+int nl_vlan::add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+                                 uint16_t vrf_id) {
+
+  return swi->ingress_port_vlan_add(port_id, vid, !tagged, vrf_id);
+}
+
 // remove vid at ingress
 int nl_vlan::remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
                                  uint16_t vrf_id) {

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -129,7 +129,7 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged,
   }
 
   // remove vid from egress
-  rv = swi->egress_bridge_port_vlan_remove(port_id, vid);
+  rv = swi->egress_port_vlan_remove(port_id, vid);
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv= " << rv

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -28,6 +28,10 @@ public:
                           uint16_t vrf_id = 0);
   int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
                           uint16_t vrf_id = 0);
+  int add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,  bool tagged,
+                      uint16_t vrf_id = 0);
+  void remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,  bool tagged,
+                          uint16_t vrf_id = 0);
 
   uint16_t get_vid(rtnl_link *link);
 

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -24,6 +24,8 @@ public:
   int add_vlan(rtnl_link *link, uint16_t vid, bool tagged, uint16_t vrf_id = 0);
   int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged,
                   uint16_t vrf_id = 0);
+  int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+                          uint16_t vrf_id = 0);
   int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
                           uint16_t vrf_id = 0);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix various issues with vlan on bond interface handling and centralize its code in `nl_vlan.cc`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

In preparation of better VRF handling, and to properly support SVIs on bond interfaces, the vlan code needs various fixes to handle it. This PR is an attempt at fixing this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Testing pipelines have been run on as4610, ag5648 with the changes applied. All tests succeeded on ag5648, as4610 succeeded until one of the test servers became unavailable due to unknown causes.