### PR TITLE
nl_l3: fix prefix length check for IPv6 addresses

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -364,7 +364,7 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
   }
 
   // TODO support VRF on IPv6 addresses
-  if (prefixlen == 32)
+  if (prefixlen == 128)
     rv = sw->l3_unicast_host_add(ipv6_dst, 0, false, update, 0);
   else
     rv = sw->l3_unicast_route_add(ipv6_dst, mask, 0, false, update, 0);


### PR DESCRIPTION
IPv6 addresses are is 128 bits wide, not 32. Likely a copy and paste
error from the IPv4 code.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Pipelines using this code have ran over the weekend.