### PR TITLE
bridging: implement update to vlan untagged

### DIFF
--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -123,6 +123,16 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
 }
 
 // add vid at ingress
+int nl_vlan::add_ingress_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
+  assert(swi);
+
+  uint16_t vrf_id = get_vrf_id(vid, link);
+  uint32_t port_id = nl->get_port_id(link);
+
+  return add_ingress_vlan(port_id, vid, tagged, vrf_id);
+}
+
+// add vid at ingress
 int nl_vlan::add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
                               uint16_t vrf_id) {
 
@@ -150,18 +160,28 @@ int nl_vlan::add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
 }
 
 // remove vid at ingress
-int nl_vlan::remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+int nl_vlan::remove_ingress_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
+  assert(swi);
+
+  uint16_t vrf_id = get_vrf_id(vid, link);
+  uint32_t port_id = nl->get_port_id(link);
+
+  return remove_ingress_vlan(port_id, vid, tagged, vrf_id);
+}
+
+// remove vid at ingress
+int nl_vlan::remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool pvid,
                                  uint16_t vrf_id) {
 
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
     auto members = nl->get_bond_members_by_port_id(port_id);
 
     for (auto mem : members) {
-      swi->ingress_port_vlan_remove(mem, vid, !tagged, vrf_id);
+      swi->ingress_port_vlan_remove(mem, vid, !pvid, vrf_id);
     }
   }
 
-  return swi->ingress_port_vlan_remove(port_id, vid, !tagged, vrf_id);
+  return swi->ingress_port_vlan_remove(port_id, vid, !pvid, vrf_id);
 }
 
 int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
@@ -282,6 +302,31 @@ int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
       remove_bridge_vlan(link, vid, pvid, tagged);
     }
   }
+
+  return rv;
+}
+
+int nl_vlan::update_egress_bridge_vlan(rtnl_link *link, uint16_t vid,
+                                       bool untagged) {
+  int rv;
+  assert(swi);
+
+  if (!is_vid_valid(vid)) {
+    LOG(ERROR) << __FUNCTION__ << ": invalid vid " << vid;
+    return -EINVAL;
+  }
+
+  uint32_t port_id = nl->get_port_id(link);
+
+  if (port_id == 0) {
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    return -EINVAL;
+  }
+
+  VLOG(2) << __FUNCTION__ << ": update egress vid=" << vid
+          << " tagged=" << untagged;
+
+  rv = swi->egress_port_vlan_add(port_id, vid, untagged, true);
 
   return rv;
 }

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -23,11 +23,17 @@ public:
 
   int add_vlan(rtnl_link *link, uint16_t vid, bool tagged);
   int remove_vlan(rtnl_link *link, uint16_t vid, bool tagged);
-  int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+
+  int add_ingress_vlan(rtnl_link *link, uint16_t vid, bool pvid);
+  int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool pvid,
                        uint16_t vrf_id = 0);
-  int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+
+  int remove_ingress_vlan(rtnl_link *link, uint16_t vid, bool pvid);
+  int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool pvid,
                           uint16_t vrf_id = 0);
+
   int add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid, bool tagged);
+  int update_egress_bridge_vlan(rtnl_link *link, uint16_t vid, bool tagged);
   void remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
                           bool tagged);
 

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -28,6 +28,9 @@ public:
   int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool pvid,
                        uint16_t vrf_id = 0);
 
+  int add_ingress_pvid(rtnl_link *link, uint16_t pvid);
+  int remove_ingress_pvid(rtnl_link *link, uint16_t vid);
+
   int remove_ingress_vlan(rtnl_link *link, uint16_t vid, bool pvid);
   int remove_ingress_vlan(uint32_t port_id, uint16_t vid, bool pvid,
                           uint16_t vrf_id = 0);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1590,6 +1590,57 @@ int controller::ingress_port_vlan_add(uint32_t port, uint16_t vid, bool pvid,
   return rv;
 }
 
+int controller::ingress_port_pvid_add(uint32_t port, uint16_t pvid) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0),
+        fm_driver.enable_port_pvid_ingress(dpt.get_version(), port, pvid));
+
+    uint32_t xid = 0;
+    dpt.send_barrier_request(rofl::cauxid(0), 1, &xid);
+    VLOG(2) << __FUNCTION__ << ": sent barrier with xid=" << (unsigned)xid;
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+
+int controller::ingress_port_pvid_remove(uint32_t port,
+                                         uint16_t pvid) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0),
+        fm_driver.disable_port_pvid_ingress(dpt.get_version(), port, pvid));
+
+    uint32_t xid = 0;
+    dpt.send_barrier_request(rofl::cauxid(0), 1, &xid);
+    VLOG(2) << __FUNCTION__ << ": sent barrier with xid=" << (unsigned)xid;
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+
 int controller::ingress_port_vlan_remove(uint32_t port, uint16_t vid, bool pvid,
                                          uint16_t vrf_id) noexcept {
   int rv = 0;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1663,8 +1663,8 @@ int controller::egress_port_vlan_drop_accept_all(uint32_t port) noexcept {
   return rv;
 }
 
-int controller::egress_port_vlan_add(uint32_t port, uint16_t vid,
-                                     bool untagged) noexcept {
+int controller::egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
+                                     bool update) noexcept {
   int rv = 0;
   try {
     // create filtered egress interface
@@ -1673,10 +1673,10 @@ int controller::egress_port_vlan_add(uint32_t port, uint16_t vid,
 
     if (nbi::get_port_type(port) == nbi::port_type_lag) {
       gm = fm_driver.enable_group_l2_trunk_interface(dpt.get_version(), port,
-                                                     vid, untagged);
+                                                     vid, untagged, update);
     } else {
       gm = fm_driver.enable_group_l2_interface(dpt.get_version(), port, vid,
-                                               untagged);
+                                               untagged, update);
     }
     dpt.send_group_mod_message(rofl::cauxid(0), gm);
   } catch (rofl::eRofBaseNotFound &e) {

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -238,6 +238,8 @@ public:
                             uint16_t vrf_id = 0) noexcept override;
   int ingress_port_vlan_remove(uint32_t port, uint16_t vid, bool pvid,
                                uint16_t vrf_id = 0) noexcept override;
+  int ingress_port_pvid_add(uint32_t port, uint16_t pvid) noexcept override;
+  int ingress_port_pvid_remove(uint32_t port, uint16_t pvid) noexcept override;
 
   int egress_port_vlan_accept_all(uint32_t port) noexcept override;
   int egress_port_vlan_drop_accept_all(uint32_t port) noexcept override;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -242,8 +242,8 @@ public:
   int egress_port_vlan_accept_all(uint32_t port) noexcept override;
   int egress_port_vlan_drop_accept_all(uint32_t port) noexcept override;
 
-  int egress_port_vlan_add(uint32_t port, uint16_t vid,
-                           bool untagged) noexcept override;
+  int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
+                           bool update = false) noexcept override;
   int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept override;
 
   int add_l2_overlay_flood(uint32_t tunnel_id,

--- a/src/sai.h
+++ b/src/sai.h
@@ -152,6 +152,9 @@ public:
                                     uint16_t vrf_id = 0) noexcept = 0;
   virtual int ingress_port_vlan_remove(uint32_t port, uint16_t vid, bool pvid,
                                        uint16_t vrf_id = 0) noexcept = 0;
+  virtual int ingress_port_pvid_add(uint32_t port, uint16_t pvid) noexcept = 0;
+  virtual int ingress_port_pvid_remove(uint32_t port,
+                                       uint16_t pvid) noexcept = 0;
   /* @} */
 
   /* @ Egress port vlan  { */

--- a/src/sai.h
+++ b/src/sai.h
@@ -158,8 +158,8 @@ public:
   virtual int egress_port_vlan_accept_all(uint32_t port) noexcept = 0;
   virtual int egress_port_vlan_drop_accept_all(uint32_t port) noexcept = 0;
 
-  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid,
-                                   bool untagged) noexcept = 0;
+  virtual int egress_port_vlan_add(uint32_t port, uint16_t vid, bool untagged,
+                                   bool update = false) noexcept = 0;
   virtual int egress_port_vlan_remove(uint32_t port, uint16_t vid) noexcept = 0;
 
   virtual int egress_bridge_port_vlan_add(uint32_t port, uint16_t vid,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
By exposing the update parameter to the l2 group interface, the controller thread is able to trigger updates to the egress
tables, thus allowing to refresh the egress untagged setting on the respective group.
There was pending code handling the untagged changes to bridge interfaces.

This PR uncomments the code, allowing the egress_untagged updatesto bridge ports being translated into the southbound.

Fixes #266 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When updating an access ports, we must be able to configure the egress (un)tagged parameter on the ASIC.
If the interface is initially set without untagged, we cannot change this behaviour without deleting the port from the bridge and reconfiguring it. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with the following script
```
#!/bin/bash

ip link add name swbridge type bridge vlan_filtering 1 vlan_default_pvid 0
ip link set swbridge up

ip link set port2 master swbridge 
ip link set port2 up

bridge vlan add vid 2 dev port2 pvid untagged
bridge vlan add vid 2 dev swbridge self
```

Expected client_grouptable_output
```
groupId = 0x00020001 (L2 Interface, VLAN ID = 2, Port ID = 1): 
            bucketIndex = 0: outputPort = 1 (Physical) *popVlanTag = 1* allowVlanTranslation = 0
```

After running the following command, thus updating the untagged parameter
```
bridge vlan add vid 2 dev port2 pvid 
```

Expected client_grouptable_output
```
groupId = 0x00020001 (L2 Interface, VLAN ID = 2, Port ID = 1): 
            bucketIndex = 0: outputPort = 1 (Physical) *popVlanTag = 0* allowVlanTranslation = 0
```

