### PR TITLE
cnetlink: delay thread running state until tap interfaces are created

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -630,9 +630,11 @@ void cnetlink::nl_cb_v2(struct nl_cache *cache, struct nl_object *old_obj,
   assert(data);
   auto nl = static_cast<cnetlink *>(data);
 
-  // only enqueue nl msgs if not in stopped state
-  if (nl->state != NL_STATE_STOPPED)
-    nl->nl_objs.emplace_back(action, old_obj, new_obj);
+  // Enqueue the messages regardless of the state
+  // Due to the cache synch, we will enqueue the objects
+  // from the start of the netlink thread, ensuring baseboxd
+  // will process all events from the nl caches
+  nl->nl_objs.emplace_back(action, old_obj, new_obj);
 }
 
 void cnetlink::set_tapmanager(std::shared_ptr<tap_manager> tm) {

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -17,7 +17,6 @@ nbi_impl::nbi_impl(std::shared_ptr<cnetlink> nl,
                    std::shared_ptr<tap_manager> tap_man)
     : nl(nl), tap_man(tap_man) {
   nl->set_tapmanager(tap_man);
-  nl->start();
 }
 
 nbi_impl::~nbi_impl() { nl->stop(); }
@@ -27,6 +26,22 @@ void nbi_impl::resend_state() noexcept { nl->resend_state(); }
 void nbi_impl::register_switch(switch_interface *swi) noexcept {
   this->swi = swi;
   nl->register_switch(swi);
+}
+
+void nbi_impl::switch_state_notification(enum switch_state state) noexcept {
+  switch (state) {
+  case SWITCH_STATE_UP:
+    nl->start();
+    break;
+  case SWITCH_STATE_DOWN:
+  case SWITCH_STATE_FAILED:
+  case SWITCH_STATE_UNKNOWN:
+    nl->stop();
+    break;
+  default:
+    LOG(FATAL) << __FUNCTION__ << ": invalid state";
+    break;
+  }
 }
 
 void nbi_impl::port_notification(

--- a/src/netlink/nbi_impl.h
+++ b/src/netlink/nbi_impl.h
@@ -25,6 +25,7 @@ public:
 
   // nbi
   void register_switch(switch_interface *) noexcept override;
+  void switch_state_notification(enum switch_state) noexcept override;
   void resend_state() noexcept override;
   void
   port_notification(std::deque<port_notification_data> &) noexcept override;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -127,6 +127,8 @@ void controller::handle_dpt_close(const rofl::cdptid &dptid) {
   }
 
   this->dptid = rofl::cdptid(0);
+
+  nb->switch_state_notification(nbi::SWITCH_STATE_DOWN);
 }
 
 void controller::handle_conn_terminated(rofl::crofdpt &dpt,
@@ -170,6 +172,7 @@ void controller::handle_features_reply(
     rofl::openflow::cofmsg_features_reply &msg) {
   VLOG(1) << __FUNCTION__ << ": dpt=" << dpt << " on auxid=" << auxid
           << ", msg: " << msg;
+  nb->switch_state_notification(nbi::SWITCH_STATE_UP);
 }
 
 void controller::handle_barrier_reply(

--- a/src/sai.h
+++ b/src/sai.h
@@ -264,6 +264,13 @@ public:
     port_type_lag = 2,
   };
 
+  enum switch_state {
+    SWITCH_STATE_UNKNOWN,
+    SWITCH_STATE_UP,
+    SWITCH_STATE_DOWN,
+    SWITCH_STATE_FAILED,
+  };
+
   static uint32_t combine_port_type(uint16_t port_num, enum port_type type) {
     return (uint32_t)port_num | type << 16;
   }
@@ -277,6 +284,7 @@ public:
   }
 
   virtual void register_switch(switch_interface *) noexcept = 0;
+  virtual void switch_state_notification(enum switch_state) noexcept = 0;
   virtual void resend_state() noexcept = 0;
   virtual void
   port_notification(std::deque<port_notification_data> &) noexcept = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to rework the netlink internal state transition from INIT to RUNNING. By setting the state to running after the tap interfaces are created, we delay baseboxd netlink objects processing until after the openflow channel is alive. 

## Motivation and Context
When running baseboxd with systemd-networkd configuring the network state, all configurations are usually set before the ofdpa agent is running. As such we risk losing route and address configuration notifications, thus leaving the switch in an unusable setup. This racy behaviour can be avoided by processing these notifications only after the openflow channel is established.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
