### PR TITLE
tap_manager: do not leak socket when setting port speed

### DIFF
--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -359,12 +359,15 @@ int tap_manager::set_port_speed(const std::string name, uint32_t speed,
   int error = ioctl(sockFd, SIOCETHTOOL, static_cast<void *>(&ifr));
   if (error < 0) {
     LOG(ERROR) << __FUNCTION__ << " handshake failed error=" << error;
+    close(sockFd);
     return error;
   }
 
   if (link_settings.req.link_mode_masks_nwords >= 0 ||
-      link_settings.req.cmd != ETHTOOL_GLINKSETTINGS)
+      link_settings.req.cmd != ETHTOOL_GLINKSETTINGS) {
+    close(sockFd);
     return -EOPNOTSUPP;
+  }
 
   link_settings.req.link_mode_masks_nwords =
       -link_settings.req.link_mode_masks_nwords;
@@ -374,6 +377,7 @@ int tap_manager::set_port_speed(const std::string name, uint32_t speed,
   if (error < 0) {
     LOG(ERROR) << __FUNCTION__ << " failed to get port= " << name
                << " error=" << error;
+    close(sockFd);
     return error;
   }
 
@@ -388,6 +392,7 @@ int tap_manager::set_port_speed(const std::string name, uint32_t speed,
                << " speed, error=" << error;
   }
 
+  close(sockFd);
   return error;
 }
 


### PR DESCRIPTION
We open a new socket every time we want to set the speed of a port, but
never close it. This eventually leads to hitting the maximum amount of
open file descriptors, leading to various other issues.

Fix this by closing the socket on return.

Fixes: b5fe46c ("tap_manager: set port speed on tap interfaces")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

## Motivation and Context

Running out of file descriptors breaks STP, since we check sysfs for the stp state of the bridge (which then fails).

## How Has This Been Tested?

1. set one port to up
2. Run `watch `'ls -l /proc/`pidof baseboxd`/fd | wc -l`` on switch
3. establish link on port
4. cut link on port

Before:

```
157 # initial state after boot
211 # port change notification flood after first link change
212 # port down again
````

After:
```
103 # initial state after boot
103 # port change notification flood after first link change
103 # port down again
```

The amount of leaks are 54 each for the first two, which correspond to one leak per port when setting the initial state, then again when setting the updated state. After that its only one leak per port change notification.