### PR TITLE
drop multicast entries on bridge vlan removal

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -888,13 +888,10 @@ int controller::l2_multicast_group_leave(
                             ? fm_driver.group_id_l2_trunk_interface(port, vid)
                             : fm_driver.group_id_l2_interface(port, vid);
 
-    auto set_it = it->l2_interface.find(group_id);
-    if (set_it == it->l2_interface.end()) {
+    if (it->l2_interface.erase(group_id) == 0) {
       LOG(ERROR) << __FUNCTION__ << ": interface group not found";
       return -EINVAL;
     }
-
-    it->l2_interface.erase(set_it);
 
     if (it->l2_interface.size() != 0) {
       dpt.send_group_mod_message(

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -173,6 +173,10 @@ public:
   int l2_multicast_group_leave(uint32_t port, uint16_t vid,
                                const rofl::caddress_ll &mc_group,
                                bool disable_only = false) noexcept override;
+  int l2_multicast_group_rejoin_all_in_vlan(uint32_t port,
+                                           uint16_t vid) noexcept override;
+  int l2_multicast_group_leave_all_in_vlan(uint32_t port,
+                                           uint16_t vid) noexcept override;
   /* @} */
 
   // dmac = Multicast or Unicast MAC Address

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -170,9 +170,9 @@ public:
   int l2_multicast_group_join(
       uint32_t port, uint16_t vid,
       const rofl::caddress_ll &mc_group) noexcept override;
-  int l2_multicast_group_leave(
-      uint32_t port, uint16_t vid,
-      const rofl::caddress_ll &mc_group) noexcept override;
+  int l2_multicast_group_leave(uint32_t port, uint16_t vid,
+                               const rofl::caddress_ll &mc_group,
+                               bool disable_only = false) noexcept override;
   /* @} */
 
   // dmac = Multicast or Unicast MAC Address
@@ -341,6 +341,7 @@ private:
     std::tuple<rofl::caddress_ll, uint16_t> key;
     int index;
     std::set<uint32_t> l2_interface;
+    std::set<uint32_t> disabled_l2_interface;
 
     multicast_entry() {}
     bool operator==(const struct multicast_entry c1) { return (c1.key == key); }

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -345,7 +345,7 @@ private:
     multicast_entry() {}
     bool operator==(const struct multicast_entry c1) { return (c1.key == key); }
   };
-  std::deque<struct multicast_entry>
+  std::list<struct multicast_entry>
       mc_groups; // mac address, vlan , index, l2_interfaces
 
   rofl::cthread bb_thread;

--- a/src/sai.h
+++ b/src/sai.h
@@ -74,6 +74,10 @@ public:
   virtual int l2_multicast_group_leave(uint32_t port, uint16_t vid,
                                        const rofl::caddress_ll &mc_group,
                                        bool disable_only = false) noexcept = 0;
+  virtual int l2_multicast_group_rejoin_all_in_vlan(uint32_t port,
+                                         uint16_t vid) noexcept = 0;
+  virtual int l2_multicast_group_leave_all_in_vlan(uint32_t port,
+                                         uint16_t vid) noexcept = 0;
   /* @} */
 
   /* @ termination MAC { */

--- a/src/sai.h
+++ b/src/sai.h
@@ -71,9 +71,9 @@ public:
   virtual int
   l2_multicast_group_join(uint32_t port, uint16_t vid,
                           const rofl::caddress_ll &mc_group) noexcept = 0;
-  virtual int
-  l2_multicast_group_leave(uint32_t port, uint16_t vid,
-                           const rofl::caddress_ll &mc_group) noexcept = 0;
+  virtual int l2_multicast_group_leave(uint32_t port, uint16_t vid,
+                                       const rofl::caddress_ll &mc_group,
+                                       bool disable_only = false) noexcept = 0;
   /* @} */
 
   /* @ termination MAC { */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make sure we properly drop all multicast references to L2 interfaces on bridge vlan removal so deletion of the group can succeed.

## Description
Both L2 unicast as multicast entries keep references to the l2 interface. On deletion of a bridge vlan, we drop the unicast entries, but not the mulicast entries, causing the deletion of the l2 interface to fail, and thus the port to stay in the vlan.

We cannot rely on the kernel for that, since the kernel does not flush the mdb on port vlan removal. So we need to drop them ourselves. But on the same time, in case the vlan comes back immediately, we need to rejoin to match the kernel state again, since the entries will still exist.

So add a new disabled state for l2 interfaces to keep a list of those that should exist, removed if the kernel deletes the mdb entry.

## Motivation and Context
We should properly remove configuration on the switch state if not needed anymore.

## How Has This Been Tested?
Weekend pipelines of the AS4610.
