### PR TITLE
nl_bridge: unbreak handling of bridge vlan changes with multiple vlans

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -489,33 +489,33 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
       } else {
         done = 1;
       }
+    }
 
-      // Process untagged changes
-      i = -1;
-      done = 0;
-      while (!done) {
-        int j = find_next_bit(i, untagged_diff);
-        if (j > 0) {
-          // egress untagged changed
-          int vid = j - 1 + base_bit;
-          bool egress_untagged = false;
+    // Process untagged changes
+    i = -1;
+    done = 0;
+    while (!done) {
+      int j = find_next_bit(i, untagged_diff);
+      if (j > 0) {
+        // egress untagged changed
+        int vid = j - 1 + base_bit;
+        bool egress_untagged = false;
 
-          // check if egress is untagged
-          if (new_br_vlan->untagged_bitmap[k] & 1 << (j - 1)) {
-            egress_untagged = true;
-          }
-
-          VLOG(3) << __FUNCTION__ << ": change vid=" << vid
-                  << " on pport_no=" << pport_no
-                  << " egress untagged=" << egress_untagged
-                  << " link: " << OBJ_CAST(_link);
-
-          vlan->update_egress_bridge_vlan(_link, vid, egress_untagged);
-
-          i = j;
-        } else {
-          done = 1;
+        // check if egress is untagged
+        if (new_br_vlan->untagged_bitmap[k] & 1 << (j - 1)) {
+          egress_untagged = true;
         }
+
+        VLOG(3) << __FUNCTION__ << ": change vid=" << vid
+                << " on pport_no=" << pport_no
+                << " egress untagged=" << egress_untagged
+                << " link: " << OBJ_CAST(_link);
+
+        vlan->update_egress_bridge_vlan(_link, vid, egress_untagged);
+
+        i = j;
+      } else {
+        done = 1;
       }
     }
   }


### PR DESCRIPTION
When adding handling of untagged changes, it accidentially got added to
the loop processing the vlan diff, causing it to abort after the first
vlan, since it will process all untagged changes, then set done and
abort.

Fix this by moving the untagged_diff handling out of the vlan_diff
handling loop, so they cannot interfere with each other.

Config:

> $ bridge vlan show
> port              vlan-id
> swbridge          100
>                   101
>                   102
>                   111
> port54            100
>                   101
>                   102
>                   110
>                   111
>                   112

Before:

> $ client_flowtable_dump
> Table ID 10 (VLAN):   Retrieving all entries. Max entries = 16384, Current entries = 1.
> --  inPort = 54 (Physical)  vlanId:mask = 0x1064:0x1fff (VLAN 100) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 8

After:

> $ client_flowtable_dump
> Table ID 10 (VLAN):   Retrieving all entries. Max entries = 16384, Current entries = 6.
> --  inPort = 54 (Physical)  vlanId:mask = 0x1064:0x1fff (VLAN 100) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 8
> --  inPort = 54 (Physical)  vlanId:mask = 0x1065:0x1fff (VLAN 101) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 10
> --  inPort = 54 (Physical)  vlanId:mask = 0x1066:0x1fff (VLAN 102) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 12
> --  inPort = 54 (Physical)  vlanId:mask = 0x106e:0x1fff (VLAN 110) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 14
> --  inPort = 54 (Physical)  vlanId:mask = 0x106f:0x1fff (VLAN 111) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 16
> --  inPort = 54 (Physical)  vlanId:mask = 0x1070:0x1fff (VLAN 112) | GoTo = 20 (Termination MAC) | priority = 3 hard_time = 0 idle_time = 0 cookie = 18

Fixes: bce2a11 ("nl_bridge: implement processing of untagged changes")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
