### PR TITLE
baseboxd: implement per vlan spanning tree functionality

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,7 +160,6 @@ src_pb = protoc_gen.process(
   'src/grpc/proto/common/empty.proto',
   'src/grpc/proto/common/openconfig-interfaces.proto',
   'src/grpc/proto/statistics/statistics-service.proto',
-  'src/grpc/proto/stp/openconfig-spanning-tree.proto',
   preserve_path_from : meson.current_source_dir()+'/src/grpc/proto')
 
 src_grpc = grpc_gen.process(

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -36,6 +36,7 @@ public:
     NL_NEIGH_CACHE,
     NL_ROUTE_CACHE,
     NL_MDB_CACHE,
+    NL_BVLAN_CACHE,
     NL_MAX_CACHE,
   };
 
@@ -167,6 +168,7 @@ private:
   void route_neigh_apply(const nl_obj &obj);
   void route_route_apply(const nl_obj &obj);
   void route_mdb_apply(const nl_obj &obj);
+  void route_bridge_vlan_apply(const nl_obj &obj);
 
   enum cnetlink_event_t {
     EVENT_NONE,

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -71,6 +71,10 @@ public:
   int get_port_id(rtnl_link *l) const;
   int get_port_id(int ifindex) const;
   int get_ifindex_by_port_id(uint32_t port_id) const;
+  int get_bridge_stp_state() {
+    assert(bridge);
+    return bridge->get_stp_state();
+  }
 
   nl_cache *get_cache(enum nl_cache_t id) { return caches[id]; }
 

--- a/src/netlink/netlink-utils.h
+++ b/src/netlink/netlink-utils.h
@@ -10,6 +10,7 @@
 extern "C" {
 struct nl_addr;
 struct rtnl_addr;
+struct rtnl_bridge_vlan;
 struct rtnl_link;
 struct rtnl_neigh;
 struct rtnl_route;
@@ -21,6 +22,7 @@ struct rtnl_mdb;
 #define ROUTE_CAST(obj) reinterpret_cast<struct rtnl_route *>(obj)
 #define ADDR_CAST(obj) reinterpret_cast<struct rtnl_addr *>(obj)
 #define MDB_CAST(obj) reinterpret_cast<struct rtnl_mdb *>(obj)
+#define BRIDGE_VLAN_CAST(obj) reinterpret_cast<struct rtnl_bridge_vlan *>(obj)
 
 namespace basebox {
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -237,6 +237,9 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
               << ": bond was already bridge slave: " << OBJ_CAST(br_link);
       nl->link_created(br_link);
 
+      if (nl->get_bridge_stp_state() == 0)
+        return rv;
+
       auto new_state = rtnl_link_bridge_get_port_state(br_link);
       std::string state;
 
@@ -261,7 +264,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
         return rv;
       }
 
-      swi->ofdpa_stg_state_port_set(port_id, state);
+      swi->ofdpa_global_stp_state_port_set(port_id, state);
     }
 
     rv = nl->set_bridge_port_vlan_tpid(br_link);
@@ -325,7 +328,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   lag_members.erase(lm_rv);
 
   if (nl->is_bridge_interface(bond)) {
-    swi->ofdpa_stg_state_port_set(port_id, "forward");
+    swi->ofdpa_global_stp_state_port_set(port_id, "forward");
 
     auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
     rv = nl->unset_bridge_port_vlan_tpid(br_link);
@@ -343,7 +346,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
       remove_l3_address(bond);
 
     if (nl->is_bridge_interface(bond))
-      swi->ofdpa_stg_state_port_set(port_id, "forward");
+      swi->ofdpa_global_stp_state_port_set(port_id, "forward");
 
     for (auto vid : vlans) {
       swi->ingress_port_vlan_remove(port_id, vid, false);

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -264,7 +264,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
         return rv;
       }
 
-      swi->ofdpa_global_stp_state_port_set(port_id, state);
+      swi->ofdpa_stg_state_port_set(port_id, 1, state);
     }
 
     rv = nl->set_bridge_port_vlan_tpid(br_link);
@@ -328,7 +328,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   lag_members.erase(lm_rv);
 
   if (nl->is_bridge_interface(bond)) {
-    swi->ofdpa_global_stp_state_port_set(port_id, "forward");
+    swi->ofdpa_stg_state_port_set(port_id, 1, "forward");
 
     auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
     rv = nl->unset_bridge_port_vlan_tpid(br_link);
@@ -346,7 +346,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
       remove_l3_address(bond);
 
     if (nl->is_bridge_interface(bond))
-      swi->ofdpa_global_stp_state_port_set(port_id, "forward");
+      swi->ofdpa_stg_state_port_set(port_id, 1, "forward");
 
     for (auto vid : vlans) {
       swi->ingress_port_vlan_remove(port_id, vid, false);

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -223,7 +223,7 @@ void nl_bridge::update_interface(rtnl_link *old_link, rtnl_link *new_link) {
   std::string state;
 
   if (old_state != new_state) {
-    if (get_stp_state() == BR_STATE_DISABLED)
+    if (get_stp_state() == STP_STATE_DISABLED)
       return;
 
     LOG(INFO) << __FUNCTION__ << " STP state changed, old=" << old_state
@@ -1078,7 +1078,7 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
   int err = 0;
 
-  if (get_stp_state() == BR_STATE_DISABLED)
+  if (get_stp_state() == STP_STATE_DISABLED)
     return err;
 
   uint32_t ifindex = rtnl_bridge_vlan_get_ifindex(bvlan_info);
@@ -1094,10 +1094,7 @@ int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
   if (err < 0)
     return err;
 
-  int pv_state = bridge_stp_states.get_pvlan_state(port_id, vlan_id);
-  if (pv_state < 0)
-    bridge_stp_states.add_pvlan_state(port_id, vlan_id, stp_state);
-
+  bridge_stp_states.add_pvlan_state(port_id, vlan_id, stp_state);
   auto g_stp_state = bridge_stp_states.get_min_state(port_id, vlan_id);
 
   LOG(INFO) << __FUNCTION__ << ": set state=" << g_stp_state

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -76,6 +76,10 @@ bool nl_bridge::is_bridge_interface(rtnl_link *link) {
   // TODO compare more?
 
   return true;
+// Read sysfs to obtain the value for STP state on a bridge
+uint32_t nl_bridge::get_stp_state() {
+  std::string portname(rtnl_link_get_name(bridge));
+  return nl->load_from_file("/sys/class/net/" + portname + "/bridge/stp_state");
 }
 
 // Read sysfs to obtain the value for the VLAN protocol on the switch.

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -7,10 +7,11 @@
 #include <map>
 #include <utility>
 #include <linux/if_packet.h>
+#include <linux/if_bridge.h>
 
 #include <glog/logging.h>
-#include <linux/if_bridge.h>
 #include <netlink/route/link.h>
+#include <netlink/route/bridge_vlan.h>
 #ifdef HAVE_NETLINK_ROUTE_MDB_H
 #include <netlink/route/mdb.h>
 #endif
@@ -218,38 +219,28 @@ void nl_bridge::update_interface(rtnl_link *old_link, rtnl_link *new_link) {
   std::string state;
 
   if (old_state != new_state) {
-    LOG(INFO) << __FUNCTION__ << "STP state changed, old=" << old_state
+    if (get_stp_state() == BR_STATE_DISABLED)
+      return;
+
+    LOG(INFO) << __FUNCTION__ << " STP state changed, old=" << old_state
               << " new=" << new_state;
 
-    switch (new_state) {
-    case BR_STATE_FORWARDING:
-      state = "forward";
-      break;
-    case BR_STATE_BLOCKING:
-      state = "block";
-      break;
-    case BR_STATE_DISABLED:
-      state = "disable";
-      break;
-    case BR_STATE_LISTENING:
-      state = "listen";
-      break;
-    case BR_STATE_LEARNING:
-      state = "learn";
-      break;
-    default:
-      VLOG(1) << __FUNCTION__ << ": stp state change not supported";
-      return;
-    }
-
     auto port_id = nl->get_port_id(new_link);
+    bridge_stp_states.add_global_state(port_id, new_state);
+
+    auto pv_states = bridge_stp_states.get_min_states(port_id);
+    for (auto it : pv_states)
+      sw->ofdpa_stg_state_port_set(port_id, it.first,
+                                   stp_state_to_string(it.second));
+
+    state = stp_state_to_string(new_state);
     if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
       auto members = nl->get_bond_members_by_lag(new_link);
       for (auto mem : members) {
-        sw->ofdpa_stg_state_port_set(mem, state);
+        sw->ofdpa_global_stp_state_port_set(mem, state);
       }
     } else {
-      sw->ofdpa_stg_state_port_set(port_id, state);
+      sw->ofdpa_global_stp_state_port_set(port_id, state);
     }
 
     return;
@@ -282,10 +273,10 @@ void nl_bridge::delete_interface(rtnl_link *link) {
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
     auto members = nl->get_bond_members_by_lag(link);
     for (auto mem : members) {
-      sw->ofdpa_stg_state_port_set(mem, "forward");
+      sw->ofdpa_global_stp_state_port_set(mem, "forward");
     }
   } else {
-    sw->ofdpa_stg_state_port_set(port_id, "forward");
+    sw->ofdpa_global_stp_state_port_set(port_id, "forward");
   }
 }
 
@@ -1069,6 +1060,73 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 #endif
 
   return rv;
+}
+
+// struct rtnl_bridge_vlan {
+//	NLHDR_COMMON
+//	uint32_t ifindex;
+//	uint8_t family;
+//
+//	uint16_t vlan_id;
+//	uint16_t flags;
+//	uint16_t range;
+//	uint8_t state;
+int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
+  int err = 0;
+
+  if (get_stp_state() == BR_STATE_DISABLED)
+    return err;
+
+  uint32_t ifindex = rtnl_bridge_vlan_get_ifindex(bvlan_info);
+  int port_id = nl->get_port_id(ifindex);
+  struct rtnl_bvlan_entry *entry = rtnl_bridge_vlan_get_entry_head(bvlan_info);
+  uint16_t vlan_id = rtnl_bridge_vlan_entry_get_vlan_id(entry);
+  uint8_t stp_state = rtnl_bridge_vlan_entry_get_state(entry);
+
+  if (is_bridge_interface(ifindex))
+    return err;
+
+  err = sw->ofdpa_stg_create(vlan_id);
+  if (err < 0)
+    return err;
+
+  int pv_state = bridge_stp_states.get_pvlan_state(port_id, vlan_id);
+  if (pv_state == 0)
+    bridge_stp_states.add_pvlan_state(port_id, vlan_id, stp_state);
+
+  auto g_stp_state = bridge_stp_states.get_min_state(port_id, vlan_id);
+
+  LOG(INFO) << __FUNCTION__ << ": set state=" << g_stp_state
+            << " ifindex= " << ifindex << " VLAN =" << vlan_id;
+
+  err = sw->ofdpa_stg_state_port_set(nl->get_port_id(ifindex), vlan_id,
+                                     stp_state_to_string(g_stp_state));
+  return err;
+}
+
+std::string nl_bridge::stp_state_to_string(uint8_t state) {
+  std::string ret;
+  switch (state) {
+  case BR_STATE_FORWARDING:
+    ret = "forward";
+    break;
+  case BR_STATE_BLOCKING:
+    ret = "block";
+    break;
+  case BR_STATE_DISABLED:
+    ret = "disable";
+    break;
+  case BR_STATE_LISTENING:
+    ret = "listen";
+    break;
+  case BR_STATE_LEARNING:
+    ret = "learn";
+    break;
+  default:
+    ret = "";
+  }
+
+  return ret;
 }
 
 } /* namespace basebox */

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -68,15 +68,19 @@ void nl_bridge::set_bridge_interface(rtnl_link *bridge) {
                << " unsupported: bridge configured with vlan_filtering 0";
 }
 
+bool nl_bridge::is_bridge_interface(int ifindex) {
+  assert(bridge);
+
+  return (ifindex == rtnl_link_get_ifindex(bridge)) ? true : false;
+}
+
 bool nl_bridge::is_bridge_interface(rtnl_link *link) {
+  assert(bridge);
   assert(link);
 
-  if (rtnl_link_get_ifindex(link) != rtnl_link_get_ifindex(bridge))
-    return false;
+  return is_bridge_interface(rtnl_link_get_ifindex(link));
+}
 
-  // TODO compare more?
-
-  return true;
 // Read sysfs to obtain the value for STP state on a bridge
 uint32_t nl_bridge::get_stp_state() {
   std::string portname(rtnl_link_get_name(bridge));

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -241,10 +241,10 @@ void nl_bridge::update_interface(rtnl_link *old_link, rtnl_link *new_link) {
     if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
       auto members = nl->get_bond_members_by_lag(new_link);
       for (auto mem : members) {
-        sw->ofdpa_global_stp_state_port_set(mem, state);
+        sw->ofdpa_stg_state_port_set(mem, 1, state);
       }
     } else {
-      sw->ofdpa_global_stp_state_port_set(port_id, state);
+      sw->ofdpa_stg_state_port_set(port_id, 1, state);
     }
 
     return;
@@ -277,10 +277,10 @@ void nl_bridge::delete_interface(rtnl_link *link) {
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
     auto members = nl->get_bond_members_by_lag(link);
     for (auto mem : members) {
-      sw->ofdpa_global_stp_state_port_set(mem, "forward");
+      sw->ofdpa_stg_state_port_set(mem, 1, "forward");
     }
   } else {
-    sw->ofdpa_global_stp_state_port_set(port_id, "forward");
+    sw->ofdpa_stg_state_port_set(port_id, 1, "forward");
   }
 }
 

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1095,7 +1095,7 @@ int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
     return err;
 
   int pv_state = bridge_stp_states.get_pvlan_state(port_id, vlan_id);
-  if (pv_state == 0)
+  if (pv_state < 0)
     bridge_stp_states.add_pvlan_state(port_id, vlan_id, stp_state);
 
   auto g_stp_state = bridge_stp_states.get_min_state(port_id, vlan_id);

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -89,7 +89,7 @@ struct bridge_stp_states {
   uint8_t get_global_state(int port_id) {
     auto it = gl_states.find(port_id);
 
-    return (it == gl_states.end()) ? 0 : it->second;
+    return (it == gl_states.end()) ? -EINVAL : it->second;
   }
 
   uint8_t get_pvlan_state(int port_id, uint16_t vid) {
@@ -97,12 +97,12 @@ struct bridge_stp_states {
 
     // no vlan found
     if (it == pv_states.end())
-      return 0;
+      return -EINVAL;
 
     // no port found
     auto pv_state = it->second.find(port_id);
     if (pv_state == it->second.end())
-      return 0;
+      return -EINVAL;
 
     return pv_state->second;
   }
@@ -127,11 +127,11 @@ struct bridge_stp_states {
     int g_state = get_global_state(port_id);
     int pv_state = get_pvlan_state(port_id, vid);
 
-    if (pv_state == 0)
-      return 0;
+    if (pv_state < 0)
+      return g_state;
 
     if (g_state == BR_STATE_BLOCKING || pv_state == BR_STATE_BLOCKING)
-      return g_state;
+      return BR_STATE_BLOCKING;
 
     return get_min(g_state, pv_state);
   }

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -63,6 +63,7 @@ public:
                   const rofl::caddress_ll &mac);
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
 
+  uint32_t get_stp_state();
   uint32_t get_vlan_proto();
   int set_vlan_proto(rtnl_link *link);
   int delete_vlan_proto(rtnl_link *link);

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -15,8 +15,18 @@
 
 #include "netlink-utils.h"
 
+#define BR_STATE_DISABLED 0
+#define BR_STATE_LISTENING 1
+#define BR_STATE_LEARNING 2
+#define BR_STATE_FORWARDING 3
+#define BR_STATE_BLOCKING 4
+
+#define STP_STATE_DISABLED 0
+#define STP_STATE_KERNEL 1
+#define STP_STATE_USERSPACE 2
+
 extern "C" {
-struct rtnl_link_bridge_vlan;
+struct rtnl_bridge_vlan;
 struct rtnl_link;
 struct rtnl_neigh;
 struct rtnl_mdb;
@@ -36,6 +46,97 @@ class switch_interface;
 class tap_manager;
 struct packet;
 
+struct key {
+  int port_id;
+  uint16_t vid;
+
+  key(int port_id, uint16_t vid) : port_id(port_id), vid(vid) {}
+  bool operator<(const struct key &rhs) const {
+    return std::tie(port_id, vid) < std::tie(rhs.port_id, rhs.vid);
+  }
+};
+
+struct bridge_stp_states {
+  // Global STP state: KEY : port_id + vid, state
+  std::map<int, uint8_t> gl_states;
+  std::map<uint16_t, std::map<uint16_t, uint8_t>> pv_states;
+
+  bridge_stp_states() = default;
+  void add_pvlan_state(int port_id, uint16_t vlan_id, uint8_t state) {
+    auto it = pv_states.find(vlan_id);
+    if (it == pv_states.end()) {
+      std::map<uint16_t, uint8_t> pv_map;
+      pv_map.emplace(port_id, state);
+      pv_states.emplace(vlan_id, pv_map);
+      return;
+    }
+
+    auto pv_it = it->second.find(port_id);
+    if (pv_it != it->second.end())
+      pv_it = it->second.erase(pv_it);
+
+    it->second.emplace(port_id, state);
+  }
+
+  void add_global_state(int port_id, uint8_t state) {
+    auto it = gl_states.find(port_id);
+    if (it != gl_states.end())
+      gl_states.erase(it);
+
+    gl_states.emplace(port_id, state);
+  }
+
+  uint8_t get_global_state(int port_id) {
+    auto it = gl_states.find(port_id);
+
+    return (it == gl_states.end()) ? 0 : it->second;
+  }
+
+  uint8_t get_pvlan_state(int port_id, uint16_t vid) {
+    auto it = pv_states.find(vid);
+
+    // no vlan found
+    if (it == pv_states.end())
+      return 0;
+
+    // no port found
+    auto pv_state = it->second.find(port_id);
+    if (pv_state == it->second.end())
+      return 0;
+
+    return pv_state->second;
+  }
+
+  uint8_t get_min(uint8_t g_state, uint8_t pv_state) {
+    return (g_state < pv_state) ? g_state : pv_state;
+  }
+
+  std::map<uint16_t, uint8_t> get_min_states(int port_id) {
+    std::map<uint16_t, uint8_t> ret;
+    for (auto it : pv_states) {
+      auto pv_it = it.second.find(port_id);
+      if (pv_it == it.second.end())
+        continue;
+
+      ret.emplace(it.first, pv_it->second);
+    }
+    return ret;
+  }
+
+  int get_min_state(int port_id, uint16_t vid) {
+    int g_state = get_global_state(port_id);
+    int pv_state = get_pvlan_state(port_id, vid);
+
+    if (pv_state == 0)
+      return 0;
+
+    if (g_state == BR_STATE_BLOCKING || pv_state == BR_STATE_BLOCKING)
+      return g_state;
+
+    return get_min(g_state, pv_state);
+  }
+};
+
 class nl_bridge {
 public:
   nl_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
@@ -44,7 +145,10 @@ public:
 
   virtual ~nl_bridge();
 
+  int set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info);
+
   void set_bridge_interface(rtnl_link *);
+  bool is_bridge_interface(int ifindex);
   bool is_bridge_interface(rtnl_link *);
 
   void add_interface(rtnl_link *);
@@ -87,12 +191,16 @@ public:
                           const uint32_t tunnel_id, bool add);
 
 private:
+  struct bridge_stp_states bridge_stp_states;
+  std::string stp_state_to_string(uint8_t state);
+
   void update_vlans(rtnl_link *, rtnl_link *);
 
   void update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
                            const uint16_t vid, const uint32_t tunnel_id,
                            const std::deque<rtnl_link *> &bridge_ports,
                            bool add);
+
   rtnl_link *bridge;
   switch_interface *sw;
   std::shared_ptr<tap_manager> tap_man;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2171,7 +2171,7 @@ int controller::tunnel_port_tenant_remove(uint32_t lport_id,
 int controller::lookup_stpid(uint32_t vlan_id) noexcept {
   auto it = vlan_to_stg.find(vlan_id);
 
-  return (it == vlan_to_stg.end()) ? 1 : it->second;
+  return (it == vlan_to_stg.end()) ? 0 : it->second;
 }
 
 int controller::ofdpa_stg_destroy(uint16_t vlan_id) noexcept { return 0; }
@@ -2180,6 +2180,8 @@ int controller::ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
                                          std::string state) noexcept {
   int rv;
   int stg_id = lookup_stpid(vlan_id);
+  if (stg_id == 0)
+    stg_id = 1;
 
   rv = ofdpa->ofdpaStgStatePortSet(port_id, state, stg_id);
   if (rv < 0) {

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2168,25 +2168,63 @@ int controller::tunnel_port_tenant_remove(uint32_t lport_id,
   return rv;
 }
 
-// TODO Unimplemented
-#if 0
-int controller::ofdpa_stg_create() noexcept { return 0; }
-int controller::ofdpa_stg_destroy() noexcept { return 0; }
+int controller::lookup_stpid(uint32_t vlan_id) noexcept {
+  auto it = vlan_to_stg.find(vlan_id);
 
-int controller::ofdpa_stg_vlan_add() noexcept { return 0; }
+  return (it == vlan_to_stg.end()) ? 0 : it->second;
+}
 
-int controller::ofdpa_stg_vlan_remove() noexcept { return 0; }
-#endif
+int controller::ofdpa_stg_destroy(uint16_t vlan_id) noexcept { return 0; }
 
-int controller::ofdpa_stg_state_port_set(uint32_t port_id,
+int controller::ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
                                          std::string state) noexcept {
   int rv;
+  int stg_id = lookup_stpid(vlan_id);
 
-  rv = ofdpa->ofdpaStgStatePortSet(port_id, state);
+  rv = ofdpa->ofdpaStgStatePortSet(port_id, state, stg_id);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed to set the STP state";
   }
 
   return rv;
 }
+
+int controller::ofdpa_stg_create(uint16_t vlan_id) noexcept {
+  int rv;
+  int stg_id = lookup_stpid(vlan_id);
+
+  if (stg_id != 0)
+    return stg_id;
+
+  rv = ofdpa->ofdpaStgCreate(current_stg);
+  if (rv < 0) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to create the STP group";
+    return rv;
+  }
+
+  rv = ofdpa->ofdpaStgVlanAdd(vlan_id, current_stg);
+  if (rv < 0) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to add VLAN=" << vlan_id
+               << " to the STP group=" << current_stg;
+    return rv;
+  }
+
+  vlan_to_stg.emplace(std::make_pair(vlan_id, current_stg));
+
+  current_stg++;
+  return rv;
+}
+
+int controller::ofdpa_global_stp_state_port_set(uint32_t port_id,
+                                                std::string state) noexcept {
+  int rv;
+
+  rv = ofdpa->ofdpaGlobalStpStatePortSet(port_id, state);
+  if (rv < 0) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to set the STP state";
+  }
+
+  return rv;
+}
+
 } // namespace basebox

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2171,7 +2171,7 @@ int controller::tunnel_port_tenant_remove(uint32_t lport_id,
 int controller::lookup_stpid(uint32_t vlan_id) noexcept {
   auto it = vlan_to_stg.find(vlan_id);
 
-  return (it == vlan_to_stg.end()) ? 0 : it->second;
+  return (it == vlan_to_stg.end()) ? 1 : it->second;
 }
 
 int controller::ofdpa_stg_destroy(uint16_t vlan_id) noexcept { return 0; }
@@ -2212,18 +2212,6 @@ int controller::ofdpa_stg_create(uint16_t vlan_id) noexcept {
   vlan_to_stg.emplace(std::make_pair(vlan_id, current_stg));
 
   current_stg++;
-  return rv;
-}
-
-int controller::ofdpa_global_stp_state_port_set(uint32_t port_id,
-                                                std::string state) noexcept {
-  int rv;
-
-  rv = ofdpa->ofdpaGlobalStpStatePortSet(port_id, state);
-  if (rv < 0) {
-    LOG(ERROR) << __FUNCTION__ << ": failed to set the STP state";
-  }
-
   return rv;
 }
 

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -67,6 +67,7 @@ public:
   }
 
   ~controller() override {}
+  int lookup_stpid(uint32_t vlan_id) noexcept;
 
 protected:
   void handle_conn_established(rofl::crofdpt &dpt,
@@ -298,24 +299,20 @@ public:
                                 uint32_t tunnel_id) noexcept override;
 
   /* STP */
-#if 0 
-  // TODO Unimplemented
   // This set of functions is currently defined in our datamodel
   // but no implementation. It is intented that these functions
   // provide the Per VLAN STP functions
-  // The stg_create and stg_destroy functions implement creating 
+  // The stg_create and stg_destroy functions implement creating
   // other Spanning Tree Groups/Instances
   // the stg_vlan_add and stg_vlan_remove function implements adding/removing
-  // VLANS from a certain STG 
-  int ofdpa_stg_create() noexcept override;
-  int ofdpa_stg_destroy() noexcept override;
+  // VLANS from a certain STG
+  int ofdpa_stg_create(uint16_t vlan_id) noexcept override;
+  int ofdpa_stg_destroy(uint16_t vlan_id) noexcept override;
 
-  int ofdpa_stg_vlan_add() noexcept override;
-  int ofdpa_stg_vlan_remove() noexcept override;
-#endif
-
-  int ofdpa_stg_state_port_set(uint32_t port_id,
+  int ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
                                std::string state) noexcept override;
+  int ofdpa_global_stp_state_port_set(uint32_t port_id,
+                                      std::string state) noexcept override;
 
   /* print this */
   friend std::ostream &operator<<(std::ostream &os, const controller &box) {
@@ -334,6 +331,8 @@ private:
   std::map<uint16_t, std::set<uint32_t>> l2_domain;
   std::map<uint16_t, std::set<uint32_t>> lag;
   std::map<uint16_t, std::set<uint32_t>> tunnel_dlf_flood;
+  std::map<uint16_t, uint32_t> vlan_to_stg;
+  uint32_t current_stg = 2;
 
   struct multicast_entry {
     // mmac, vlan

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -311,8 +311,6 @@ public:
 
   int ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
                                std::string state) noexcept override;
-  int ofdpa_global_stp_state_port_set(uint32_t port_id,
-                                      std::string state) noexcept override;
 
   /* print this */
   friend std::ostream &operator<<(std::ostream &os, const controller &box) {

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -319,25 +319,6 @@ ofdpa_client::ofdpaStgStatePortSet(uint32_t port_id, std::string state,
 }
 
 ofdpa::OfdpaStatus::OfdpaStatusCode
-ofdpa_client::ofdpaGlobalStpStatePortSet(uint32_t port_id, std::string state) {
-  ::OfdpaStatus response;
-  ::ClientContext context;
-  ::StpInterfaceState request;
-
-  context.set_wait_for_ready(true);
-
-  request.set_port_num(port_id);
-  request.set_port_state(state);
-
-  ::Status rv = stub_->ofdpaGlobalStpStatePortSet(&context, request, &response);
-  if (not rv.ok()) {
-    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
-  }
-
-  return response.status();
-}
-
-ofdpa::OfdpaStatus::OfdpaStatusCode
 ofdpa_client::ofdpaStgCreate(uint16_t stg_id) {
   ::OfdpaStatus response;
   ::ClientContext context;

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -298,20 +298,86 @@ ofdpa_client::ofdpaTunnelPortTenantDelete(uint32_t port_id,
 }
 
 ofdpa::OfdpaStatus::OfdpaStatusCode
-ofdpa_client::ofdpaStgStatePortSet(uint32_t port_id, std::string state) {
+ofdpa_client::ofdpaStgStatePortSet(uint32_t port_id, std::string state,
+                                   uint32_t stg_id) {
   ::OfdpaStatus response;
   ::ClientContext context;
-  ::openconfig_spanning_tree::Stp_Rstp_Interface_State request;
+  ::StpInterfaceState request;
 
   context.set_wait_for_ready(true);
 
-  request.set_name(std::to_string(port_id));
+  request.set_port_num(port_id);
   request.set_port_state(state);
+  request.mutable_stg_id()->set_id(stg_id);
 
   ::Status rv = stub_->ofdpaStgStatePortSet(&context, request, &response);
   if (not rv.ok()) {
     return ofdpa::OfdpaStatus::OFDPA_E_RPC;
   }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaGlobalStpStatePortSet(uint32_t port_id, std::string state) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::StpInterfaceState request;
+
+  context.set_wait_for_ready(true);
+
+  request.set_port_num(port_id);
+  request.set_port_state(state);
+
+  ::Status rv = stub_->ofdpaGlobalStpStatePortSet(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaStgCreate(uint16_t stg_id) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::StgId request;
+
+  context.set_wait_for_ready(true);
+  request.set_id(stg_id);
+
+  ::Status rv = stub_->ofdpaStgCreate(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaStgVlanAdd(uint16_t vlanid, uint32_t stgid) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+  ::StgVlan request;
+
+  context.set_wait_for_ready(true);
+  request.mutable_stg_id()->set_id(stgid);
+  request.mutable_vlan_id()->set_id(vlanid);
+
+  ::Status rv = stub_->ofdpaStgVlanAdd(&context, request, &response);
+  if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+ofdpa::OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaStgVlanRemove(uint16_t vlan_id, uint32_t stg_id) {
+  ::OfdpaStatus response;
+  ::ClientContext context;
+
+  context.set_wait_for_ready(true);
 
   return response.status();
 }
@@ -411,6 +477,7 @@ ofdpa_client::ofdpaTrunkPortPSCSet(uint32_t lag_id, uint8_t mode) {
   if (not rv.ok()) {
     return ofdpa::OfdpaStatus::OFDPA_E_RPC;
   }
+
   return response.status();
 }
 

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "api/ofdpa.grpc.pb.h"
-#include "stp/openconfig-spanning-tree.pb.h"
 
 using grpc::Channel;
 
@@ -55,16 +54,19 @@ public:
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelPortTenantDelete(uint32_t port_id, uint32_t tunnel_id);
 
-#if 0
-  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgCreate();
-  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgDestroy();
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgCreate(uint16_t stg_id);
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgDestroy(uint16_t stg_id);
 
-  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanAdd();
-  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanRemove();
-#endif
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanAdd(uint16_t vlanid,
+                                                      uint32_t stgid);
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgVlanRemove(uint16_t vlan_id,
+                                                         uint32_t stg_id);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgStatePortSet(uint32_t port_id,
-                                                           std::string state);
+                                                           std::string state,
+                                                           uint32_t stg_id = 0);
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  ofdpaGlobalStpStatePortSet(uint32_t port_id, std::string state);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   OfdpaTrunkCreate(uint32_t lag_id, std::string name, uint8_t mode);

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -65,8 +65,6 @@ public:
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgStatePortSet(uint32_t port_id,
                                                            std::string state,
                                                            uint32_t stg_id = 0);
-  ofdpa::OfdpaStatus::OfdpaStatusCode
-  ofdpaGlobalStpStatePortSet(uint32_t port_id, std::string state);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   OfdpaTrunkCreate(uint32_t lag_id, std::string name, uint8_t mode);

--- a/src/sai.h
+++ b/src/sai.h
@@ -223,24 +223,17 @@ public:
   /* @} */
 
   /* @ STP  { */
-#if 0
-  // TODO Unimplemented
-  // This set of functions is currently defined in our datamodel
-  // but no implementation. It is intented that these functions
-  // provide the Per VLAN STP functions
-  // The stg_create and stg_destroy functions implement creating 
+  // The stg_create and stg_destroy functions implement creating
   // other Spanning Tree Groups/Instances
   // the stg_vlan_add and stg_vlan_remove function implements adding/removing
-  // VLANS from a certain STG 
-  virtual int ofdpa_stg_create() noexcept = 0;
-  virtual int ofdpa_stg_destroy() noexcept = 0;
+  // VLANS from a certain STG
+  virtual int ofdpa_stg_create(uint16_t vlan_id) noexcept = 0;
+  virtual int ofdpa_stg_destroy(uint16_t vlan_id) noexcept = 0;
 
-  virtual int ofdpa_stg_vlan_add() noexcept = 0;
-  virtual int ofdpa_stg_vlan_remove() noexcept = 0;
-#endif
-
-  virtual int ofdpa_stg_state_port_set(uint32_t port_id,
+  virtual int ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
                                        std::string state) noexcept = 0;
+  virtual int ofdpa_global_stp_state_port_set(uint32_t port_id,
+                                              std::string state) noexcept = 0;
   /* @} */
 };
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -232,8 +232,6 @@ public:
 
   virtual int ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
                                        std::string state) noexcept = 0;
-  virtual int ofdpa_global_stp_state_port_set(uint32_t port_id,
-                                              std::string state) noexcept = 0;
   /* @} */
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR aims to add Per VLAN spanning tree state functionality to baseboxd, required by protocols like MSTP and PVST. 

This is achieved by tracking the VLAN Database changes in the kernel, that stores VLAN and STP states in all Linux interfaces(tap/bridge/bond/...). The kernel reports changes to the database via NETLINK messages RTM_GET/NEW/DELVLAN, and baseboxd is able to cache these messages via libnl. See: https://github.com/rubensfig/libnl/tree/bridge_vlandb

Setting the state on the ASIC is done via the gRPC connection, with the model from https://github.com/bisdn/basebox-protobuf/pull/9.

## Description
<!--- Describe your changes in detail -->
This PR adds receiving and parsing of VLAN Database STP states to nl_bridge, where all bridging related events are handled. We obtain the Kernel changes to the VLAN DB via NETLINK, and then process the resulting bridge vlan object to reflect the state on the ASIC. 

We streamlined behaviour in global STP state handling in the ASIC by setting the first STG (spanning tree group), enabled with all VLANS and all ports. When the RTM_NEWVLAN message is received we obtain the interface index of a port, the port state and VLAN, and map that VLAN id onto a new or exisiting STG id, therefore allowing us to individually set the port's state on a per VLAN/per port basis. 

## How Has This Been Tested?
Ran internal testing pipelines. Tested with systemd and iproute2
