### PR TITLE
properly link against libpthread if needed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,8 @@ endif
 
 grpc_reflection = cppc.find_library('grpc++_reflection', required: false)
 
+threadlibs = dependency('threads')
+
 # set up generators
 protoc_gen = generator(protoc,
   output    : ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
@@ -226,6 +228,7 @@ executable('baseboxd',
     librofl_ofdpa,
     libsystemd,
     protobuf,
+    threadlibs,
   ],
   install: true,
   install_dir: bindir)


### PR DESCRIPTION
Newer GCC versions require explicit linking against libs. Since we need
libpthread, we should properly pull it in as a depedency. Luckily there
is an easy meson dependency for that.

Fixes the following build error with yocto dunfell:

| FAILED: baseboxd
| x86_64-poky-linux-g++ -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot  -o baseboxd 'baseboxd@exe/meson-generated_api_ofdpa.pb.cc.o' 'baseboxd@exe/meson-generated_common_empty.pb.cc.o' 'baseboxd@exe/meson-generated_common_openconfig-interfaces.pb.cc.o' 'baseboxd@exe/meson-generated_statistics_statistics-service.pb.cc.o' 'baseboxd@exe/meson-generated_api_ofdpa.grpc.pb.cc.o' 'baseboxd@exe/meson-generated_statistics_statistics-service.grpc.pb.cc.o' 'baseboxd@exe/src_basebox_api.cc.o' 'baseboxd@exe/src_basebox_grpc_statistics.cc.o' 'baseboxd@exe/src_baseboxd.cc.o' 'baseboxd@exe/src_netlink_cnetlink.cc.o' 'baseboxd@exe/src_netlink_ctapdev.cc.o' 'baseboxd@exe/src_netlink_nbi_impl.cc.o' 'baseboxd@exe/src_netlink_netlink-utils.cc.o' 'baseboxd@exe/src_netlink_nl_bond.cc.o' 'baseboxd@exe/src_netlink_nl_bridge.cc.o' 'baseboxd@exe/src_netlink_nl_interface.cc.o' 'baseboxd@exe/src_netlink_nl_l3.cc.o' 'baseboxd@exe/src_netlink_nl_obj.cc.o' 'baseboxd@exe/src_netlink_nl_output.cc.o' 'baseboxd@exe/src_netlink_nl_vlan.cc.o' 'baseboxd@exe/src_netlink_nl_vxlan.cc.o' 'baseboxd@exe/src_netlink_tap_io.cc.o' 'baseboxd@exe/src_netlink_tap_manager.cc.o' 'baseboxd@exe/src_of-dpa_controller.cc.o' 'baseboxd@exe/src_of-dpa_ofdpa_client.cc.o' -Wl,--no-undefined -Wl,-O1 -Wl,--hash-style=gnu -fstack-protector-strong -Wl,-z,relro,-z,now -Wl,--start-group -lssl -lcrypto -Wl,--no-as-needed /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/../lib/libglog.so -lgrpc -lgrpc++_reflection -lgrpc++ /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/../lib/libgflags.so /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/libnl-3.so /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/libnl-route-3.so /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/librofl_common.so /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/librofl_ofdpa.so /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/lib/libsystemd.so /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/usr/lib/libprotobuf.so -Wl,--end-group
| /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/../../libexec/x86_64-poky-linux/gcc/x86_64-poky-linux/9.3.0/ld: baseboxd@exe/src_baseboxd.cc.o: undefined reference to symbol 'pthread_rwlock_destroy@@GLIBC_2.2.5'
| /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/../../libexec/x86_64-poky-linux/gcc/x86_64-poky-linux/9.3.0/ld: /tmp/work/corei7-64-poky-linux/baseboxd/1.9.4-r0/recipe-sysroot/lib/libpthread.so.0: error adding symbols: DSO missing from command line
| collect2: error: ld returned 1 exit status
| ninja: build stopped: subcommand failed.
| WARNING: exit code 1 from a shell command.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>