### PR TITLE
controller: fix typos that broke compilation

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2244,7 +2244,7 @@ int controller::ofdpa_stg_create(uint16_t vlan_id) noexcept {
 
   stg_id = find_free_stgid();
   if (stg_id < 0) {
-    LOG(ERRROR) << _FUNCTION__ << ": failed to allocate STG ID: " << stg_id;
+    LOG(ERROR) << __FUNCTION__ << ": failed to allocate STG ID: " << stg_id;
     return stg_id;
   }
 


### PR DESCRIPTION
Fix the following build error:
| In file included from ../git/src/of-dpa/controller.h:17,
|                  from ../git/src/of-dpa/controller.cc:16:
| ../git/src/of-dpa/controller.cc: In member function 'virtual int basebox::controller::ofdpa_stg_create(uint16_t)':
| ../git/src/of-dpa/controller.cc:2247:5: error: 'COMPACT_GOOGLE_LOG_ERRROR' was not declared in this scope; did you mean 'COMPACT_GOOGLE_LOG_ERROR'?
|  2247 |     LOG(ERRROR) << _FUNCTION__ << ": failed to allocate STG ID: " << stg_id;
|       |     ^~~
| ../git/src/of-dpa/controller.cc:2247:20: error: '_FUNCTION__' was not declared in this scope
|  2247 |     LOG(ERRROR) << _FUNCTION__ << ": failed to allocate STG ID: " << stg_id;
|       |                    ^~~~~~~~~~~

Fixes: 8139c13 ("controller: reuse deleted stg ids")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>