### PR TITLE
baseboxd: add a flag to make multicast support optional

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -1,5 +1,8 @@
 ### Configuration options for baseboxd
 #
+# Enable multicast supporrt:
+# FLAGS_multicast=true
+#
 # Listening port:
 # FLAGS_port=6653
 #

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -13,6 +13,7 @@
 #include "version.h"
 
 DECLARE_string(tryfromenv); // from gflags
+DEFINE_bool(multicast, true, "Enable multicast support");
 DEFINE_int32(port, 6653, "Listening port");
 DEFINE_int32(ofdpa_grpc_port, 50051, "Listening port of ofdpa gRPC server");
 
@@ -40,7 +41,7 @@ int main(int argc, char **argv) {
   }
 
   // all variables can be set from env
-  FLAGS_tryfromenv = std::string("port,ofdpa_grpc_port");
+  FLAGS_tryfromenv = std::string("multicast,port,ofdpa_grpc_port");
   gflags::SetUsageMessage("");
   gflags::SetVersionString(PROJECT_VERSION);
 


### PR DESCRIPTION
Multicast support is currently triggering unexpected behaviour where
DHCP packets do not get properly forwarded anymore. Until we identify
the cause, make it possible to disable multicast if encountering this
issue.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

## How Has This Been Tested?

ran multicast-ipv4 test with FLAG_multicast=true => passed
ran multicast-ipv4 test with FLAG_multicast=false => failed due to missing flow table entries