### PR TITLE
improve bridge ll neighbor handling

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1555,8 +1555,7 @@ void cnetlink::neigh_ll_created(rtnl_neigh *neigh) noexcept {
     // XXX TODO maybe we have to do this as well wrt. local bridging
     // normal bridging
     try {
-      if (bridge)
-        bridge->add_neigh_to_fdb(neigh);
+      bridge->add_neigh_to_fdb(neigh);
     } catch (std::exception &e) {
       LOG(ERROR) << __FUNCTION__
                  << ": failed to add mac to fdb"; // TODO log mac, port,...?
@@ -1601,8 +1600,7 @@ void cnetlink::neigh_ll_deleted(rtnl_neigh *neigh) noexcept {
   } break;
 
   default:
-    if (bridge)
-      bridge->remove_neigh_from_fdb(neigh);
+    bridge->remove_neigh_from_fdb(neigh);
   }
 }
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1502,6 +1502,11 @@ bool cnetlink::check_ll_neigh(rtnl_neigh *neigh) noexcept {
     return false;
   }
 
+  if (rtnl_neigh_get_master(neigh) != bridge->get_ifindex()) {
+    VLOG(1) << __FUNCTION__ << ": bridge not ours for neighour " << neigh;
+    return false;
+  }
+
   int ifindex = rtnl_neigh_get_ifindex(neigh);
   if (ifindex == 0) {
     VLOG(1) << __FUNCTION__ << ": no ifindex for neighbour " << neigh;

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1498,7 +1498,7 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
 // returns true if the neigh should be handled by us
 bool cnetlink::check_ll_neigh(rtnl_neigh *neigh) noexcept {
   if (nullptr == bridge) {
-    LOG(ERROR) << __FUNCTION__ << ": bridge not set";
+    VLOG(1) << __FUNCTION__ << ": bridge not set";
     return false;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make sure we do not try to handle l2 neighbors for other bridges, and be silent about them.

## Description
We may have additional bridges on the system, like `docker0`. So getting notifications about changes on a bridge without it being "our" bridge is perfectly normal.

## Motivation and Context
Appearance of the docker bridge might cause issues due to not properly filtering the notifications.

## How Has This Been Tested?
Weekend pipeline on the AS4610.