### PR TITLE
nl_l3: properly handle layer 3 neighbors on bridges

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -732,9 +732,8 @@ int nl_l3::update_l3_neigh(struct rtnl_neigh *n_old, struct rtnl_neigh *n_new) {
   struct nl_addr *n_ll_new;
 
   int ifindex = rtnl_neigh_get_ifindex(n_old);
-  uint32_t port_id = nl->get_port_id(ifindex);
 
-  if (port_id == 0) {
+  if (!nl->is_switch_interface(ifindex)) {
     VLOG(1) << __FUNCTION__ << ": port not supported";
     return -EINVAL;
   }
@@ -786,7 +785,7 @@ int nl_l3::update_l3_neigh(struct rtnl_neigh *n_old, struct rtnl_neigh *n_new) {
       ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
     }
 
-    port_id = nl->get_port_id(ifindex);
+    uint32_t port_id = nl->get_port_id(ifindex);
 
     VLOG(2) << __FUNCTION__ << " : source old mac " << s_mac << " dst old mac  "
             << n_ll_old << " dst new mac " << n_ll_new;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -779,6 +779,15 @@ int nl_l3::update_l3_neigh(struct rtnl_neigh *n_old, struct rtnl_neigh *n_new) {
     auto s_mac = rtnl_link_get_addr(link.get());
     uint16_t vid = vlan->get_vid(link.get());
 
+    if (nl->is_bridge_interface(ifindex)) {
+      auto fdb_res = nl->search_fdb(vid, n_ll_new);
+
+      assert(fdb_res.size() == 1);
+      ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
+    }
+
+    port_id = nl->get_port_id(ifindex);
+
     VLOG(2) << __FUNCTION__ << " : source old mac " << s_mac << " dst old mac  "
             << n_ll_old << " dst new mac " << n_ll_new;
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1798,21 +1798,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
 
   // remove egress references
   for (auto n : neighs) {
-    auto ifindex = rtnl_neigh_get_ifindex(n);
-
-    auto link = nl->get_link_by_ifindex(ifindex);
-    auto vid = vlan->get_vid(link.get());
-
-    struct nl_addr *s_mac = rtnl_link_get_addr(link.get());
-    struct nl_addr *d_mac = rtnl_neigh_get_lladdr(n);
-
-    if (nl->is_bridge_interface(ifindex)) {
-      auto fdb_res = nl->search_fdb(vid, d_mac);
-
-      assert(fdb_res.size() == 1);
-      ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
-    }
-    rv = del_l3_egress(ifindex, vid, s_mac, d_mac);
+    rv = del_l3_neigh_egress(n);
 
     if (rv < 0 and rv != -EEXIST) {
       // clean up

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -899,13 +899,8 @@ int nl_l3::del_l3_neigh(struct rtnl_neigh *n) {
     return rv;
   }
 
-  struct nl_addr *s_mac = rtnl_link_get_addr(link.get());
-  struct nl_addr *d_mac = rtnl_neigh_get_lladdr(n);
-  uint16_t vid = vlan->get_vid(link.get());
-
   // delete l3 unicast group (mac rewrite)
-  if (s_mac && d_mac)
-    rv = del_l3_egress(ifindex, vid, s_mac, d_mac);
+  rv = del_l3_neigh_egress(n);
 
   // if a route still exists thats pointing to the nexthop,
   // update the route to point to controller and delete the nexthop egress 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -832,6 +832,20 @@ int nl_l3::del_l3_neigh(struct rtnl_neigh *n) {
   int family = rtnl_neigh_get_family(n);
   bool skip_addr_remove = false;
 
+  int state = rtnl_neigh_get_state(n);
+
+  switch (state) {
+  case NUD_FAILED:
+    LOG(INFO) << __FUNCTION__ << ": neighbour not reachable state=failed";
+    return -EINVAL;
+  case NUD_INCOMPLETE:
+    LOG(INFO) << __FUNCTION__ << ": neighbour state=incomplete";
+    return 0;
+  case NUD_STALE:
+    LOG(INFO) << __FUNCTION__ << ": neighbour state=stale";
+    break;
+  }
+
   if (n == nullptr)
     return -EINVAL;
 


### PR DESCRIPTION
Fix various issues with layer 3 neighbor handling on bridges.

## Description
Currently multiple codepaths related to updating and deleting layer 3 neighbors were not handling those on bridges due to a port id requirement for the interface, which bridge interfaces don't have.

Fix this by adding the appropriate resolution through the fdb to figure out the physical port, and allow any switch related port for updates.

## Motivation and Context
This fixes the issue that l3 neighbors that were learned in failed state were never updated once they became reachable, were never triggering layer 3 interface creation and therefore no routing in hardware would be setup.

## How Has This Been Tested?
Test pipeline has been run on as4610, all tests passed.
