### PR TITLE
nl_bond: make sure to add the default vlan to new members if needed

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -551,6 +551,15 @@ int cnetlink::remove_l3_configuration(rtnl_link *link) {
   return rv;
 }
 
+bool cnetlink::has_l3_addresses(rtnl_link *link) {
+  assert(link);
+
+  std::deque<rtnl_addr *> addresses;
+  l3->get_l3_addrs(link, &addresses);
+
+  return !addresses.empty();
+}
+
 struct rtnl_neigh *cnetlink::get_neighbour(int ifindex,
                                            struct nl_addr *a) const {
   assert(ifindex);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -64,6 +64,8 @@ public:
   int add_l3_configuration(rtnl_link *link);
   int remove_l3_configuration(rtnl_link *link);
 
+  bool has_l3_addresses(rtnl_link *link);
+
   bool is_bridge_interface(rtnl_link *l) const;
   bool is_bridge_interface(int ifindex) const;
   bool is_bridge_configured(rtnl_link *l);

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -273,6 +273,11 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   } else {
     std::deque<uint16_t> vlans;
 
+    if (nl->has_l3_addresses(bond)) {
+      swi->ingress_port_vlan_add(port_id, 1, true);
+      swi->egress_port_vlan_add(port_id, 1, true);
+    }
+
     nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
     for (auto vid : vlans) {
       swi->ingress_port_vlan_add(port_id, vid, false);
@@ -344,6 +349,11 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     for (auto vid : vlans) {
       swi->ingress_port_vlan_remove(port_id, vid, false);
       swi->egress_port_vlan_remove(port_id, vid);
+    }
+
+    if (nl->has_l3_addresses(bond)) {
+      swi->ingress_port_vlan_remove(port_id, 1, true);
+      swi->egress_port_vlan_remove(port_id, 1);
     }
   }
 #endif


### PR DESCRIPTION
When adding an IP address to an interface, we need to add vlan flows for
the untagged vlan. Since the assignment flows require physical ports,
we need to have them for all bond members.

Currently we do not add or a remove them when adding new members, so the
following flow would fail:

> sudo ip link add name bond1 type bond mode active-backup
> sudo ip link set port1 master bond1
> sudo ip address add 10.0.0.1/24 dev bond1
> sudo ip link set port2 master bond1

To fix this, add a new helper to know if a (bond) interface has any ip
addresses configured, and add the default vlan configuration to the port
in that case.

client_flowtable_dump 10 output:

Before:
> Table ID 10 (VLAN):   Retrieving all entries. Max entries = 12288, Current entries = 3.
> --  inPort = 1 (Physical)  vlanId:mask = 0x0000:0x1fff (VLAN 0) | GoTo = 20 (Termination MAC) newVlanId = 0x1001 (VLAN 1)
> --  inPort = 1 (Physical)  vlanId:mask = 0x1001:0x1fff (VLAN 1) | GoTo = 20 (Termination MAC)
> --  inPort = 1 (Trunk)  vlanId:mask = 0x1001:0x1fff (VLAN 1) | GoTo = 20 (Termination MAC)

After:
> Table ID 10 (VLAN):   Retrieving all entries. Max entries = 12288, Current entries = 5.
> --  inPort = 1 (Physical)  vlanId:mask = 0x0000:0x1fff (VLAN 0) | GoTo = 20 (Termination MAC) newVlanId = 0x1001 (VLAN 1)
> --  inPort = 1 (Physical)  vlanId:mask = 0x1001:0x1fff (VLAN 1) | GoTo = 20 (Termination MAC)
> --  inPort = 2 (Physical)  vlanId:mask = 0x0000:0x1fff (VLAN 0) | GoTo = 20 (Termination MAC) newVlanId = 0x1001 (VLAN 1)
> --  inPort = 2 (Physical)  vlanId:mask = 0x1001:0x1fff (VLAN 1) | GoTo = 20 (Termination MAC)
> --  inPort = 1 (Trunk)  vlanId:mask = 0x1001:0x1fff (VLAN 1) | GoTo = 20 (Termination MAC)

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
