### PR TITLE
do not call std::string_view() with NULL pointer as argument

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1072,15 +1072,19 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
   int af_old = rtnl_link_get_family(old_link);
   int af_new = rtnl_link_get_family(new_link);
 
-  VLOG(3) << __FUNCTION__ << ": old_link_type="
-          << std::string_view(rtnl_link_get_type(old_link))
-          << ", new_link_type="
-          << std::string_view(rtnl_link_get_type(new_link))
-          << ", old_link_slave_type="
-          << std::string_view(rtnl_link_get_slave_type(old_link))
-          << ", new_link_slave_type="
-          << std::string_view(rtnl_link_get_slave_type(new_link))
-          << ", af_old=" << af_old << ", af_new=" << af_new;
+  if ((rtnl_link_get_type(old_link) != NULL) && (rtnl_link_get_type(new_link) != NULL)) {
+          VLOG(3) << __FUNCTION__ << ": old_link_type="
+                  << std::string_view(rtnl_link_get_type(old_link))
+                  << ", new_link_type="
+                  << std::string_view(rtnl_link_get_type(new_link));
+  }
+  if ((rtnl_link_get_slave_type(old_link) != NULL) && (rtnl_link_get_slave_type(new_link) != NULL)) {
+          VLOG(3) << __FUNCTION__ << ": old_link_slave_type="
+                  << std::string_view(rtnl_link_get_slave_type(old_link))
+                  << ", new_link_slave_type="
+                  << std::string_view(rtnl_link_get_slave_type(new_link))
+                  << ", af_old=" << af_old << ", af_new=" << af_new;
+  }
 
   if (af_old != af_new) {
     VLOG(1) << __FUNCTION__ << ": af changed from " << af_old << " to "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In [cnetlink.cc line 1075](https://github.com/bisdn/basebox/blob/master/src/netlink/cnetlink.cc#L1075) the VLOG call must not call std::string_view(NULL). 
Added two checks to prevent a situation where calling rtnl_link_get_type() or rtnl_link_get_slave_type() yield a NULL pointer, inevitably causing an exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
  - Solves issue #307 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
  - See issue #307 how to reproduce the exception
  - tested against master branch (exception occurs) and branch containing proposed changes (no exception occurs)

