### PR TITLE
nl_l3: update Link Layer Egress Entries

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -588,7 +588,7 @@ int nl_l3::del_l3_neigh_egress(struct rtnl_neigh *n) {
 
   // remove egress group reference
   int rv = del_l3_egress(ifindex, vid, s_mac, d_mac);
-  if (rv < 0) {
+  if (rv < 0 and rv != -EEXIST) {
     LOG(ERROR) << __FUNCTION__ << ": failed to add l3 egress";
   }
 
@@ -872,6 +872,22 @@ int nl_l3::del_l3_neigh(struct rtnl_neigh *n) {
   if (s_mac && d_mac)
     rv = del_l3_egress(ifindex, vid, s_mac, d_mac);
 
+  // if a route still exists thats pointing to the nexthop,
+  // update the route to point to controller and delete the nexthop egress 
+  // reference
+  if (rv == -EEXIST) {
+    for (auto cb = std::begin(nh_unreach_callbacks);
+         cb != std::end(nh_unreach_callbacks);) {
+      if (cb->second.nh.ifindex == rtnl_neigh_get_ifindex(n) &&
+          nl_addr_cmp(cb->second.nh.nh, rtnl_neigh_get_dst(n)) == 0) {
+        cb->first->nh_unreachable_notification(n, cb->second);
+        cb = nh_unreach_callbacks.erase(cb);
+      } else {
+        ++cb;
+      }
+    }
+  }
+
   return rv;
 }
 
@@ -959,8 +975,7 @@ int nl_l3::del_l3_egress(int ifindex, uint16_t vid, const struct nl_addr *s_mac,
         return rv;
       }
     }
-
-    return 0;
+    return -EEXIST;
   }
 
   LOG(ERROR) << __FUNCTION__
@@ -1275,6 +1290,11 @@ void nl_l3::notify_on_nh_reachable(nh_reachable *f,
   nh_callbacks.emplace_back(f, p);
 }
 
+void nl_l3::notify_on_nh_unreachable(nh_unreachable *f,
+                                     struct nh_params p) noexcept {
+  nh_unreach_callbacks.emplace_back(f, p);
+}
+
 int nl_l3::get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
                                const struct nl_addr *d_mac,
                                uint32_t *l3_interface_id, uint16_t vid) {
@@ -1494,6 +1514,14 @@ void nl_l3::nh_reachable_notification(struct nh_params p) noexcept {
   nl_object_put(OBJ_CAST(rt));
 }
 
+void nl_l3::nh_unreachable_notification(struct rtnl_neigh *n,
+                                        struct nh_params p) noexcept {
+  // TODO handle VRF
+  add_l3_unicast_route(p.np.addr, 0, false, true, 0);
+  del_l3_neigh_egress(n);
+  notify_on_nh_reachable(this, p);
+}
+
 int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
   assert(r);
   int nnhs = rtnl_route_get_nnexthops(r);
@@ -1566,6 +1594,13 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
 
     VLOG(2) << __FUNCTION__ << ": got l3_interface_id=" << l3_interface_id;
     l3_interfaces.emplace(l3_interface_id);
+
+    // Register route to track nexthop changes
+    struct nh_stub nh {
+      rtnl_neigh_get_dst(n), ifindex
+    };
+    notify_on_nh_unreachable(
+        this, nh_params{net_params{rtnl_route_get_dst(r), nh.ifindex}, nh});
   }
 
   switch (nnhs) {
@@ -1718,7 +1753,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
     }
     rv = del_l3_egress(ifindex, vid, s_mac, d_mac);
 
-    if (rv < 0) {
+    if (rv < 0 and rv != -EEXIST) {
       // clean up
       LOG(ERROR) << __FUNCTION__ << ": del l3 egress failed for neigh "
                  << OBJ_CAST(n);

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -833,6 +833,16 @@ int nl_l3::del_l3_neigh(struct rtnl_neigh *n) {
     rv = sw->l3_unicast_host_remove(ipv4_dst);
   } else {
     addr = rtnl_neigh_get_dst(n);
+
+    auto p = nl_addr_alloc(16);
+    nl_addr_parse("fe80::/10", AF_INET6, &p);
+    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
+
+    if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
+      VLOG(1) << __FUNCTION__ << ": skipping fe80::/10";
+      return 0;
+    }
+
     rofl::caddress_in6 ipv6_dst = libnl_in6addr_2_rofl(addr, &rv);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": could not parse addr " << addr;

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -32,7 +32,7 @@ class nl_vlan;
 class nl_bridge;
 class switch_interface;
 
-class nl_l3 : public nh_reachable {
+class nl_l3 : public nh_reachable, public nh_unreachable {
 public:
   nl_l3(std::shared_ptr<nl_vlan> vlan, cnetlink *nl);
   ~nl_l3() {}
@@ -66,8 +66,11 @@ public:
 
   void notify_on_net_reachable(net_reachable *f, struct net_params p) noexcept;
   void notify_on_nh_reachable(nh_reachable *f, struct nh_params p) noexcept;
+  void notify_on_nh_unreachable(nh_unreachable *f, struct nh_params p) noexcept;
 
   void nh_reachable_notification(struct nh_params) noexcept override;
+  void nh_unreachable_notification(struct rtnl_neigh *,
+                                   struct nh_params) noexcept override;
 
 private:
   int get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
@@ -125,6 +128,7 @@ private:
   cnetlink *nl;
   std::list<std::pair<net_reachable *, net_params>> net_callbacks;
   std::list<std::pair<nh_reachable *, nh_params>> nh_callbacks;
+  std::list<std::pair<nh_unreachable *, nh_params>> nh_unreach_callbacks;
   const uint8_t MAIN_ROUTING_TABLE = 254;
 };
 

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -73,4 +73,11 @@ public:
   virtual void nh_reachable_notification(struct nh_params) noexcept = 0;
 };
 
+class nh_unreachable {
+public:
+  virtual ~nh_unreachable() = default;
+  virtual void nh_unreachable_notification(struct rtnl_neigh *,
+                                           struct nh_params) noexcept = 0;
+};
+
 } // namespace basebox

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1338,6 +1338,8 @@ int controller::l3_unicast_route_add(const rofl::caddress_in4 &ipv4_dst,
                               fm_driver.enable_ipv4_unicast_lpm(
                                   dpt.get_version(), ipv4_dst, mask,
                                   l3_interface_id, update_route, vrf_id));
+
+    dpt.send_barrier_request(rofl::cauxid(0));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1379,6 +1381,8 @@ int controller::l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
                               fm_driver.enable_ipv6_unicast_lpm(
                                   dpt.get_version(), ipv6_dst, mask,
                                   l3_interface_id, update_route, vrf_id));
+
+    dpt.send_barrier_request(rofl::cauxid(0));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR deals with updating L3 egress entries. 
There are L3 egress entries being removed on IPv6 Link Layer addresses neigh removal. This is a mismatch since we are not refcounting ipv6 ll addresses.

Additionally, we have to track nexthop changes, more specifically updating routes over a nexthop when it turns unreachable. This is done via registering a route and its nexthop on addition, and waiting on this object until the corresponding nexthop gets deleted via del_l3_neigh. We then rewrite the route to controller, which is a mismatch to Linux state. Linux "wipes" the route from the kernel state, but we do not receive a specific notification for this event.

## How Has This Been Tested?
Internal static-route test on the 4610.
