### PR TITLE
handle neighbors moving between ports

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -208,6 +208,9 @@ private:
   void link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept;
   void link_deleted(rtnl_link *) noexcept;
 
+
+  bool check_ll_neigh(rtnl_neigh *neigh) noexcept;
+
   void neigh_ll_created(rtnl_neigh *neigh) noexcept;
   void neigh_ll_updated(rtnl_neigh *old_neigh, rtnl_neigh *new_neigh) noexcept;
   void neigh_ll_deleted(rtnl_neigh *neigh) noexcept;

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -682,7 +682,7 @@ void nl_bridge::update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
   }
 }
 
-void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh) {
+void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
   assert(sw);
   assert(neigh);
 
@@ -724,7 +724,7 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh) {
             << rtnl_link_get_name(bridge) << " on port=" << port
             << " vlan=" << (unsigned)vid << ", permanent=" << permanent;
   LOG(INFO) << __FUNCTION__ << ": object: " << OBJ_CAST(neigh);
-  sw->l2_addr_add(port, vid, _mac, true, permanent);
+  sw->l2_addr_add(port, vid, _mac, true, permanent, update);
 }
 
 void nl_bridge::remove_neigh_from_fdb(rtnl_neigh *neigh) {

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -166,7 +166,7 @@ public:
   void update_interface(rtnl_link *old_link, rtnl_link *new_link);
   void delete_interface(rtnl_link *);
 
-  void add_neigh_to_fdb(rtnl_neigh *);
+  void add_neigh_to_fdb(rtnl_neigh *, bool update = false);
   void remove_neigh_from_fdb(rtnl_neigh *);
 
   int mdb_entry_add(rtnl_mdb *mdb_entry);

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -155,7 +155,8 @@ public:
 
   int l2_addr_remove_all_in_vlan(uint32_t port, uint16_t vid) noexcept override;
   int l2_addr_add(uint32_t port, uint16_t vid, const rofl::caddress_ll &mac,
-                  bool filtered, bool permanent) noexcept override;
+                  bool filtered, bool permanent,
+                  bool update = false) noexcept override;
   int l2_addr_remove(uint32_t port, uint16_t vid,
                      const rofl::caddress_ll &mac) noexcept override;
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -56,7 +56,7 @@ public:
                                          uint16_t vid) noexcept = 0;
   virtual int l2_addr_add(uint32_t port, uint16_t vid,
                           const rofl::caddress_ll &mac, bool filtered,
-                          bool permanent) noexcept = 0;
+                          bool permanent, bool update = false) noexcept = 0;
   virtual int l2_addr_remove(uint32_t port, uint16_t vid,
                              const rofl::caddress_ll &mac) noexcept = 0;
 


### PR DESCRIPTION
Properly update forwarding entries for known neighbors moving to new ports.

Depends on OF-DPA changes actually notifying us about station moves.

## Description

Handle moving stations between ports by properly detecting if this happens, and updating the ext_learn entry in the kernel and the flow entry. 

## Motivation and Context

Moving between ports may happen if e.g. people move their laptops, or if roaming from one AP to another. Not updating the entry means no connectivity until the old entry times out.

## How Has This Been Tested?

Tested on as4610 (and questone-2a with slightly different port names)

Switch 1:

```
ip link add name swbridge type bridge vlan_filtering 1
ip link set port2 master swbridge
ip link set port3 master swbridge
ip link set port54 master swbridge
ip link set swbridge up
ip link set port2 up
ip link set port3 up
ip link set port54 up
```

Switch 2:

```
ip link set port54 up
ip address add 10.0.10.1/24 dev port54
```

Server 1:

```
ip link add name swbridge type bridge vlan_filtering 1
ip link set swbridge address '02:00:00:00:00:01'
ip address add 10.0.10.2/24 dev swbridge
ip link set up swbridge
```

then either:

```
ip link set eno2 up
ip link set eno3 up

ip link set eno2 master swbridge
ping 10.0.10.1 -c 3
ip link set eno2 nomaster
ip link set eno3 master swbridge
ping 10.0.10.1 -c 3
```

or 

```
ip link set eno2 master swbridge
ip link set eno3 master swbridge

ip link set eno2 up
ping 10.0.10.1 -c 3
ip link set eno2 down
ip link set eno3 up
ping 10.0.10.1 -c 3
```