### PR TITLE
cnetlink: ignore bridge attachment for untracked interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1196,6 +1196,14 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
         return;
       }
 
+      // we only care if we attach a link that is backed by openflow,
+      // i.e. a tap device or a bond with attached tap devices
+      if (get_port_id(link) == 0) {
+        VLOG(1) << __FUNCTION__ << ": ignoring untracked interface "
+                << rtnl_link_get_name(link);
+        break;
+      }
+
       auto br_link = get_link_by_ifindex(rtnl_link_get_master(link));
       LOG(INFO) << __FUNCTION__ << ": using bridge "
                 << OBJ_CAST(br_link.get());


### PR DESCRIPTION
Our code adding IP addresses and routes has checks for the bridge having
actual port or bond interfaces attached, else they will get ignored.

So we need to make sure that we do not create the bridge too early, and
only do so when the attached interface is one we track, i.e. has a
port_id.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

## Motivation and Context
Creating the bridge too early might lead to issues when applying the l3 configuration on it.

## How Has This Been Tested?

Weekend pipelines ran with this change applied.