### PR TITLE
nl_bridge: relax bridge rtnl_link requirement

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -54,7 +54,10 @@ static rofl::caddress_in4 libnl_in4addr_2_rofl(struct nl_addr *addr, int *rv) {
 
 void nl_bridge::set_bridge_interface(rtnl_link *bridge) {
   assert(bridge);
-  assert(std::string("bridge").compare(rtnl_link_get_type(bridge)) == 0);
+  assert((rtnl_link_get_type(bridge) != nullptr &&
+          std::string("bridge").compare(rtnl_link_get_type(bridge)) == 0) ||
+         (rtnl_link_get_family(bridge) == AF_BRIDGE &&
+          rtnl_link_get_ifindex(bridge) == rtnl_link_get_master(bridge)));
 
   this->bridge = bridge;
   nl_object_get(OBJ_CAST(bridge));


### PR DESCRIPTION
If there already is a preexisting bonded interface attached to a bridge,
we might get a early version of the bridge interface that does not has
its kind set. This triggers a null pointer access in the assert.

To work around this, check for kind being set, and in absence, check if
the link's master is itself (which will be for the bridge).

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description

The issue shows up in the journal as

```
Dec 02 20:29:30 agema-ag5648 baseboxd[2278]: I1202 20:29:30.747992  2305 cnetlink.cc:1092] link_updated: link enslaved port7
Dec 02 20:29:30 agema-ag5648 baseboxd[2278]: I1202 20:29:30.780452  2305 cnetlink.cc:977] link_created: using bridge bridge swbridge ether a6:6b:15:2b:97:17 master swbridge <broadcast,multicast,up>
Dec 02 20:29:30 agema-ag5648 kernel: Code: 0f 1f 40 00 66 0f ef c0 66 0f ef c9 66 0f ef d2 66 0f ef db 48 89 f8 48 89 f9 48 81 e1 ff 0f 00 00 48 81 f9 cf 0f 00 00 77 6a <f3> 0f 6f 20 66 0f 74 e0 66 0f d7 d4 85 d2 74 04 0f bc c2 c3 48 83
Dec 02 20:29:30 agema-ag5648 kernel: bond1: (slave port7): Enslaving as a backup interface with a down link
Dec 02 20:29:30 agema-ag5648 kernel: audit: type=1701 audit(1606940970.813:8): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2278 comm="netlink" exe="/usr/bin/baseboxd" sig=11 res=1
Dec 02 20:29:30 agema-ag5648 audit[2278]: ANOM_ABEND auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2278 comm="netlink" exe="/usr/bin/baseboxd" sig=11 res=1
```
backtrace shows:
```
(gdb) bt
#0  0x00007fe3c7b587d6 in ?? () from /lib/libc.so.6
#1  0x0000560feed3e0d8 in std::char_traits<char>::length (__s=0x0) at /usr/include/c++/8.3.0/bits/char_traits.h:322
#2  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::compare (__s=0x0, this=0x7fe3c7a13100)
    at /usr/include/c++/8.3.0/bits/basic_string.tcc:1422
#3  basebox::nl_bridge::set_bridge_interface (this=0x7fe3c00180a0, bridge=bridge@entry=0x7fe3c0036cd0)
    at ../git/src/netlink/nl_bridge.cc:57
#4  0x0000560feed2a271 in basebox::cnetlink::link_created (this=0x560fef5e5120, link=link@entry=0x7fe3c0001b00)
    at ../git/src/netlink/cnetlink.cc:981
#5  0x0000560feed375ca in basebox::nl_bond::add_lag_member (this=0x560fef5e0740, bond=bond@entry=0x7fe3c0037d10, 
```
The appropriate code is:

```
void nl_bridge::set_bridge_interface(rtnl_link *bridge) {
  assert(bridge);
  assert(std::string("bridge").compare(rtnl_link_get_type(bridge)) == 0);
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Where `rtnl_link_get_type` seems to have returned a nullptr.


`nl_bridge::set_bridge_interface` was called from:

```
     if (bridge == nullptr) {
        std::unique_ptr<rtnl_link, decltype(&rtnl_link_put)> br_link(
            rtnl_link_get(caches[NL_LINK_CACHE], rtnl_link_get_master(link)),
            rtnl_link_put);
        LOG(INFO) << __FUNCTION__ << ": using bridge "
                  << OBJ_CAST(br_link.get());
        bridge = new nl_bridge(this->swi, tap_man, this, vlan, vxlan);
        bridge->set_bridge_interface(br_link.get());
```

Comparing the output from two INFO logs shows:

Working:

```
Dec 02 20:29:33 agema-ag5648 baseboxd[2794]: I1202 20:29:33.208673  2795 cnetlink.cc:977] link_created: using bridge bridge swbridge ether a6:6b:15:2b:97:17 <broadcast,multicast,up> group 0
```

Crashing:

```
Dec 02 20:29:30 agema-ag5648 baseboxd[2278]: I1202 20:29:30.780452  2305 cnetlink.cc:977] link_created: using bridge bridge swbridge ether a6:6b:15:2b:97:17 master swbridge <broadcast,multicast,up>
```

A dive into the libnl and linux code shows that the crashing bridge object is returned by the kernel when getting the link object (not an update) of the bridge itself, which is called by libnl to prefill its link cache.

Since there is no way to prevent us from seing this early link version, just relax the bridge check to also accept this object.

## Motivation and Context

At this point we will already have created the enslaved trunk group interface, so a baseboxd restart will cause a desync between baseboxd and internal OF-DPA configuration, leading to broken functionality.

## How Has This Been Tested?

Tests were run over the weekend, 4 times per day per platform. No further crashes were detected.