### PR TITLE
nl_l3: fix check for address family

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -374,7 +374,7 @@ int nl_l3::add_lo_addr_v6(struct rtnl_addr *a) {
   auto addr = rtnl_addr_get_local(a);
 
   auto p = nl_addr_alloc(16);
-  nl_addr_parse("::1/128", AF_INET, &p);
+  nl_addr_parse("::1/128", AF_INET6, &p);
   std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
 
   if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {


### PR DESCRIPTION
The check for avoiding adding the ::1/128 address is broken due to a
false AF.

Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
