### PR TITLE
cnetlink::search_fdb: handle bridge not set 

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1662,10 +1662,14 @@ int cnetlink::unset_bridge_port_vlan_tpid(rtnl_link *l) {
 }
 
 std::deque<rtnl_neigh *> cnetlink::search_fdb(uint16_t vid, nl_addr *lladdr) {
+  std::deque<rtnl_neigh *> fdb_entries;
+
+  if (!bridge)
+    return fdb_entries;
+
   std::deque<rtnl_link *> br_ports;
   get_bridge_ports(bridge->get_ifindex(), &br_ports);
 
-  std::deque<rtnl_neigh *> fdb_entries;
   for (auto port : br_ports) {
     auto fdb = bridge->get_fdb_entries_of_port(port, vid, lladdr);
 


### PR DESCRIPTION
When attaching a vrf to a bridge vlan interface on a bridge with no port
interfaces attached, the vrf code will call cnetlink:search_fdb, which
will then try to access the still unset bridge, causing a segfault.

To avoid this, let cnetlink::search_fdb handle this and just return an
empty deque in this case.

Stacktrace showing the issue:

> Program terminated with signal SIGSEGV, Segmentation fault.
> #0  0x000055ad93b0909d in basebox::cnetlink::search_fdb (this=0x55ad950dcda0, vid=vid@entry=30, lladdr=lladdr@entry=0x0) at ../git/src/netlink/cnetlink.cc:1666
> 1666	  get_bridge_ports(bridge->get_ifindex(), &br_ports);
> [Current thread is 1 (LWP 3276)]
> (gdb) print bridge
> $1 = (basebox::nl_bridge *) 0x0
> (gdb) bt
> #0  0x000055ad93b0909d in basebox::cnetlink::search_fdb (this=0x55ad950dcda0, vid=vid@entry=30, lladdr=lladdr@entry=0x0) at ../git/src/netlink/cnetlink.cc:1666
> #1  0x000055ad93b3427b in basebox::nl_vlan::vrf_attach (this=0x55ad950db930, old_link=old_link@entry=0x7f7f54002540, new_link=new_link@entry=0x7f7f54001210) at ../git/src/netlink/nl_vlan.cc:384
> #2  0x000055ad93b06451 in basebox::cnetlink::link_updated (this=0x55ad950dcda0, old_link=0x7f7f54002540, new_link=0x7f7f54001210) at /usr/include/c++/9.3.0/bits/shared_ptr_base.h:1020
> #3  0x000055ad93b0a81a in basebox::cnetlink::route_link_apply (this=0x55ad950dcda0, obj=...) at ../git/src/netlink/nl_obj.h:27
> #4  0x000055ad93b0c8c7 in basebox::cnetlink::handle_wakeup (this=0x55ad950dcda0, thread=...) at ../git/src/netlink/cnetlink.cc:766
> #5  0x00007f7f5cac45d4 in rofl::cthread::handle_wakeup() () from /usr/lib/librofl_common.so.0
> #6  0x00007f7f5cac52b5 in rofl::cthread::run_loop() () from /usr/lib/librofl_common.so.0
> #7  0x00007f7f5c1daea4 in ?? () from /lib/libpthread.so.0
> #8  0x00007f7f5c10ddcf in clone () from /lib/libc.so.6

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>