### PR TITLE
add static flowmods to copy IS-IS PDUs to controller

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1977,6 +1977,24 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
     dpt.send_flow_mod_message(rofl::cauxid(0),
                               fm_driver.enable_policy_8021d(dpt.get_version()));
 
+    /* Add flowmods to always copy IS-IS PDUs (identified by eth_dst mac) to
+     * controller and clear them from the pipeline to avoid duplication
+     * 01-80-C2-00-00-14 ("all L1 intermediate systems")
+     * 01-80-C2-00-00-15 ("All L2 intermediate systems")
+     * 09-00-2B-00-00-04 ("all end systems")
+     * 09-00-2B-00-00-05 ("all intermediate systems")
+     */
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_policy_l2(
+                             dpt.get_version(),
+                             rofl::caddress_ll("01:80:C2:00:00:14"),
+                             rofl::caddress_ll("ff:ff:ff:ff:ff:fe")));
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_policy_l2(
+                             dpt.get_version(),
+                             rofl::caddress_ll("09:00:2B:00:00:04"),
+                             rofl::caddress_ll("ff:ff:ff:ff:ff:fe")));
+
     // Adding policy entry so that the multicast packets reach the switch
     // The ff02:: address is a permanent multicast address with a link scope
     dpt.send_flow_mod_message(


### PR DESCRIPTION
* add static flowmods to allow controller to receive IS-IS PDUs and drop
  them from the pipeline (clearAction) to avoid packet duplication

Signed-off-by: Jan Klare <jan.klare@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
