### PR TITLE
nl_l3: align ip address removal to add

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -415,6 +415,14 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
     return -EINVAL;
   }
 
+  bool is_loopback = (rtnl_link_get_flags(link) & IFF_LOOPBACK);
+
+  // if it isn't on loopback and not our interfaces, ignore it
+  if (!is_loopback && !nl->is_switch_interface(link)) {
+    VLOG(1) << __FUNCTION__ << ": ignoring " << OBJ_CAST(link);
+    return -EINVAL;
+  }
+
   struct nl_addr *addr = rtnl_addr_get_local(a);
   int prefixlen = nl_addr_get_prefixlen(addr);
 
@@ -454,7 +462,7 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
     return -EINVAL;
   }
 
-  if (rtnl_link_get_flags(link) & IFF_LOOPBACK) {
+  if (is_loopback) {
     return 0;
   }
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -475,11 +475,6 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
   int ifindex = rtnl_addr_get_ifindex(a);
   int port_id = nl->get_port_id(ifindex);
 
-  if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": invalid port_id 0";
-    return -EINVAL;
-  }
-
   addr = rtnl_link_get_addr(link);
   rofl::caddress_ll mac = libnl_lladdr_2_rofl(addr);
 


### PR DESCRIPTION
Fix three small issues in the ip address removal paths that can lead to flows being left existing or deleted which shouldn't be. 

## Description
There are a few subtle difference between the code adding and the code removing flows for IP addresses that can lead to flows not being deleted, or being deleted too early.  there are three issues:

1. for IP address removals on any interface we tried to remove the corresponding unicast table flow, even if this wasn't our interface (e.g. the management interface)
2. We never removed termination mac entries for any interfaces without a port id, even we did add it (vlan interfaces on bridges)
3. We always tried to remove the vlan, even if we never added one because this interface was bridged, potentially leading to vlan flows being deleted that shouldn't be.

#  Motivation and Context
Fixes are always good.

## How Has This Been Tested?
1. is harmless, since the removal will just fail

for 2.

```
ip link add name swbridge type bridge vlan_filtering 1
ip link set port1 master swbridge
ip link add name swbridge.1 link swbridge type vlan id 1
ip address add 10.0.0.1/24 dev swbridge.1
ip address del 10.0.0.1/24 dev swbridge.1
```

Before the change, the termination mac entry for the vlan interface was kept, after this the table is empty again.

For 3:

```
ip link add name swbridge type bridge vlan_filtering 1
ip address add 10.0.0.1/24 dev port1
ip link set port1 master swbridge
ip address del 10.0.0.1/24 dev port1
```

Before this change, the vlan table entry for port 1 will be removed, after this change, they will be kept.