### PR TITLE
make bridge vlan support in libnl optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,10 @@ if cppc.has_header_symbol('netlink/route/link/bonding.h', 'rtnl_link_bond_get_mo
   add_global_arguments('-DHAVE_RTNL_LINK_BOND_GET_MODE',  language: 'cpp')
 endif
 
+if cppc.has_header('netlink/route/bridge_vlan.h', dependencies: libnl, required: false)
+  add_global_arguments('-DHAVE_NETLINK_ROUTE_BRIDGE_VLAN_H',  language: 'cpp')
+endif
+
 libnl_route = dependency('libnl-route-3.0', required: false)
 if not libnl_route.found()
   # find the lib without pkg-config

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -14,7 +14,9 @@
 #include <linux/if.h>
 #include <netlink/object.h>
 #include <netlink/route/addr.h>
+#ifdef HAVE_NETLINK_ROUTE_BRIDGE_VLAN_H
 #include <netlink/route/bridge_vlan.h>
+#endif
 #include <netlink/route/link.h>
 #include <netlink/route/link/bonding.h>
 #include <netlink/route/link/vlan.h>
@@ -179,6 +181,7 @@ void cnetlink::init_caches() {
   }
 #endif
 
+#ifdef HAVE_NETLINK_ROUTE_BRIDGE_VLAN_H
   /* init bridge-vlan cache */
   rc = rtnl_bridge_vlan_alloc_cache_flags(sock_mon, &caches[NL_BVLAN_CACHE],
                                           NL_CACHE_AF_ITER);
@@ -191,6 +194,7 @@ void cnetlink::init_caches() {
   if (0 != rc) {
     LOG(FATAL) << __FUNCTION__ << ": add route/bridge-vlan to cache mngr";
   }
+#endif
 
   try {
     thread.add_read_fd(this, nl_cache_mngr_get_fd(mngr), true, false);
@@ -735,10 +739,12 @@ void cnetlink::handle_wakeup(rofl::cthread &thread) {
       route_mdb_apply(obj);
       break;
 #endif
+#ifdef HAVE_NETLINK_ROUTE_BRIDGE_VLAN_H
     case RTM_NEWVLAN:
     case RTM_DELVLAN:
       route_bridge_vlan_apply(obj);
       break;
+#endif
     default:
       LOG(ERROR) << __FUNCTION__ << ": unexpected netlink type "
                  << obj.get_msg_type();

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -11,7 +11,9 @@
 
 #include <glog/logging.h>
 #include <netlink/route/link.h>
+#ifdef HAVE_NETLINK_ROUTE_BRIDGE_VLAN_H
 #include <netlink/route/bridge_vlan.h>
+#endif
 #ifdef HAVE_NETLINK_ROUTE_MDB_H
 #include <netlink/route/mdb.h>
 #endif
@@ -1078,6 +1080,7 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
   int err = 0;
 
+#ifdef HAVE_NETLINK_ROUTE_BRIDGE_VLAN_H
   if (get_stp_state() == STP_STATE_DISABLED)
     return err;
 
@@ -1102,6 +1105,7 @@ int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
 
   err = sw->ofdpa_stg_state_port_set(nl->get_port_id(ifindex), vlan_id,
                                      stp_state_to_string(g_stp_state));
+#endif
   return err;
 }
 


### PR DESCRIPTION
The bridge vlan support is WIP and not yet submitted upstream. So to
allow building and using baseboxd without a patched libnl, add a check
for the new header and guard the code using it.

Fixes: 186326a ("cnetlink: add support for Linux RTM_NEW/DELVLAN messages;      * add libnl bridge-vlan cache support;")
Reported-by: Andreas Koepsel <andreas.koepsel@bisdn.de>
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>