### PR TITLE
nl_l3: get_neighbours_of_route: treat neighbors without lladdr as unresolved

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1305,6 +1305,13 @@ int nl_l3::get_neighbours_of_route(
       neigh = nl->get_neighbour(ifindex, nh_addr);
       VLOG(2) << __FUNCTION__ << ": get neigh=" << OBJ_CAST(neigh)
               << " of nh_addr=" << nh_addr;
+
+      if (neigh && rtnl_neigh_get_lladdr(neigh) == nullptr) {
+        VLOG(2) << __FUNCTION__ << ": neigh=" << OBJ_CAST(neigh)
+                << " is not reachable";
+        rtnl_neigh_put(neigh);
+        neigh = nullptr;
+      }
     }
 
     if (neigh)


### PR DESCRIPTION
nl::get_neighbor() might return known, but unreachable neighbors. If
this happens when deleting a route, we try then to pass this incomplete
neighbor to nl_l3::del_l3_egress, which will then trigger an assert, as
it expectes a complete neighbor.

Fixes the following crash seen on restart of FRR after reoute exchange
with eigrp:

```
Jul 21 11:27:17 agema-ag7648 baseboxd[2025]: I0721 11:27:17.681071  2079 nl_l3.cc:1425] get_neighbours_of_route: ifindex=8 gw=10.0.0.1
Jul 21 11:27:17 agema-ag7648 baseboxd[2025]: I0721 11:27:17.681125  2079 nl_l3.cc:1434] get_neighbours_of_route: get neigh=inet 10.0.0.1 dev bond2 <failed>
Jul 21 11:27:17 agema-ag7648 baseboxd[2025]:  of nh_addr=10.0.0.1
Jul 21 11:27:17 agema-ag7648 baseboxd[2025]: I0721 11:27:17.681174  2079 nl_l3.cc:1836] del_l3_unicast_route: number of next hops is 1
Jul 21 11:27:17 agema-ag7648 baseboxd[2025]: baseboxd: ../git/src/netlink/nl_l3.cc:989: int basebox::nl_l3::del_l3_egress(int, uint16_t, const nl_addr*, const nl_addr*): Assertion `d_mac' failed.
```

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

## How Has This Been Tested?

Pipeline #16746