### PR TITLE
properly take over ip configuration on bridge/bond attachment

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -416,6 +416,65 @@ int cnetlink::remove_l3_addresses(rtnl_link *link) {
   return rv;
 }
 
+int cnetlink::add_l3_routes(rtnl_link *link) {
+  int rv = 0;
+  assert(link);
+
+  std::deque<rtnl_route *> routes;
+  l3->get_l3_routes(link, &routes);
+
+  for (auto i : routes) {
+    LOG(INFO) << __FUNCTION__ << ": adding route=" << OBJ_CAST(i);
+
+    switch (rtnl_route_get_family(i)) {
+    case AF_INET:
+    case AF_INET6:
+      rv = l3->add_l3_route(i);
+      break;
+    default:
+      LOG(WARNING) << __FUNCTION__ << ": family not supported: " << rtnl_route_get_family(i)
+	           << " for route=" << OBJ_CAST(i);
+      rv = -EINVAL;
+      break;
+    }
+
+    if (rv < 0)
+      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 route " << OBJ_CAST(i)
+                 << " to " << OBJ_CAST(link);
+  }
+  LOG(INFO) << __FUNCTION__ << ": added l3 routes to " << OBJ_CAST(link);
+
+  return rv;
+}
+
+int cnetlink::remove_l3_routes(rtnl_link *link) {
+  int rv = 0;
+  assert(link);
+
+  std::deque<rtnl_route *> routes;
+  l3->get_l3_routes(link, &routes);
+
+  for (auto i : routes) {
+    switch (rtnl_route_get_family(i)) {
+    case AF_INET:
+    case AF_INET6:
+      rv = l3->del_l3_route(i);
+      break;
+    default:
+      LOG(WARNING) << __FUNCTION__ << ": family not supported: " << rtnl_route_get_family(i)
+	           << " for route=" << OBJ_CAST(i);
+      rv = -EINVAL;
+      break;
+    }
+
+    if (rv < 0)
+      LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 route from "
+                 << OBJ_CAST(link);
+  }
+
+  return rv;
+}
+
 int cnetlink::add_l3_configuration(rtnl_link *link) {
   return add_l3_addresses(link);
 }

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -387,6 +387,43 @@ void cnetlink::get_vlans(int ifindex,
       vlan_list);
 }
 
+int cnetlink::add_l3_address(rtnl_link *link) {
+  int rv = 0;
+  assert(link);
+
+  std::deque<rtnl_addr *> addresses;
+  get_l3_addrs(link, &addresses);
+
+  for (auto i : addresses) {
+    LOG(INFO) << __FUNCTION__ << ": adding address=" << OBJ_CAST(i);
+
+    rv = add_l3_addr(i);
+    if (rv < 0)
+      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 address " << OBJ_CAST(i)
+                 << " to " << OBJ_CAST(link);
+  }
+  LOG(INFO) << __FUNCTION__ << ": added l3 addresses to " << OBJ_CAST(link);
+
+  return rv;
+}
+
+int cnetlink::remove_l3_address(rtnl_link *link) {
+  int rv = 0;
+  assert(link);
+
+  std::deque<rtnl_addr *> addresses;
+  get_l3_addrs(link, &addresses);
+
+  for (auto i : addresses) {
+    rv = del_l3_addr(i);
+    if (rv < 0)
+      LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 address from "
+                 << OBJ_CAST(link);
+  }
+
+  return rv;
+}
+
 struct rtnl_neigh *cnetlink::get_neighbour(int ifindex,
                                            struct nl_addr *a) const {
   assert(ifindex);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1159,10 +1159,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     // We can delete the addresses on the interface because we will later
     // receive a notification readding the addresses, that time with the correct
     // VRF
-    std::deque<rtnl_addr *> addresses;
-    get_l3_addrs(old_link, &addresses);
-    for (auto i : addresses)
-      l3->del_l3_addr(i);
+    remove_l3_address(old_link);
 
     vlan->vrf_attach(old_link, new_link);
   } break;
@@ -1175,11 +1172,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
       // We can delete the addresses on the interface because we will later
       // receive a notification readding the addresses, that time with the
       // correct VRF
-      std::deque<rtnl_addr *> addresses;
-      get_l3_addrs(old_link, &addresses);
-      // delete l3 addresses no longer associated with vrf
-      for (auto i : addresses)
-        l3->del_l3_addr(i);
+      remove_l3_address(old_link);
       vlan->vrf_detach(old_link, new_link);
     } else if (lt_new == LT_VRF_SLAVE) {
       LOG(INFO) << __FUNCTION__ << ": link updated " << OBJ_CAST(new_link);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -476,10 +476,22 @@ int cnetlink::remove_l3_routes(rtnl_link *link) {
 }
 
 int cnetlink::add_l3_configuration(rtnl_link *link) {
-  return add_l3_addresses(link);
+  int rv;
+
+  rv = add_l3_addresses(link);
+  ir (rv < 0)
+    LOG(WARNING) << __FUNCTION__ << ": failed to add l3 addresses: " << rv;
+
+  return add_l3_routes(link);
 }
 
 int cnetlink::remove_l3_configuration(rtnl_link *link) {
+  int rv;
+
+  rv = remove_l3_routes(link);
+  if (rv < 0)
+    LOG(WARNING) << __FUNCTION__ << ": failed to remove l3 routes: " << rv;
+
   return remove_l3_addresses(link);
 }
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -365,7 +365,7 @@ void cnetlink::get_vlans(int ifindex,
       vlan_list);
 }
 
-int cnetlink::add_l3_address(rtnl_link *link) {
+int cnetlink::add_l3_addresses(rtnl_link *link) {
   int rv = 0;
   assert(link);
 
@@ -399,7 +399,7 @@ int cnetlink::add_l3_address(rtnl_link *link) {
   return rv;
 }
 
-int cnetlink::remove_l3_address(rtnl_link *link) {
+int cnetlink::remove_l3_addresses(rtnl_link *link) {
   int rv = 0;
   assert(link);
 
@@ -1151,7 +1151,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     // We can delete the addresses on the interface because we will later
     // receive a notification readding the addresses, that time with the correct
     // VRF
-    remove_l3_address(old_link);
+    remove_l3_addresses(old_link);
 
     vlan->vrf_attach(old_link, new_link);
   } break;
@@ -1164,7 +1164,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
       // We can delete the addresses on the interface because we will later
       // receive a notification readding the addresses, that time with the
       // correct VRF
-      remove_l3_address(old_link);
+      remove_l3_addresses(old_link);
       vlan->vrf_detach(old_link, new_link);
     } else if (lt_new == LT_VRF_SLAVE) {
       LOG(INFO) << __FUNCTION__ << ": link updated " << OBJ_CAST(new_link);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -416,6 +416,14 @@ int cnetlink::remove_l3_addresses(rtnl_link *link) {
   return rv;
 }
 
+int cnetlink::add_l3_configuration(rtnl_link *link) {
+  return add_l3_addresses(link);
+}
+
+int cnetlink::remove_l3_configuration(rtnl_link *link) {
+  return remove_l3_addresses(link);
+}
+
 struct rtnl_neigh *cnetlink::get_neighbour(int ifindex,
                                            struct nl_addr *a) const {
   assert(ifindex);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -335,11 +335,6 @@ std::set<uint32_t> cnetlink::get_bond_members_by_lag(rtnl_link *bond_link) {
   return bond->get_members(bond_link);
 }
 
-int cnetlink::get_l3_addrs(struct rtnl_link *link,
-                           std::deque<rtnl_addr *> *addresses) {
-  return l3->get_l3_addrs(link, addresses);
-}
-
 std::set<uint32_t> cnetlink::get_bond_members_by_port_id(uint32_t port_id) {
   return bond->get_members_by_port_id(port_id);
 }
@@ -392,7 +387,7 @@ int cnetlink::add_l3_address(rtnl_link *link) {
   assert(link);
 
   std::deque<rtnl_addr *> addresses;
-  get_l3_addrs(link, &addresses);
+  l3->get_l3_addrs(link, &addresses);
 
   for (auto i : addresses) {
     LOG(INFO) << __FUNCTION__ << ": adding address=" << OBJ_CAST(i);
@@ -412,7 +407,7 @@ int cnetlink::remove_l3_address(rtnl_link *link) {
   assert(link);
 
   std::deque<rtnl_addr *> addresses;
-  get_l3_addrs(link, &addresses);
+  l3->get_l3_addrs(link, &addresses);
 
   for (auto i : addresses) {
     rv = del_l3_addr(i);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -354,8 +354,6 @@ int cnetlink::add_l3_addr(struct rtnl_addr *a) {
   return -EINVAL;
 }
 
-int cnetlink::del_l3_addr(struct rtnl_addr *a) { return l3->del_l3_addr(a); }
-
 void cnetlink::get_vlans(int ifindex,
                          std::deque<uint16_t> *vlan_list) const noexcept {
   assert(vlan_list);
@@ -410,7 +408,7 @@ int cnetlink::remove_l3_address(rtnl_link *link) {
   l3->get_l3_addrs(link, &addresses);
 
   for (auto i : addresses) {
-    rv = del_l3_addr(i);
+    rv = l3->del_l3_addr(i);
     if (rv < 0)
       LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 address from "
                  << OBJ_CAST(link);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -204,6 +204,8 @@ private:
 
   int add_l3_addresses(rtnl_link *link);
   int remove_l3_addresses(rtnl_link *link);
+  int add_l3_routes(rtnl_link *link);
+  int remove_l3_routes(rtnl_link *link);
 };
 
 } // end of namespace basebox

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -60,7 +60,6 @@ public:
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
   int add_l3_addr(struct rtnl_addr *a);
-  int del_l3_addr(struct rtnl_addr *a);
 
   int add_l3_address(rtnl_link *link);
   int remove_l3_address(rtnl_link *link);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -59,7 +59,6 @@ public:
    */
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
-  int get_l3_addrs(struct rtnl_link *link, std::deque<rtnl_addr *> *addresses);
   int add_l3_addr(struct rtnl_addr *a);
   int del_l3_addr(struct rtnl_addr *a);
 

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -59,8 +59,8 @@ public:
    */
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
-  int add_l3_address(rtnl_link *link);
-  int remove_l3_address(rtnl_link *link);
+  int add_l3_addresses(rtnl_link *link);
+  int remove_l3_addresses(rtnl_link *link);
 
   bool is_bridge_interface(rtnl_link *l) const;
   bool is_bridge_interface(int ifindex) const;

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -63,6 +63,9 @@ public:
   int add_l3_addr(struct rtnl_addr *a);
   int del_l3_addr(struct rtnl_addr *a);
 
+  int add_l3_address(rtnl_link *link);
+  int remove_l3_address(rtnl_link *link);
+
   bool is_bridge_interface(rtnl_link *l) const;
   bool is_bridge_interface(int ifindex) const;
   bool is_bridge_configured(rtnl_link *l);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -53,6 +53,8 @@ public:
 
   void get_vlans(int ifindex, std::deque<uint16_t> *vid_list) const noexcept;
 
+  void get_vlan_links(int ifindex, std::deque<struct rtnl_link *> *vlan_list) const noexcept;
+
   uint16_t get_vrf_table_id(rtnl_link *link);
   /**
    * @return rtnl_neigh* which needs to be freed using rtnl_neigh_put

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -59,8 +59,8 @@ public:
    */
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
-  int add_l3_addresses(rtnl_link *link);
-  int remove_l3_addresses(rtnl_link *link);
+  int add_l3_configuration(rtnl_link *link);
+  int remove_l3_configuration(rtnl_link *link);
 
   bool is_bridge_interface(rtnl_link *l) const;
   bool is_bridge_interface(int ifindex) const;
@@ -201,6 +201,9 @@ private:
   void neigh_ll_created(rtnl_neigh *neigh) noexcept;
   void neigh_ll_updated(rtnl_neigh *old_neigh, rtnl_neigh *new_neigh) noexcept;
   void neigh_ll_deleted(rtnl_neigh *neigh) noexcept;
+
+  int add_l3_addresses(rtnl_link *link);
+  int remove_l3_addresses(rtnl_link *link);
 };
 
 } // end of namespace basebox

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -59,8 +59,6 @@ public:
    */
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
-  int add_l3_addr(struct rtnl_addr *a);
-
   int add_l3_address(rtnl_link *link);
   int remove_l3_address(rtnl_link *link);
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -109,7 +109,7 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
     return 0;
   }
 
-  add_l3_address(new_link);
+  nl->add_l3_address(new_link);
 #endif
 
   return 0;
@@ -288,7 +288,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   // ASIC, but repeated messages will be seen
   // This should be done in ::add_lag, but for currently unknown reasons
   // this fails when the lag has no members yet. So keep it here for now.
-  add_l3_address(bond);
+  nl->add_l3_address(bond);
 #endif
 
   return rv;
@@ -343,7 +343,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
 
     if (lm_rv->second.empty())
-      remove_l3_address(bond);
+      nl->remove_l3_address(bond);
 
     if (nl->is_bridge_interface(bond))
       swi->ofdpa_stg_state_port_set(port_id, 1, "forward");
@@ -391,48 +391,6 @@ int nl_bond::update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave) {
                                   new_state == 0);
 #endif
   return 0;
-}
-
-int nl_bond::add_l3_address(rtnl_link *link) {
-  int rv = 0;
-#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
-  assert(link);
-
-  std::deque<rtnl_addr *> addresses;
-  nl->get_l3_addrs(link, &addresses);
-
-  for (auto i : addresses) {
-    LOG(INFO) << __FUNCTION__ << ": adding address=" << OBJ_CAST(i);
-
-    rv = nl->add_l3_addr(i);
-    if (rv < 0)
-      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 address " << OBJ_CAST(i)
-                 << " to " << OBJ_CAST(link);
-  }
-  LOG(INFO) << __FUNCTION__ << ": added l3 addresses to bond "
-            << OBJ_CAST(link);
-
-#endif
-  return rv;
-}
-
-int nl_bond::remove_l3_address(rtnl_link *link) {
-  int rv = 0;
-#ifdef HAVE_RTNL_LINK_BOND_GET_MODE
-  assert(link);
-
-  std::deque<rtnl_addr *> addresses;
-  nl->get_l3_addrs(link, &addresses);
-
-  for (auto i : addresses) {
-    rv = nl->del_l3_addr(i);
-    if (rv < 0)
-      LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 address from "
-                 << OBJ_CAST(link);
-  }
-
-#endif
-  return rv;
 }
 
 } // namespace basebox

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -109,7 +109,7 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
     return 0;
   }
 
-  nl->add_l3_address(new_link);
+  nl->add_l3_addresses(new_link);
 #endif
 
   return 0;
@@ -288,7 +288,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   // ASIC, but repeated messages will be seen
   // This should be done in ::add_lag, but for currently unknown reasons
   // this fails when the lag has no members yet. So keep it here for now.
-  nl->add_l3_address(bond);
+  nl->add_l3_addresses(bond);
 #endif
 
   return rv;
@@ -343,7 +343,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
 
     if (lm_rv->second.empty())
-      nl->remove_l3_address(bond);
+      nl->remove_l3_addresses(bond);
 
     if (nl->is_bridge_interface(bond))
       swi->ofdpa_stg_state_port_set(port_id, 1, "forward");

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -109,7 +109,7 @@ int nl_bond::update_lag(rtnl_link *old_link, rtnl_link *new_link) {
     return 0;
   }
 
-  nl->add_l3_addresses(new_link);
+  nl->add_l3_configuration(new_link);
 #endif
 
   return 0;
@@ -288,7 +288,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   // ASIC, but repeated messages will be seen
   // This should be done in ::add_lag, but for currently unknown reasons
   // this fails when the lag has no members yet. So keep it here for now.
-  nl->add_l3_addresses(bond);
+  nl->add_l3_configuration(bond);
 #endif
 
   return rv;
@@ -343,7 +343,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
 
     if (lm_rv->second.empty())
-      nl->remove_l3_addresses(bond);
+      nl->remove_l3_configuration(bond);
 
     if (nl->is_bridge_interface(bond))
       swi->ofdpa_stg_state_port_set(port_id, 1, "forward");

--- a/src/netlink/nl_bond.h
+++ b/src/netlink/nl_bond.h
@@ -53,9 +53,6 @@ public:
   int remove_lag_member(rtnl_link *link);
   int update_lag(rtnl_link *old_link, rtnl_link *new_link);
 
-  int add_l3_address(rtnl_link *link);
-  int remove_l3_address(rtnl_link *link);
-
   int update_lag_member(rtnl_link *old_slave, rtnl_link *new_slave);
 
 private:

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -15,6 +15,7 @@
 #include <netlink/route/link/vrf.h>
 #include <netlink/route/neighbour.h>
 #include <netlink/route/route.h>
+#include <netlink/route/nexthop.h>
 #include <netlink/cache.h>
 
 #include "cnetlink.h"
@@ -533,6 +534,29 @@ int nl_l3::get_l3_addrs(struct rtnl_link *link,
         addr->push_back(ADDR_CAST(o));
       },
       addresses);
+  return 0;
+}
+
+int nl_l3::get_l3_routes(struct rtnl_link *link,
+                         std::deque<rtnl_route *> *routes) {
+  std::unique_ptr<rtnl_route, decltype(&rtnl_route_put)> filter(rtnl_route_alloc(),
+                                                                rtnl_route_put);
+  auto nh = rtnl_route_nh_alloc();
+
+  rtnl_route_nh_set_ifindex(nh, rtnl_link_get_ifindex(link));
+  rtnl_route_add_nexthop(filter.get(), nh);
+  rtnl_route_set_type(filter.get(), RTN_UNICAST);
+
+  VLOG(1) << __FUNCTION__
+          << ": searching l3 routes from interface=" << OBJ_CAST(link);
+
+  nl_cache_foreach_filter(
+      nl->get_cache(cnetlink::NL_ROUTE_CACHE), OBJ_CAST(filter.get()),
+      [](struct nl_object *o, void *arg) {
+        auto *route = (std::deque<rtnl_route *> *)arg;
+        route->push_back(ROUTE_CAST(o));
+      },
+      routes);
   return 0;
 }
 

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -55,6 +55,8 @@ public:
   int update_l3_route(struct rtnl_route *r_old, struct rtnl_route *r_new);
   int del_l3_route(struct rtnl_route *r);
 
+  int get_l3_routes(struct rtnl_link *link, std::deque<rtnl_route *> *routes);
+
   void get_nexthops_of_route(rtnl_route *route,
                              std::deque<struct rtnl_nexthop *> *nhs) noexcept;
 


### PR DESCRIPTION
Properly take over configured IP addresses and routes on (first) attachment to bond and bridge interfaces.

## Description

Currently the code does checks for ip and route configuration if it applies to interfaces linked to port interfaces, and ignores if it it doesn't. This makes sense at first, but breaks if the configuration might get added before port interfaces do get attached.

We do attempt to take over IP address configuration on bond interfaces, but miss configuration on linked vlan interfaces, and all configuration on bridge interfaces. Configured routes are completely ignored.

This PR attempts fixing the situation by expanding the code adding the ip addresses to also check all linked vlan interfaces, check the route cache for routes, and also call this on initial attachment to the bridge.

## Motivation and Context

Currently IP configuration on vlan interfaces  can get lost on the following order of network events:

1. create bridge
2. create SVI on top of bridge
3. add ip addresss to SVI
4. set bridge as master for port interfaces

At step three we will see that the brige has no port interfaces, so we ignore the IP address, but then at step 4 we don't scan the interface and add the IP address later.

So we need to be ready to take over the configuration on attachment.

## How Has This Been Tested?
A pipeline was run on Questone 2A