### PR TITLE
fix updating routes when nexthop becomes available

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -815,8 +815,7 @@ int nl_l3::update_l3_neigh(struct rtnl_neigh *n_old, struct rtnl_neigh *n_new) {
 
     uint32_t l3_interface_id = it_old->second.l3_interface_id;
     rv = sw->l3_egress_update(port_id, vid, libnl_lladdr_2_rofl(s_mac),
-                              libnl_lladdr_2_rofl(n_ll_new),
-                              &l3_interface_id);
+                              libnl_lladdr_2_rofl(n_ll_new), &l3_interface_id);
     if (rv < 0) {
       VLOG(2) << __FUNCTION__ << ": failed to update neighbor";
       return -EINVAL;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -659,8 +659,7 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
 
   for (auto cb = std::begin(nh_callbacks); cb != std::end(nh_callbacks);) {
     if (cb->second.nh.ifindex == rtnl_neigh_get_ifindex(n) &&
-        nl_addr_get_family(cb->second.np.addr) == rtnl_neigh_get_family(n) &&
-        nl_addr_cmp(cb->second.np.addr, rtnl_neigh_get_dst(n)) == 0) {
+        nl_addr_cmp(cb->second.nh.nh, rtnl_neigh_get_dst(n)) == 0) {
       // XXX TODO add l3_interface?
       cb->first->nh_reachable_notification(cb->second);
       cb = nh_callbacks.erase(cb);

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <deque>
+#include <list>
 #include <memory>
 #include <set>
 
@@ -122,8 +123,8 @@ private:
   switch_interface *sw;
   std::shared_ptr<nl_vlan> vlan;
   cnetlink *nl;
-  std::deque<std::pair<net_reachable *, net_params>> net_callbacks;
-  std::deque<std::pair<nh_reachable *, nh_params>> nh_callbacks;
+  std::list<std::pair<net_reachable *, net_params>> net_callbacks;
+  std::list<std::pair<nh_reachable *, nh_params>> nh_callbacks;
   const uint8_t MAIN_ROUTING_TABLE = 254;
 };
 

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -31,7 +31,7 @@ class nl_vlan;
 class nl_bridge;
 class switch_interface;
 
-class nl_l3 {
+class nl_l3 : public nh_reachable {
 public:
   nl_l3(std::shared_ptr<nl_vlan> vlan, cnetlink *nl);
   ~nl_l3() {}
@@ -65,7 +65,8 @@ public:
 
   void notify_on_net_reachable(net_reachable *f, struct net_params p) noexcept;
   void notify_on_nh_reachable(nh_reachable *f, struct nh_params p) noexcept;
-  void notify_on_nh_resolved(struct net_params p) noexcept;
+
+  void nh_reachable_notification(struct nh_params) noexcept override;
 
 private:
   int get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
@@ -123,7 +124,6 @@ private:
   cnetlink *nl;
   std::deque<std::pair<net_reachable *, net_params>> net_callbacks;
   std::deque<std::pair<nh_reachable *, nh_params>> nh_callbacks;
-  std::deque<net_params> net_resolved_callbacks; // handle the unknown nexthops
   const uint8_t MAIN_ROUTING_TABLE = 254;
 };
 


### PR DESCRIPTION
Fix several issues preventing routes with unresolved nexthops being updated when the nexthop becomes available.

1. On adding l3 neighbors, when we check the nh_resolved_callbacks we compare the l3 address of the neighbor with the route destination networks waiting for a nexthop to become available. Fix this by comparing the l3 neighbor address with the nexthop address stored in the callback request's data instead.
2. The net_resolved_resolved callbacks only have the net, not the nexthop, which makes them unable to know when the nexthop becomes available for a route. Instead of trying to add this, just register for a nh_resolved_callback and drop the net_resolved_callback code.
3. The registered callbacks are stored in a `std:deque`, but `std:deque` behaves weird when removing elements that are not at the top or bottom, which leads to rerence count mismatches and ultimately use-after-free issues (as well as memory leaks). Fix this by using `std:list`s instead, which are made for arbitrary manipulation.

These three together fix the issue that routes that were installed before the nexthop was known were never updated, causing routing to be done in software.

Tested on as4610.