### PR TITLE
sysconfig.template: fix typo supporrt => support

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -1,6 +1,6 @@
 ### Configuration options for baseboxd
 #
-# Enable multicast supporrt:
+# Enable multicast support:
 # FLAGS_multicast=true
 #
 # Listening port:


### PR DESCRIPTION
Fix obvious typo supporrt, which should be support.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>