### PR TITLE
do not log netlink messages for loopback devices

### DIFF
--- a/src/netlink/netlink-utils.cc
+++ b/src/netlink/netlink-utils.cc
@@ -66,14 +66,14 @@ enum link_type get_link_type(rtnl_link *link) noexcept {
     type = rtnl_link_get_type(link);
   }
 
-  VLOG(4) << __FUNCTION__ << ": type=" << std::string_view(type)
-          << ", slave=" << slave << ", af=" << rtnl_link_get_family(link)
-          << " of link " << OBJ_CAST(link);
-
   // lo has no type
   if (!type) {
     return LT_UNSUPPORTED;
   }
+
+  VLOG(4) << __FUNCTION__ << ": type=" << std::string_view(type)
+          << ", slave=" << slave << ", af=" << rtnl_link_get_family(link)
+          << " of link " << OBJ_CAST(link);
 
   auto it = kind2lt.find(std::string(type));
 


### PR DESCRIPTION
Signed-off-by: Andreas Koepsel <andreas.koepsel@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Swapped code blocks on lines [69-71](https://github.com/bisdn/basebox/blob/master/src/netlink/netlink-utils.cc#L69) and [73-76](https://github.com/bisdn/basebox/blob/master/src/netlink/netlink-utils.cc#L73) in [src/netlink/netlink-utils.cc](https://github.com/bisdn/basebox/blob/master/src/netlink/netlink-utils.cc) to avoid an exception caused by a NULL (string) pointer when the set of initial netlink messages referring to the loopback device  is received and baseboxd's verbosity level causes the VLOG stream to call function rtnl_link_get_family(link).

## Motivation and Context
  - Solves issue #305
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
  - See issue #305 how to reproduce the exception
  - tested against master branch (exception occurs) and branches containing proposed changes (no exception occurs)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
