### PR TITLE
Extend support for VRFs on bonded interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1103,9 +1103,10 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
               << OBJ_CAST(
                      get_link_by_ifindex(rtnl_link_get_master(new_link)).get());
     // Lookup l3 addresses to delete
+    // We can delete the addresses on the interface because we will later receive a
+    // notification readding the addresses, that time with the correct VRF
     std::deque<rtnl_addr *> addresses;
     get_l3_addrs(old_link, &addresses);
-    // delete l3 addresses
     for (auto i : addresses)
       l3->del_l3_addr(i);
 
@@ -1117,9 +1118,11 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
                 << OBJ_CAST(old_link);
 
       // Lookup l3 addresses to delete
+      // We can delete the addresses on the interface because we will later receive a
+      // notification readding the addresses, that time with the correct VRF
       std::deque<rtnl_addr *> addresses;
       get_l3_addrs(old_link, &addresses);
-     // delete l3 addresses no longer associated with vrf 
+      // delete l3 addresses no longer associated with vrf 
       for (auto i: addresses)
           l3->del_l3_addr(i);
       vlan->vrf_detach(old_link, new_link);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1105,13 +1105,16 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     vlan->vrf_attach(old_link, new_link);
     break;
   case LT_VRF_SLAVE:
-    if (lt_new != LT_VLAN) {
-      VLOG(1) << __FUNCTION__ << ": ignoring update of VRF SLAVE interface";
-      return;
+    if (lt_new == LT_VLAN) {
+      LOG(INFO) << __FUNCTION__ << ": freed vrf slave interface "
+                << OBJ_CAST(old_link);
+      vlan->vrf_detach(old_link, new_link);
+    } else if (lt_new == LT_VRF_SLAVE) {
+      LOG(INFO) << __FUNCTION__ << ": link updated " << OBJ_CAST(new_link);
+      vlan->vrf_attach(old_link, new_link);
     }
-    LOG(INFO) << __FUNCTION__ << ": freed vrf slave interface "
-              << OBJ_CAST(old_link);
-    l3->vrf_detach(old_link, new_link);
+    // TODO handle LT_TAP/LT_BOND, currently unimplemented
+    // happens when a bond/tap interface enslaved directly to a VRF and you set nomaster
     break;
   case LT_TUN:
     if (lt_new == LT_BOND_SLAVE) {

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1108,6 +1108,13 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     if (lt_new == LT_VLAN) {
       LOG(INFO) << __FUNCTION__ << ": freed vrf slave interface "
                 << OBJ_CAST(old_link);
+
+      // Lookup l3 addresses to delete
+      std::deque<rtnl_addr *> addresses;
+      get_l3_addrs(old_link, &addresses);
+     // delete l3 addresses no longer associated with vrf 
+      for (auto i: addresses)
+          l3->del_l3_addr(i);
       vlan->vrf_detach(old_link, new_link);
     } else if (lt_new == LT_VRF_SLAVE) {
       LOG(INFO) << __FUNCTION__ << ": link updated " << OBJ_CAST(new_link);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -52,6 +52,7 @@ public:
 
   void get_vlans(int ifindex, std::deque<uint16_t> *vid_list) const noexcept;
 
+  uint16_t get_vrf_table_id(rtnl_link *link);
   /**
    * @return rtnl_neigh* which needs to be freed using rtnl_neigh_put
    */

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -54,9 +54,6 @@ public:
   int update_l3_route(struct rtnl_route *r_old, struct rtnl_route *r_new);
   int del_l3_route(struct rtnl_route *r);
 
-  void vrf_attach(rtnl_link *old_link, rtnl_link *new_link);
-  void vrf_detach(rtnl_link *old_link, rtnl_link *new_link);
-
   void get_nexthops_of_route(rtnl_route *route,
                              std::deque<struct rtnl_nexthop *> *nhs) noexcept;
 
@@ -120,8 +117,6 @@ private:
 
     return !nl_addr_cmp_prefix(mc_addr.get(), addr);
   }
-
-  uint16_t get_vrf_table_id(rtnl_link *vrf);
 
   switch_interface *sw;
   std::shared_ptr<nl_vlan> vlan;

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -7,6 +7,8 @@
 #include <glog/logging.h>
 #include <netlink/route/link.h>
 #include <netlink/route/link/vlan.h>
+#include <netlink/route/link/vrf.h>
+#include <netlink/route/neighbour.h>
 
 #include "cnetlink.h"
 #include "nl_output.h"
@@ -17,16 +19,18 @@ namespace basebox {
 
 nl_vlan::nl_vlan(cnetlink *nl) : swi(nullptr), nl(nl) {}
 
-int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged,
-                      uint16_t vrf_id) {
+int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   assert(swi);
 
-  VLOG(2) << __FUNCTION__ << ": add vid=" << vid << " tagged=" << tagged
-          << " vrf=" << vrf_id;
   if (!is_vid_valid(vid)) {
     LOG(ERROR) << __FUNCTION__ << ": invalid vid " << vid;
     return -EINVAL;
   }
+
+  uint16_t vrf_id = get_vrf_id(vid, link);
+
+  VLOG(2) << __FUNCTION__ << ": add vid=" << vid << " tagged=" << tagged
+          << " vrf=" << vrf_id;
 
   uint32_t port_id = nl->get_port_id(link);
 
@@ -162,9 +166,10 @@ int nl_vlan::remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
   return swi->ingress_port_vlan_remove(port_id, vid, !tagged, vrf_id);
 }
 
-int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged,
-                         uint16_t vrf_id) {
+int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   assert(swi);
+
+  uint16_t vrf_id = get_vrf_id(vid, link);
 
   if (!is_vid_valid(vid)) {
     LOG(ERROR) << __FUNCTION__ << ": invalid vid " << vid;
@@ -234,9 +239,11 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged,
 }
 
 int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
-                             bool tagged, uint16_t vrf_id) {
+                             bool tagged) {
   int rv;
   assert(swi);
+
+  uint16_t vrf_id = get_vrf_id(vid, link);
 
   VLOG(2) << __FUNCTION__ << ": add vid=" << vid << " pvid=" << pvid
 	  <<  " tagged=" << tagged << " vrf=" << vrf_id;
@@ -272,7 +279,7 @@ int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
     }
 
     if (rv < 0) {
-      remove_bridge_vlan(link, vid, pvid, tagged, vrf_id);
+      remove_bridge_vlan(link, vid, pvid, tagged);
     }
   }
 
@@ -280,8 +287,10 @@ int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
 }
 
 void nl_vlan::remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
-                                 bool tagged, uint16_t vrf_id) {
+                                 bool tagged) {
   assert(swi);
+
+  uint16_t vrf_id = get_vrf_id(vid, link);
 
   VLOG(2) << __FUNCTION__ << ": remove vid=" << vid << " pvid=" << pvid
 	  <<  " tagged=" << tagged << " vrf=" << vrf_id;
@@ -344,6 +353,68 @@ uint16_t nl_vlan::get_vid(rtnl_link *link) {
   VLOG(2) << __FUNCTION__ << ": vid=" << vid << " interface=" << OBJ_CAST(link);
 
   return vid;
+}
+
+uint16_t nl_vlan::get_vrf_id(uint16_t vid, rtnl_link *link) {
+  auto vlanmap = vlan_vrf.find(vid);
+  if (vlanmap == vlan_vrf.end()) {
+    auto id = nl->get_vrf_table_id(link);
+    if (id <= 0) // not found, doesnt exist
+      return 0;
+
+    vlan_vrf.insert(std::make_pair(vid, id));
+    return id;
+  }
+
+  return vlanmap->second;
+}
+
+void nl_vlan::vrf_attach(rtnl_link *old_link, rtnl_link *new_link) {
+  uint16_t vid = get_vid(new_link);
+  if(vid == 0)
+    return;
+
+  uint16_t vrf = get_vrf_id(vid, new_link);
+
+  LOG(INFO) << __FUNCTION__ << ": map vlan=" << vid << " vrf=" << vrf;
+
+  // delete old entries
+  auto fdb_entries = nl->search_fdb(vid, nullptr);
+  for (auto entry : fdb_entries) {
+    auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
+
+    remove_ingress_vlan(nl->get_port_id(link.get()), vid, true);
+  }
+
+  // add updated entries
+  for (auto entry : fdb_entries) {
+    auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
+
+    add_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf);
+  }
+}
+
+void nl_vlan::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
+  uint16_t vid = get_vid(new_link);
+  auto vrf = get_vrf_id(vid, old_link);
+  if (vrf == 0)
+    return;
+
+  // delete old entries
+  auto fdb_entries = nl->search_fdb(vid, nullptr);
+  for (auto entry : fdb_entries) {
+    auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
+
+    remove_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf);
+  }
+
+  // add updated entries
+  for (auto entry : fdb_entries) {
+    auto link = nl->get_link_by_ifindex(rtnl_neigh_get_ifindex(entry));
+
+    add_ingress_vlan(nl->get_port_id(link.get()), vid, true);
+  }
+
 }
 
 } // namespace basebox

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -21,17 +21,12 @@ public:
 
   void register_switch_interface(switch_interface *swi) { this->swi = swi; }
 
-  int add_vlan(rtnl_link *link, uint16_t vid, bool tagged, uint16_t vrf_id = 0);
-  int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged,
-                  uint16_t vrf_id = 0);
-  int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
-                          uint16_t vrf_id = 0);
-  int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
-                          uint16_t vrf_id = 0);
-  int add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,  bool tagged,
-                      uint16_t vrf_id = 0);
-  void remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,  bool tagged,
-                          uint16_t vrf_id = 0);
+  int add_vlan(rtnl_link *link, uint16_t vid, bool tagged);
+  int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged);
+  int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged, uint16_t vrf_id=0);
+  int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged, uint16_t vrf_id=0);
+  int add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,  bool tagged);
+  void remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,  bool tagged);
 
   uint16_t get_vid(rtnl_link *link);
 
@@ -41,6 +36,10 @@ public:
     return true;
   }
 
+  void vrf_attach(rtnl_link *old_link, rtnl_link *new_link);
+  void vrf_detach(rtnl_link *old_link, rtnl_link *new_link);
+  uint16_t get_vrf_id(uint16_t vid, rtnl_link *link);
+
 private:
   static const uint16_t vid_low = 1;
   static const uint16_t vid_high = 0xfff;
@@ -48,6 +47,8 @@ private:
 
   // ifindex - vlan - refcount
   std::map<std::pair<uint32_t, uint16_t>, uint32_t> port_vlan;
+  // vlan - vrf
+  std::map<uint16_t, uint16_t> vlan_vrf;
 
   switch_interface *swi;
   cnetlink *nl;


### PR DESCRIPTION
## Description
This PR aims to extend VRF support.  We have centralized all VRF handling on the nl_vlan classes, which then provides a clean way to configure VRFs on all interfaces, removing the specific order limitation that was present until the current PR. 

We have started tracking all of the VLAN - VRF mappings, so that it is easier to lookup the ids when we need to configure this.

## Motivation and Context
This Pr extends the work done to support bond interfaces.

## How Has This Been Tested?
Ran pipelines including the trunk-vrf tests.