### PR TITLE
fix various issues in multicast code and unbreak IPv6 snooping

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1031,7 +1031,7 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 
       rv = sw->l2_multicast_addr_remove(port_id, vid, mc_ll);
       if (rv < 0) {
-        LOG(ERROR) << __FUNCTION__ << ": failed to add bridging MC entry";
+        LOG(ERROR) << __FUNCTION__ << ": failed to remove bridging MC entry";
         return rv;
       }
     } else if (rtnl_mdb_entry_get_proto(i) == ETH_P_IPV6) {
@@ -1055,7 +1055,7 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 
       rv = sw->l2_multicast_addr_remove(port_id, vid, mc_ll);
       if (rv < 0) {
-        LOG(ERROR) << __FUNCTION__ << ": failed to add bridging MC entry";
+        LOG(ERROR) << __FUNCTION__ << ": failed to remove bridging MC entry";
         return rv;
       }
     }

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -915,7 +915,7 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
     unsigned char buf[ETH_ALEN];
 
     if (port_ifindex == get_ifindex()) {
-      return rv;
+      continue;
     }
 
     auto addr = rtnl_mdb_entry_get_addr(i);

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1008,6 +1008,14 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 
       multicast_ipv4_to_ll(ipv4_dst.get_addr_hbo(), buf);
     } else if (rtnl_mdb_entry_get_proto(i) == ETH_P_IPV6) {
+
+      // Is address Linklocal Multicast
+      auto p = nl_addr_alloc(16);
+      nl_addr_parse("ff02::/10", AF_INET6, &p);
+      std::unique_ptr<nl_addr, decltype(&nl_addr_put)> tm_addr(p, nl_addr_put);
+      if (!nl_addr_cmp_prefix(addr, tm_addr.get()))
+        continue;
+
       struct in6_addr *v6_addr =
           (struct in6_addr *)nl_addr_get_binary_addr(addr);
 

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -935,7 +935,7 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
       nl_addr_parse("ff02::/10", AF_INET6, &p);
       std::unique_ptr<nl_addr, decltype(&nl_addr_put)> tm_addr(p, nl_addr_put);
       if (!nl_addr_cmp_prefix(addr, tm_addr.get()))
-        return 0;
+        continue;
 
       struct in6_addr *v6_addr =
           (struct in6_addr *)nl_addr_get_binary_addr(addr);

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -994,6 +994,10 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
     uint16_t vid = rtnl_mdb_entry_get_vid(i);
     unsigned char buf[ETH_ALEN];
 
+    if (port_ifindex == get_ifindex()) {
+      continue;
+    }
+
     auto addr = rtnl_mdb_entry_get_addr(i);
     if (rtnl_mdb_entry_get_proto(i) == ETH_P_IP) {
       rofl::caddress_in4 ipv4_dst = libnl_in4addr_2_rofl(addr, &rv);


### PR DESCRIPTION
Fix various issues in multicast handling to follow specs and allow IPv6.

## Description

Fixes the following issues in the multicast code:

* fix debug messages on removal
* align add and remove code to do the same checks
* do not abort on the first ignored entry (go through them all)
* do not create/remove groups for 224.0.0.0/8, these should always be flooded
* do not ignore ff02::/10, but only ff::/15 and ff02::1, allowing IPv6 snooping to actually work

## How Has This Been Tested?

Running a pipeline and updating the multicast-ipv4 test to handle the additional IPv6 groups created.
