### PR TITLE
Adapt libnl bridge vlan usage to updated API

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1699,15 +1699,16 @@ void cnetlink::route_mdb_apply(const nl_obj &obj) {
 }
 
 void cnetlink::route_bridge_vlan_apply(const nl_obj &obj) {
-  assert(obj.get_new_obj());
 
-  switch (obj.get_msg_type()) {
-  case RTM_NEWVLAN:
+  switch (obj.get_action()) {
+  case NL_ACT_NEW:
+  case NL_ACT_CHANGE:
+    assert(obj.get_new_obj());
     if (bridge)
       bridge->set_pvlan_stp(BRIDGE_VLAN_CAST(obj.get_new_obj()));
     break;
 #if 0
-  case RTM_DELVLAN:
+  case NL_ACT_DEL:
 	if (bridge)
 	        bridge->set_pvlan_stp(BRIDGE_VLAN_CAST(obj.get_new_obj()));
 	break;

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1707,12 +1707,9 @@ void cnetlink::route_bridge_vlan_apply(const nl_obj &obj) {
     if (bridge)
       bridge->set_pvlan_stp(BRIDGE_VLAN_CAST(obj.get_new_obj()));
     break;
-#if 0
   case NL_ACT_DEL:
-	if (bridge)
-	        bridge->set_pvlan_stp(BRIDGE_VLAN_CAST(obj.get_new_obj()));
-	break;
-#endif
+    VLOG(1) << __FUNCTION__ << ": removing vlan stg membership not supported";
+    break;
   default:
     LOG(ERROR) << __FUNCTION__ << ": invalid action " << obj.get_action();
     break;

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1086,9 +1086,8 @@ int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
 
   uint32_t ifindex = rtnl_bridge_vlan_get_ifindex(bvlan_info);
   int port_id = nl->get_port_id(ifindex);
-  struct rtnl_bvlan_entry *entry = rtnl_bridge_vlan_get_entry_head(bvlan_info);
-  uint16_t vlan_id = rtnl_bridge_vlan_entry_get_vlan_id(entry);
-  uint8_t stp_state = rtnl_bridge_vlan_entry_get_state(entry);
+  uint16_t vlan_id = rtnl_bridge_vlan_get_vlan_id(bvlan_info);
+  uint8_t stp_state = rtnl_bridge_vlan_get_state(bvlan_info);
 
   if (is_bridge_interface(ifindex))
     return err;


### PR DESCRIPTION
With https://github.com/bisdn/meta-switch/pull/2 we simplify the libnl bridge vlan API. Since this changes the API, we need to update the code here as well.

## How Has This Been Tested?

Ran on tonights pipelines.

Depends on https://github.com/bisdn/meta-switch/pull/2
