### PR TITLE
cnetlink: do not pass sock_mon to rtnl_*_alloc_cache*

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -118,7 +118,7 @@ void cnetlink::init_caches() {
 
   set_nl_socket_buffer_sizes(sock_mon);
 
-  rc = rtnl_link_alloc_cache_flags(sock_mon, AF_UNSPEC, &caches[NL_LINK_CACHE],
+  rc = rtnl_link_alloc_cache_flags(nullptr, AF_UNSPEC, &caches[NL_LINK_CACHE],
                                    NL_CACHE_AF_ITER);
 
   if (0 != rc) {
@@ -134,7 +134,7 @@ void cnetlink::init_caches() {
   }
 
   /* init route cache */
-  rc = rtnl_route_alloc_cache(sock_mon, AF_UNSPEC, 0, &caches[NL_ROUTE_CACHE]);
+  rc = rtnl_route_alloc_cache(nullptr, AF_UNSPEC, 0, &caches[NL_ROUTE_CACHE]);
   if (rc < 0) {
     LOG(FATAL) << __FUNCTION__ << ": add route/route to cache mngr";
   }
@@ -145,7 +145,7 @@ void cnetlink::init_caches() {
   }
 
   /* init addr cache*/
-  rc = rtnl_addr_alloc_cache(sock_mon, &caches[NL_ADDR_CACHE]);
+  rc = rtnl_addr_alloc_cache(nullptr, &caches[NL_ADDR_CACHE]);
   if (rc < 0) {
     LOG(FATAL) << __FUNCTION__ << ": add route/addr to cache mngr";
   }
@@ -156,7 +156,7 @@ void cnetlink::init_caches() {
   }
 
   /* init neigh cache */
-  rc = rtnl_neigh_alloc_cache_flags(sock_mon, &caches[NL_NEIGH_CACHE],
+  rc = rtnl_neigh_alloc_cache_flags(nullptr, &caches[NL_NEIGH_CACHE],
                                     NL_CACHE_AF_ITER);
   if (0 != rc) {
     LOG(FATAL) << __FUNCTION__
@@ -171,7 +171,7 @@ void cnetlink::init_caches() {
 #ifdef HAVE_NETLINK_ROUTE_MDB_H
   if (FLAGS_multicast) {
     /* init mdb cache */
-    rc = rtnl_mdb_alloc_cache_flags(sock_mon, &caches[NL_MDB_CACHE],
+    rc = rtnl_mdb_alloc_cache_flags(nullptr, &caches[NL_MDB_CACHE],
                                     NL_CACHE_AF_ITER);
     if (0 != rc) {
       LOG(FATAL) << __FUNCTION__
@@ -188,7 +188,7 @@ void cnetlink::init_caches() {
 
 #ifdef HAVE_NETLINK_ROUTE_BRIDGE_VLAN_H
   /* init bridge-vlan cache */
-  rc = rtnl_bridge_vlan_alloc_cache_flags(sock_mon, &caches[NL_BVLAN_CACHE],
+  rc = rtnl_bridge_vlan_alloc_cache_flags(nullptr, &caches[NL_BVLAN_CACHE],
                                           NL_CACHE_AF_ITER);
   if (0 != rc) {
     LOG(FATAL) << __FUNCTION__


### PR DESCRIPTION
libnl uses two sockets for handling netlink mesages, a socket for
notifications, and a separate socket for requests to the kernel.

The difference is that the notifications socket has sequence number
checking disabled, since notifications are broadcast and do not have a
valid sequence number, while the request socket does have it enabled,
to ensure we get the correct reply to requests.

The notification netlink socket is created by us and passed to the cache
manager, while the requests socket is created by the cache manager
itself.

When allocating a cache, they allow passing a netlink socket. If doing
so, it will use it to initially fill its cache.

Since we have a socket (the notification socket), and the function takes
a socket, passing it was a the obvious thing.

Unfortunately due to the notification socket having the sequence checking
disabled, if there is a notification coming in between the request from
the cache to the kernel and the reply from the kernel, the notification
will get routed to the cache, the cache fill will abort due to an
unexpected reply, and the allocation call will fail.

Fortunately we can just pass a nullptr instead of the notification
socket. This is fine since we when we pass the allocated cache to the
cache manager, the cache manager itself will trigger a sync with the
kernel as well, this time with the correct socket.

Fixes crashes on startup like:

Aug 25 09:33:00 cel-questone-2a baseboxd[3242]: F0825 09:33:00.481150  3242 cnetlink.cc:177] init_caches: rtnl_mdb_alloc_cache_flags failed rc=-22
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]: *** Check failure stack trace: ***
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x7f74b41d484d  google::LogMessage::Fail()
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x7f74b41d9434  google::LogMessage::SendToLog()
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x7f74b41d454b  google::LogMessage::Flush()
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x7f74b41d4d99  google::LogMessageFatal::~LogMessageFatal()
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x55c74bab8e22  (unknown)
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x55c74babc5f4  (unknown)
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x55c74b97d4ed  (unknown)
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x7f74b320cd0b  __libc_start_main
Aug 25 09:33:00 cel-questone-2a baseboxd[3242]:     @     0x55c74b97e0aa  (unknown)
Aug 25 09:33:01 cel-questone-2a systemd[1]: baseboxd.service: Main process exited, code=dumped, status=6/ABRT

Fixes: 42e7190 ("resync netlink state every 5 seconds")
Fixes: 65a22e4 ("l3 neighbour support")
Fixes: 676d218 ("controller: expand range for multicast policy entry")
Fixes: 186326a ("cnetlink: add support for Linux RTM_NEW/DELVLAN messages;      * add libnl bridge-vlan cache support;")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>