### PR TITLE
controller: l3_egress_remove: fix race with dropping references

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1165,6 +1165,7 @@ int controller::l3_egress_remove(uint32_t l3_interface_id) noexcept {
   int rv = 0;
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_barrier_request(rofl::cauxid(0));
     dpt.send_group_mod_message(
         rofl::cauxid(0),
         fm_driver.disable_group_l3_unicast(dpt.get_version(), l3_interface_id));


### PR DESCRIPTION
When l3 neighbors that are also route nexthop become unavailable, we
will send in rapid succession an update for the route to point to
controller instead of the l3 unicast group, and the removal of the l3
unicast group.

If the removal is processed before the route update, the removal will
fail since it still is referenced by the route, and the l3 interface ids
in baseboxd and ofdpa become out of sync, causing various issues.

Fix this by adding a barrier before trying to remove the l3 unicast
group to ensure that any pending route updates finished processing.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>