### PR TITLE
Handle MAC address changes on tap interfaces

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -551,6 +551,10 @@ int cnetlink::remove_l3_configuration(rtnl_link *link) {
   return rv;
 }
 
+int cnetlink::update_on_mac_change(rtnl_link *old_link, rtnl_link *new_link) {
+  return 0;
+}
+
 bool cnetlink::has_l3_addresses(rtnl_link *link) {
   assert(link);
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -552,7 +552,33 @@ int cnetlink::remove_l3_configuration(rtnl_link *link) {
 }
 
 int cnetlink::update_on_mac_change(rtnl_link *old_link, rtnl_link *new_link) {
-  return 0;
+  int rv = 0;
+  int port_id = get_port_id(old_link);
+  uint16_t vid = vlan->get_vid(old_link);
+  struct nl_addr *old_mac = rtnl_link_get_addr(old_link);
+  struct nl_addr *new_mac = rtnl_link_get_addr(new_link);
+
+  rv = l3->update_l3_termination(port_id, vid, old_mac, new_mac);
+  if (rv < 0)
+    VLOG(1) << __FUNCTION__ << ": failed to update termination MAC, old link="
+            << OBJ_CAST(old_link) << " new link=" << OBJ_CAST(new_link);
+
+  // In response to the MAC address change on the interface, linux deletes the
+  // neighbors configured on the interface. We are tracking the state
+  // of the nexthops in the l3_interface_mapping in the nl_l3 class, by storing
+  // the port id, vid, src mac and dst mac.  The neighbor deletion messages are
+  // received for all neighbors on the link.
+  // While these messages will delete the link neighbors after the MAC address
+  // changes, they do not carry the source mac, which forces a lookup for it
+  // returning the updated one. We need to make sure the deletions find their
+  // targets by updating the entry and the map.
+  rv = l3->update_l3_egress(port_id, vid, old_mac, new_mac);
+  if (rv < 0)
+    VLOG(1) << __FUNCTION__
+            << ": failed to update l3 egress, old link=" << OBJ_CAST(old_link)
+            << " new link=" << OBJ_CAST(new_link);
+
+  return rv;
 }
 
 bool cnetlink::has_l3_addresses(rtnl_link *link) {
@@ -1299,6 +1325,14 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
           << ", new_link_slave_type="
           << std::string_view(rtnl_link_get_slave_type(new_link))
           << ", af_old=" << af_old << ", af_new=" << af_new;
+
+  if (nl_addr_cmp(rtnl_link_get_addr(old_link), rtnl_link_get_addr(new_link)) &&
+      is_switch_interface(old_link)) {
+    if (update_on_mac_change(old_link, new_link) < 0)
+      LOG(ERROR) << __FUNCTION__
+                 << ": failed to update MAC old_link=" << OBJ_CAST(old_link)
+                 << " new_link=" << OBJ_CAST(new_link);
+  }
 
   if (af_old != af_new) {
     VLOG(1) << __FUNCTION__ << ": af changed from " << af_old << " to "

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -64,6 +64,8 @@ public:
   int add_l3_configuration(rtnl_link *link);
   int remove_l3_configuration(rtnl_link *link);
 
+  int update_on_mac_change(rtnl_link *old_link, rtnl_link *new_link);
+
   bool has_l3_addresses(rtnl_link *link);
 
   bool is_bridge_interface(rtnl_link *l) const;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -476,7 +476,7 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
   rofl::caddress_ll mac = libnl_lladdr_2_rofl(addr);
 
   rv = del_l3_termination(port_id, vid, mac, family);
-  if (rv < 0) {
+  if (rv < 0 && rv != -ENODATA) {
     LOG(ERROR) << __FUNCTION__
                << ": failed to remove l3 termination mac(local) vid=" << vid
                << "; rv=" << rv;
@@ -1200,7 +1200,7 @@ int nl_l3::del_l3_termination(uint32_t port_id, uint16_t vid,
         << __FUNCTION__
         << ": tried to delete a non existing termination mac for port_id="
         << port_id << ", vid=" << vid << ", mac=" << mac << ", af=" << af;
-    return 0;
+    return -ENODATA;
   }
 
   // still existing references

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -68,7 +68,7 @@ std::unordered_map<
     l3_interface>
     l3_interface_mapping;
 
-// key: source port_id, vid, src_mac, ethertype ; value: refcount
+// key: source port_id, vid, src_mac, af ; value: refcount
 std::unordered_multimap<std::tuple<int, uint16_t, rofl::caddress_ll, uint16_t>,
                         int>
     termination_mac_mapping;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -641,7 +641,9 @@ int nl_l3::del_l3_neigh_egress(struct rtnl_neigh *n) {
   // remove egress group reference
   int rv = del_l3_egress(ifindex, vid, s_mac, d_mac);
   if (rv < 0 and rv != -EEXIST) {
-    LOG(ERROR) << __FUNCTION__ << ": failed to add l3 egress";
+    LOG(ERROR) << __FUNCTION__
+               << ": failed to remove l3 egress ifindex=" << ifindex
+               << " vid=" << vid;
   }
 
   return rv;
@@ -1142,6 +1144,9 @@ int nl_l3::add_l3_termination(uint32_t port_id, uint16_t vid,
     if (i->first == needle) {
       // found, increment refcount
       i->second++;
+      VLOG(4) << __FUNCTION__ << ": incremented refcount=" << i->second
+              << " for key portid=" << port_id << " vid=" << vid
+              << " mac=" << mac << " af=" << af;
       return 0;
     }
   }
@@ -1167,6 +1172,9 @@ int nl_l3::add_l3_termination(uint32_t port_id, uint16_t vid,
     break;
   }
 
+  VLOG(3) << __FUNCTION__ << ": added l3 termination for port=" << port_id
+          << " vid=" << vid << " mac=" << mac << " af=" << af;
+
   return rv;
 }
 
@@ -1185,7 +1193,9 @@ int nl_l3::del_l3_termination(uint32_t port_id, uint16_t vid,
     if (i->first == needle) {
       // found, decrement refcount
       --i->second;
-      VLOG(4) << __FUNCTION__ << ": found new refcount=" << i->second;
+      VLOG(4) << __FUNCTION__ << ": decremented refcount=" << i->second
+              << " for l3 terminaton for portid=" << port_id << " vid=" << vid
+              << " mac=" << mac << " af=" << af;
       break;
     }
   }
@@ -1224,6 +1234,129 @@ int nl_l3::del_l3_termination(uint32_t port_id, uint16_t vid,
   }
 
   termination_mac_mapping.erase(i);
+
+  return rv;
+}
+
+int nl_l3::update_l3_termination(int port_id, uint16_t vid,
+                                 struct nl_addr *old_mac,
+                                 struct nl_addr *new_mac) noexcept {
+  int rv = 0;
+
+  auto o_mac = libnl_lladdr_2_rofl(old_mac);
+  auto n_mac = libnl_lladdr_2_rofl(new_mac);
+
+  // parse the AF list and remove the entry from the termination mac map
+  // call the switch function to remove and insert the entry with the
+  // new mac address.
+  // We cant call del_l3_termination because we need to keep the refcounts
+  // currently configured in the map
+  auto entry = termination_mac_mapping.find(
+      std::make_tuple(port_id, vid, o_mac, AF_INET));
+  if (entry != termination_mac_mapping.end()) {
+    int refcnt = entry->second;
+
+    termination_mac_mapping.erase(entry);
+    rv = sw->l3_termination_remove(port_id, vid, o_mac);
+
+    if (rv < 0)
+      VLOG(3) << __FUNCTION__
+              << ": failed to remove termination mac port=" << port_id
+              << " vid=" << vid << " mac=" << o_mac;
+    rv = sw->l3_termination_add(port_id, vid, n_mac);
+    if (rv < 0) {
+      VLOG(3) << __FUNCTION__
+              << ": failed to add termination mac port=" << port_id
+              << " vid=" << vid << " mac=" << n_mac;
+      return rv;
+    }
+
+    auto new_key = std::make_tuple(port_id, vid, n_mac, AF_INET);
+    termination_mac_mapping.emplace(std::move(new_key), refcnt);
+
+    VLOG(2) << __FUNCTION__
+            << ": updated Termination MAC for port_id=" << port_id
+            << " old mac address=" << o_mac << " new mac address=" << n_mac
+            << " AF=" << AF_INET;
+  }
+
+  entry = termination_mac_mapping.find(
+      std::make_tuple(port_id, vid, o_mac, AF_INET6));
+  if (entry != termination_mac_mapping.end()) {
+    int refcnt = entry->second;
+
+    termination_mac_mapping.erase(entry);
+    rv = sw->l3_termination_remove_v6(port_id, vid, o_mac);
+    if (rv < 0)
+      VLOG(3) << __FUNCTION__
+              << ": failed to remove termination mac port=" << port_id
+              << " vid=" << vid << " mac=" << o_mac;
+    rv = sw->l3_termination_add_v6(port_id, vid, n_mac);
+    if (rv < 0) {
+      VLOG(3) << __FUNCTION__
+              << ": failed to add termination mac port=" << port_id
+              << " vid=" << vid << " mac=" << n_mac;
+      return rv;
+    }
+
+    auto new_key = std::make_tuple(port_id, vid, n_mac, AF_INET6);
+    termination_mac_mapping.emplace(std::move(new_key), refcnt);
+    VLOG(2) << __FUNCTION__
+            << ": updated Termination MAC for port_id=" << port_id
+            << " old mac address=" << o_mac << " new mac address=" << n_mac
+            << " AF=" << AF_INET6;
+  }
+  return rv;
+}
+
+int nl_l3::update_l3_egress(int port_id, uint16_t vid, struct nl_addr *old_mac,
+                            struct nl_addr *new_mac) noexcept {
+
+  int rv = 0;
+
+  auto o_mac = libnl_lladdr_2_rofl(old_mac);
+  auto n_mac = libnl_lladdr_2_rofl(new_mac);
+
+  // search the l3 interface mapping for an entry corresponding to the
+  // old mac address to be updated
+  std::unordered_map<
+      std::tuple<int, uint16_t, rofl::caddress_ll, rofl::caddress_ll>,
+      l3_interface>
+      update_l3;
+
+  // vlan, mac address combination is unique, get the entries that match
+  // not parsing for the port id solves the issue for bridge interfaces
+  // that portid is 0 and the entries are gotten from the fdb
+  for (auto it : l3_interface_mapping) {
+    if (std::get<1>(it.first) == vid && std::get<2>(it.first) == o_mac)
+      update_l3.emplace(it.first, it.second);
+  }
+
+  if (update_l3.empty()) {
+    VLOG(4) << __FUNCTION__
+            << ": no mapping found, no egress entry to be updated";
+    return 0;
+  }
+
+  // update the switch egress entry with the new mac address
+  for (auto it : update_l3) {
+    uint32_t l3_iface_id = it.second.l3_interface_id;
+    rv = sw->l3_egress_update(std::get<0>(it.first), vid, n_mac,
+                              std::get<3>(it.first), &l3_iface_id);
+
+    auto l3_if_new_tuple =
+        std::make_tuple(port_id, vid, n_mac, std::get<3>(it.first));
+
+    // updates the l3 interface map, erasing the entry to the old mac address
+    // and inserting the new one
+    l3_interface_mapping.erase(it.first);
+    l3_interface_mapping.emplace(std::make_pair(l3_if_new_tuple, it.second));
+
+    VLOG(2) << __FUNCTION__ << ": updated egress l3 for port_id=" << port_id
+            << " old mac address=" << std::get<3>(it.first)
+            << " new mac address=" << n_mac
+            << " l3 interface id=" << l3_iface_id;
+  }
 
   return rv;
 }

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -57,6 +57,11 @@ public:
 
   int get_l3_routes(struct rtnl_link *link, std::deque<rtnl_route *> *routes);
 
+  int update_l3_termination(int port_id, uint16_t vid, struct nl_addr *old_mac,
+                            struct nl_addr *new_mac) noexcept;
+  int update_l3_egress(int port_id, uint16_t vid, struct nl_addr *old_mac,
+                       struct nl_addr *new_mac) noexcept;
+
   void get_nexthops_of_route(rtnl_route *route,
                              std::deque<struct rtnl_nexthop *> *nhs) noexcept;
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -988,6 +988,8 @@ int controller::l3_termination_add(uint32_t sport, uint16_t vid,
                                      fm_driver.enable_tmac_ipv4_unicast_mac(
                                          dpt.get_version(), sport, vid, dmac));
     }
+
+    dpt.send_barrier_request(rofl::cauxid(0));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1016,6 +1018,8 @@ int controller::l3_termination_add_v6(uint32_t sport, uint16_t vid,
                                      fm_driver.enable_tmac_ipv6_unicast_mac(
                                          dpt.get_version(), sport, vid, dmac));
     }
+
+    dpt.send_barrier_request(rofl::cauxid(0));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1038,6 +1042,8 @@ int controller::l3_termination_remove(uint32_t sport, uint16_t vid,
     dpt.send_flow_mod_message(rofl::cauxid(0),
                               fm_driver.disable_tmac_ipv4_unicast_mac(
                                   dpt.get_version(), sport, vid, dmac));
+
+    dpt.send_barrier_request(rofl::cauxid(0));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1060,6 +1066,8 @@ int controller::l3_termination_remove_v6(
     dpt.send_flow_mod_message(rofl::cauxid(0),
                               fm_driver.disable_tmac_ipv6_unicast_mac(
                                   dpt.get_version(), sport, vid, dmac));
+
+    dpt.send_barrier_request(rofl::cauxid(0));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;


### PR DESCRIPTION
## Description
This PR adds handling of changing MAC addresses on the TAP interfaces. When doing commands like,

```
$ ip link set PORT address MAC_ADDRESS 
```

The linux mac address will change to the one specified. When this change is triggered, kernel sends two notifications, the first one related to the change of the address itself. The next one will be flushing the ip neighs on the interface. 

The changing of mac addresses on the tap interfaces is relevant when there are IP addresses/ neighs/ routes configured on the interface. baseboxd must pick up the notification and change the entries in the termination mac table and egress l3 unicast group. Since there are maps following the entries in these tables, and associated refcounts, they must also be updated.

## Motivation and Context
Setting new mac addresses in tap interfaces is a management operation that should be supported in baseboxd. After the mac are reset, connectivity should still continue. For example, since https://github.com/systemd/systemd/commit/550c8784c5, the mac addresses will be reset on baseboxd startup. If there are races between baseboxd setting the ASIC entries and the rewrite of the mac address, that can potentially leave pending entries in the asic, making the system unusable.

## How Has This Been Tested?
