### PR TITLE
fix various issues with l3 interface handling

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -577,6 +577,13 @@ int nl_l3::del_l3_neigh_egress(struct rtnl_neigh *n) {
   uint16_t vid = vlan->get_vid(link.get());
   auto s_mac = rtnl_link_get_addr(link.get());
 
+  if (nl->is_bridge_interface(ifindex)) {
+    auto fdb_res = nl->search_fdb(vid, d_mac);
+
+    assert(fdb_res.size() == 1);
+    ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
+  }
+
   // XXX TODO del vlan
 
   // remove egress group reference

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1552,21 +1552,16 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
       auto fdb_res = nl->search_fdb(vid, d_mac);
 
       assert(fdb_res.size() == 1);
-      int fdb_neigh_ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
+      ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
+    }
 
-      get_l3_interface_id(fdb_neigh_ifindex, s_mac, d_mac, &l3_interface_id,
-                            vid);
-    } else {
-      rv = get_l3_interface_id(ifindex, s_mac, d_mac, &l3_interface_id, vid);
-      if (rv == -ENODATA) {
-        // add neigh
-        rv = add_l3_egress(ifindex, vid, s_mac, d_mac, &l3_interface_id);
-      } else if (rv < 0) {
-        LOG(ERROR) << __FUNCTION__ << ": add l3 egress failed for neigh "
-                   << OBJ_CAST(n);
-        // XXX TODO create l3 neigh later
-        continue;
-      }
+    // add neigh
+    rv = add_l3_egress(ifindex, vid, s_mac, d_mac, &l3_interface_id);
+    if (rv < 0) {
+      LOG(ERROR) << __FUNCTION__ << ": add l3 egress failed for neigh "
+                 << OBJ_CAST(n);
+      // XXX TODO create l3 neigh later
+      continue;
     }
 
     VLOG(2) << __FUNCTION__ << ": got l3_interface_id=" << l3_interface_id;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -62,7 +62,7 @@ public:
 };
 
 // next hop mapping key: <port_id, vid, src_mac, dst_mac>
-std::unordered_multimap<
+std::unordered_map<
     std::tuple<int, uint16_t, rofl::caddress_ll, rofl::caddress_ll>,
     l3_interface>
     l3_interface_mapping;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1324,32 +1324,21 @@ int nl_l3::get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
   rofl::caddress_ll dst_mac = libnl_lladdr_2_rofl(d_mac);
   auto needle = std::make_tuple(port_id, vid, src_mac, dst_mac);
 
-  auto it = l3_interface_mapping.equal_range(needle);
+  auto it = l3_interface_mapping.find(needle);
 
-  if (it.first == l3_interface_mapping.end()) {
+  if (it == l3_interface_mapping.end()) {
     LOG(ERROR) << __FUNCTION__ << ": l3_interface_id entry not found for port "
                << port_id << ", src_mac " << src_mac << ", dst_mac " << dst_mac
                << ", vid " << vid;
     return -ENODATA;
   }
 
-  for (auto i = it.first; i != it.second; ++i) {
-    if (i->first == needle) {
-      *l3_interface_id = i->second.l3_interface_id;
+  *l3_interface_id = it->second.l3_interface_id;
 
-      VLOG(2) << __FUNCTION__ << ": l3_interface_id " << *l3_interface_id
-              << " found for port " << port_id << ", src_mac " << src_mac
-              << ", dst_mac " << dst_mac << ", vid " << vid;
-      return 0;
-    }
-  }
-
-  LOG(ERROR) << __FUNCTION__ << ": l3_interface_id entry not found for port "
-             << port_id << ", src_mac " << src_mac << ", dst_mac " << dst_mac
-             << ", vid " << vid;
-
-  // not found either
-  return -ENODATA;
+  VLOG(2) << __FUNCTION__ << ": l3_interface_id " << *l3_interface_id
+          << " found for port " << port_id << ", src_mac " << src_mac
+          << ", dst_mac " << dst_mac << ", vid " << vid;
+  return 0;
 }
 
 int nl_l3::add_l3_unicast_route(nl_addr *rt_dst, uint32_t l3_interface_id,

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1675,11 +1675,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
         auto fdb_res = nl->search_fdb(vid, d_mac);
 
         assert(fdb_res.size() == 1);
-        int fdb_neigh_ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
-        get_l3_interface_id(fdb_neigh_ifindex, s_mac, d_mac, &l3_interface_id,
-                            vid);
-        l3_interfaces.emplace(l3_interface_id);
-        continue;
+        ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
       }
       // add neigh
       rv = get_l3_interface_id(ifindex, s_mac, d_mac, &l3_interface_id, vid);

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1557,7 +1557,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
       get_l3_interface_id(fdb_neigh_ifindex, s_mac, d_mac, &l3_interface_id,
                             vid);
     } else {
-      rv = get_l3_interface_id(ifindex, s_mac, d_mac, &l3_interface_id);
+      rv = get_l3_interface_id(ifindex, s_mac, d_mac, &l3_interface_id, vid);
       if (rv == -ENODATA) {
         // add neigh
         rv = add_l3_neigh_egress(n, &l3_interface_id);
@@ -1682,7 +1682,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
         continue;
       }
       // add neigh
-      rv = get_l3_interface_id(ifindex, s_mac, d_mac, &l3_interface_id);
+      rv = get_l3_interface_id(ifindex, s_mac, d_mac, &l3_interface_id, vid);
 
       if (rv < 0) {
         LOG(ERROR) << __FUNCTION__


### PR DESCRIPTION
## Description
Reference counting was severily broken for l3 interfaces, which causes baseboxd trying to remove l3 unicast groups before we removed all references to them, causing ids being reused and a desync between baseboxd and openflow.

These commits attempt at fixing the most egregious instances, namely:
* nl_l3::add_l3_egress() not increasing the refcount for existing l3_interfaces
* nl_l3::add_l3_unicast_route() only getting the l3_interface_ids, but not increasing refcounts if they exist, but nl_l3::del_l3_unicast_route() always calling calling nl_l3::del_l3_neigh_egress(), leading to an imbalance in refcounts.
* nl_l3::del_l3_neigh_egress() not handling neighbors on bridge SVI interfaces
* nl_l3::add_l3_neigh(): creating an l3 egress interface before checking if the address should be handled

## How Has This Been Tested?
Testing pipelines were run on agema ag7648, ag5648 and accton as4610, all succeeding.