### PR TITLE
simplify layer 2 multicast SAI interface 

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1028,16 +1028,9 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
 
     rofl::caddress_ll mc_ll = rofl::caddress_ll(buf, ETH_ALEN);
 
-    rv = sw->l2_multicast_group_add(port_id, vid, mc_ll);
+    rv = sw->l2_multicast_group_join(port_id, vid, mc_ll);
     if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__
-                 << ": failed to add Layer 2 Multicast Group Entry";
-      return rv;
-    }
-
-    rv = sw->l2_multicast_addr_add(port_id, vid, mc_ll);
-    if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": failed to add bridging MC entry";
+      LOG(ERROR) << __FUNCTION__ << ": failed to join Layer 2 Multicast Group";
       return rv;
     }
 
@@ -1115,23 +1108,10 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
 
     rofl::caddress_ll mc_ll = rofl::caddress_ll(buf, ETH_ALEN);
 
-    rv = sw->l2_multicast_group_remove(port_id, vid, mc_ll);
-
-    // nothing left to do, there are still entries in the mc group
-    if (rv < 0 && rv != -ENOTEMPTY) {
-      LOG(ERROR) << __FUNCTION__
-                 << ": failed to remove Layer 2 Multicast Group Entry";
+    rv = sw->l2_multicast_group_leave(port_id, vid, mc_ll);
+    if (rv < 0) {
+      LOG(ERROR) << __FUNCTION__ << ": failed to leave Layer 2 Multicast Group";
       return rv;
-    }
-
-    if (rv != -ENOTEMPTY) {
-      rv = sw->l2_multicast_addr_remove(port_id, vid, mc_ll);
-      if (rv < 0) {
-        LOG(ERROR) << __FUNCTION__ << ": failed to remove bridging MC entry";
-        return rv;
-      }
-    } else {
-      rv = 0;
     }
 
     VLOG(2) << __FUNCTION__ << ": mdb entry removed, port" << port_id

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -811,13 +811,12 @@ int controller::l2_overlay_addr_remove(uint32_t tunnel_id, uint32_t lport_id,
   return rv;
 }
 
-int controller::l2_multicast_group_add(uint32_t port, uint16_t vid,
-                                       rofl::caddress_ll mc_group) noexcept {
+int controller::l2_multicast_group_join(
+    uint32_t port, uint16_t vid, const rofl::caddress_ll &mc_group) noexcept {
   int rv = 0;
 
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
-
     int index = 1;
     struct multicast_entry n_mcast;
     n_mcast.key = std::make_tuple(mc_group, vid);
@@ -851,6 +850,11 @@ int controller::l2_multicast_group_add(uint32_t port, uint16_t vid,
                              dpt.get_version(), index, vid, it->l2_interface,
                              (it->l2_interface.size() > 1)));
 
+    // create flow when creating group
+    if (it->l2_interface.size() == 1)
+      dpt.send_flow_mod_message(
+          rofl::cauxid(0), fm_driver.add_bridging_multicast_vlan(
+                               dpt.get_version(), it->index, vid, mc_group));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -865,13 +869,12 @@ int controller::l2_multicast_group_add(uint32_t port, uint16_t vid,
   return rv;
 }
 
-int controller::l2_multicast_group_remove(uint32_t port, uint16_t vid,
-                                          rofl::caddress_ll mc_group) noexcept {
+int controller::l2_multicast_group_leave(
+    uint32_t port, uint16_t vid, const rofl::caddress_ll &mc_group) noexcept {
   int rv = 0;
 
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
-
     struct multicast_entry n_mcast;
     n_mcast.key = std::make_tuple(mc_group, vid);
 
@@ -893,15 +896,26 @@ int controller::l2_multicast_group_remove(uint32_t port, uint16_t vid,
 
     it->l2_interface.erase(set_it);
 
-    dpt.send_group_mod_message(
-        rofl::cauxid(0),
-        // send update without port
-        fm_driver.enable_group_l2_multicast(dpt.get_version(), it->index, vid,
-                                            it->l2_interface, true));
-
-    dpt.send_barrier_request(rofl::cauxid(0));
     if (it->l2_interface.size() != 0) {
-      return -ENOTEMPTY;
+      dpt.send_group_mod_message(
+          rofl::cauxid(0),
+          // send update without port
+          fm_driver.enable_group_l2_multicast(dpt.get_version(), it->index, vid,
+                                              it->l2_interface, true));
+
+      dpt.send_barrier_request(rofl::cauxid(0));
+    } else {
+      dpt.send_flow_mod_message(rofl::cauxid(0),
+                                fm_driver.remove_bridging_multicast_vlan(
+                                    dpt.get_version(), port, vid, mc_group));
+
+      dpt.send_barrier_request(rofl::cauxid(0));
+
+      dpt.send_group_mod_message(rofl::cauxid(0),
+                                 fm_driver.disable_group_l2_multicast(
+                                     dpt.get_version(), it->index, vid));
+
+      mc_groups.erase(it);
     }
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
@@ -917,115 +931,6 @@ int controller::l2_multicast_group_remove(uint32_t port, uint16_t vid,
   return rv;
 }
 
-int controller::l2_multicast_addr_add(uint32_t port, uint16_t vid,
-                                      const rofl::caddress_ll &mac) noexcept {
-  int rv = 0;
-
-  try {
-    rofl::crofdpt &dpt = set_dpt(dptid, true);
-    struct multicast_entry n_mcast;
-    n_mcast.key = std::make_tuple(mac, vid);
-
-    // find grp/vlan combination
-    auto it = std::find(mc_groups.begin(), mc_groups.end(), n_mcast);
-
-    dpt.send_flow_mod_message(rofl::cauxid(0),
-                              fm_driver.add_bridging_multicast_vlan(
-                                  dpt.get_version(), it->index, vid, mac));
-  } catch (rofl::eRofBaseNotFound &e) {
-    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
-    rv = -EINVAL;
-  } catch (rofl::eRofConnNotConnected &e) {
-    LOG(ERROR) << ": not connected msg=" << e.what();
-    rv = -ENOTCONN;
-  } catch (std::exception &e) {
-    LOG(ERROR) << ": caught unknown exception: " << e.what();
-    rv = -EINVAL;
-  }
-
-  return rv;
-}
-
-int controller::l2_multicast_addr_remove(
-    uint32_t port, uint16_t vid, const rofl::caddress_ll &mac) noexcept {
-  int rv = 0;
-
-  try {
-    rofl::crofdpt &dpt = set_dpt(dptid, true);
-
-    struct multicast_entry n_mcast;
-    n_mcast.key = std::make_tuple(mac, vid);
-
-    // find grp/vlan combination
-    auto it = std::find(mc_groups.begin(), mc_groups.end(), n_mcast);
-
-    dpt.send_flow_mod_message(rofl::cauxid(0),
-                              fm_driver.remove_bridging_multicast_vlan(
-                                  dpt.get_version(), port, vid, mac));
-
-    dpt.send_barrier_request(rofl::cauxid(0));
-
-    dpt.send_group_mod_message(
-        rofl::cauxid(0), fm_driver.disable_group_l2_multicast(dpt.get_version(),
-                                                              it->index, vid));
-
-    mc_groups.erase(it);
-
-  } catch (rofl::eRofBaseNotFound &e) {
-    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
-    rv = -EINVAL;
-  } catch (rofl::eRofConnNotConnected &e) {
-    LOG(ERROR) << ": not connected msg=" << e.what();
-    rv = -ENOTCONN;
-  } catch (std::exception &e) {
-    LOG(ERROR) << ": caught unknown exception: " << e.what();
-    rv = -EINVAL;
-  }
-
-  return rv;
-}
-
-int controller::l2_multicast_group_join(
-    uint32_t port, uint16_t vid, const rofl::caddress_ll &mc_group) noexcept {
-  int rv = l2_multicast_group_add(port, vid, mc_group);
-  if (rv < 0) {
-    LOG(ERROR) << __FUNCTION__
-               << ": failed to add Layer 2 Multicast Group Entry";
-    return rv;
-  }
-
-  rv = l2_multicast_addr_add(port, vid, mc_group);
-  if (rv < 0) {
-    LOG(ERROR) << __FUNCTION__ << ": failed to add bridging MC entry";
-    return rv;
-  }
-
-  return rv;
-}
-
-int controller::l2_multicast_group_leave(
-    uint32_t port, uint16_t vid, const rofl::caddress_ll &mc_group) noexcept {
-  int rv = l2_multicast_group_remove(port, vid, mc_group);
-
-  // nothing left to do, there are still entries in the mc group
-  if (rv < 0 && rv != -ENOTEMPTY) {
-    LOG(ERROR) << __FUNCTION__
-               << ": failed to remove Layer 2 Multicast Group Entry";
-    return rv;
-  }
-
-  if (rv != -ENOTEMPTY) {
-    rv = l2_multicast_addr_remove(port, vid, mc_group);
-    if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": failed to remove bridging MC entry";
-      return rv;
-    }
-  } else {
-    rv = 0;
-  }
-
-  return rv;
-}
 int controller::l3_termination_add(uint32_t sport, uint16_t vid,
                                    const rofl::caddress_ll &dmac) noexcept {
   int rv = 0;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -165,16 +165,14 @@ public:
                           bool permanent) noexcept override;
   int l2_overlay_addr_remove(uint32_t tunnel_id, uint32_t lport_id,
                              const rofl::cmacaddr &mac) noexcept override;
-  int l2_multicast_addr_add(uint32_t port, uint16_t vid,
-                            const rofl::caddress_ll &mac) noexcept override;
-  int l2_multicast_addr_remove(uint32_t port, uint16_t vid,
-                               const rofl::caddress_ll &mac) noexcept override;
 
   /* @ Layer 2 Multicast { */
-  int l2_multicast_group_add(uint32_t port, uint16_t vid,
-                             rofl::caddress_ll mc_group) noexcept override;
-  int l2_multicast_group_remove(uint32_t port, uint16_t vid,
-                                rofl::caddress_ll mc_group) noexcept override;
+  int l2_multicast_group_join(
+      uint32_t port, uint16_t vid,
+      const rofl::caddress_ll &mc_group) noexcept override;
+  int l2_multicast_group_leave(
+      uint32_t port, uint16_t vid,
+      const rofl::caddress_ll &mc_group) noexcept override;
   /* @} */
 
   // dmac = Multicast or Unicast MAC Address
@@ -381,6 +379,15 @@ private:
                              rofl::openflow::cofmsg_packet_in &msg);
 
   void handle_bridging_table_rm(rofl::openflow::cofmsg_flow_removed &msg);
+
+  int l2_multicast_addr_add(uint32_t port, uint16_t vid,
+                            const rofl::caddress_ll &mac) noexcept;
+  int l2_multicast_addr_remove(uint32_t port, uint16_t vid,
+                               const rofl::caddress_ll &mac) noexcept;
+  int l2_multicast_group_add(uint32_t port, uint16_t vid,
+                             rofl::caddress_ll mc_group) noexcept;
+  int l2_multicast_group_remove(uint32_t port, uint16_t vid,
+                                rofl::caddress_ll mc_group) noexcept;
 }; // class controller
 
 } // end of namespace basebox

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -379,15 +379,6 @@ private:
                              rofl::openflow::cofmsg_packet_in &msg);
 
   void handle_bridging_table_rm(rofl::openflow::cofmsg_flow_removed &msg);
-
-  int l2_multicast_addr_add(uint32_t port, uint16_t vid,
-                            const rofl::caddress_ll &mac) noexcept;
-  int l2_multicast_addr_remove(uint32_t port, uint16_t vid,
-                               const rofl::caddress_ll &mac) noexcept;
-  int l2_multicast_group_add(uint32_t port, uint16_t vid,
-                             rofl::caddress_ll mc_group) noexcept;
-  int l2_multicast_group_remove(uint32_t port, uint16_t vid,
-                                rofl::caddress_ll mc_group) noexcept;
 }; // class controller
 
 } // end of namespace basebox

--- a/src/sai.h
+++ b/src/sai.h
@@ -65,19 +65,15 @@ public:
                                   bool permanent) noexcept = 0;
   virtual int l2_overlay_addr_remove(uint32_t tunnel_id, uint32_t lport_id,
                                      const rofl::cmacaddr &mac) noexcept = 0;
-  virtual int l2_multicast_addr_add(uint32_t port, uint16_t vid,
-                                    const rofl::caddress_ll &mac) noexcept = 0;
-  virtual int
-  l2_multicast_addr_remove(uint32_t port, uint16_t vid,
-                           const rofl::caddress_ll &mac) noexcept = 0;
   /* @} */
 
   /* @ Layer 2 Multicast { */
-  virtual int l2_multicast_group_add(uint32_t port, uint16_t vid,
-                                     rofl::caddress_ll mc_group) noexcept = 0;
   virtual int
-  l2_multicast_group_remove(uint32_t port, uint16_t vid,
-                            rofl::caddress_ll mc_group) noexcept = 0;
+  l2_multicast_group_join(uint32_t port, uint16_t vid,
+                          const rofl::caddress_ll &mc_group) noexcept = 0;
+  virtual int
+  l2_multicast_group_leave(uint32_t port, uint16_t vid,
+                           const rofl::caddress_ll &mc_group) noexcept = 0;
   /* @} */
 
   /* @ termination MAC { */


### PR DESCRIPTION
Sinplify the SAI multicast interface into just join and leave calls, and hide the implementation details in controller.cc.

## Description
Currently l2 multicast handling is split into two sets functions, one for handling the multicast group and flow, and one for handling the joined ports to that group.

Since baseboxd does not track the number of group listeners, it needs the functions to tell it when to add or remove the group and flow. This makes it a bit awkward to use, so instead of forcing baseboxd to handle that, let the controller implementaton do that and just expose "generic" join and leave calls that do the flow/group creation in the background.

## Motivation and Context
It makes the code a bit more clearer and understandable.

## How Has This Been Tested?
Running multicast-ipv{4,6} on questones.
