### PR TITLE
fix applying per vlan STP state to bond interfaces

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -85,6 +85,11 @@ public:
     return bridge->get_stp_state();
   }
 
+  std::map<uint16_t, uint8_t> get_port_vlan_stp_states(rtnl_link *link) {
+    assert(bridge);
+    return bridge->get_port_vlan_stp_states(link);
+  }
+
   nl_cache *get_cache(enum nl_cache_t id) { return caches[id]; }
 
   void resend_state() noexcept;

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -239,30 +239,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
         return rv;
 
       auto new_state = rtnl_link_bridge_get_port_state(br_link);
-      std::string state;
-
-      switch (new_state) {
-      case BR_STATE_FORWARDING:
-        state = "forward";
-        break;
-      case BR_STATE_BLOCKING:
-        state = "block";
-        break;
-      case BR_STATE_DISABLED:
-        state = "disable";
-        break;
-      case BR_STATE_LISTENING:
-        state = "listen";
-        break;
-      case BR_STATE_LEARNING:
-        state = "learn";
-        break;
-      default:
-        VLOG(1) << __FUNCTION__ << ": stp state change not supported";
-        return rv;
-      }
-
-      swi->ofdpa_stg_state_port_set(port_id, 1, state);
+      swi->ofdpa_stg_state_port_set(port_id, 1, new_state);
     }
 
     rv = nl->set_bridge_port_vlan_tpid(br_link);
@@ -326,7 +303,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   lag_members.erase(lm_rv);
 
   if (nl->is_bridge_interface(bond)) {
-    swi->ofdpa_stg_state_port_set(port_id, 1, "forward");
+    swi->ofdpa_stg_state_port_set(port_id, 1, BR_STATE_FORWARDING);
 
     auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
     rv = nl->unset_bridge_port_vlan_tpid(br_link);
@@ -344,7 +321,7 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
       nl->remove_l3_configuration(bond);
 
     if (nl->is_bridge_interface(bond))
-      swi->ofdpa_stg_state_port_set(port_id, 1, "forward");
+      swi->ofdpa_stg_state_port_set(port_id, 1, BR_STATE_FORWARDING);
 
     for (auto vid : vlans) {
       swi->ingress_port_vlan_remove(port_id, vid, false);

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1242,4 +1242,16 @@ int nl_bridge::drop_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
   return err;
 }
 
+std::map<uint16_t, uint8_t>
+nl_bridge::get_port_vlan_stp_states(rtnl_link *link) {
+  if (get_stp_state() == STP_STATE_DISABLED)
+    return {};
+
+  uint32_t port_id = nl->get_port_id(link);
+  if (port_id == 0)
+    return {};
+
+  return bridge_stp_states.get_min_states(port_id);
+}
+
 } /* namespace basebox */

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1127,6 +1127,25 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
   return rv;
 }
 
+int nl_bridge::set_port_vlan_stp_state(uint32_t port_id, uint16_t vid,
+                                       uint8_t state) {
+  auto err = 0;
+
+  if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
+    auto members = nl->get_bond_members_by_port_id(port_id);
+    auto err2 = 0;
+    for (auto mem : members) {
+      err2 = sw->ofdpa_stg_state_port_set(mem, vid, state);
+      if (err2 < 0)
+        err = err2;
+    }
+  } else {
+    err = sw->ofdpa_stg_state_port_set(port_id, vid, state);
+  }
+
+  return err;
+}
+
 void nl_bridge::set_port_stp_state(uint32_t port_id, uint8_t stp_state) {
   bridge_stp_states.add_global_state(port_id, stp_state);
 

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -184,6 +184,8 @@ public:
   int delete_vlan_proto(rtnl_link *link);
   uint32_t get_vlan_filtering();
 
+  std::map<uint16_t, uint8_t> get_port_vlan_stp_states(rtnl_link *link);
+
   void clear_tpid_entries();
 
   // XXX Improve cache search mechanism

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -215,6 +215,7 @@ private:
   int add_port_vlan_stp_state(uint32_t port_id, uint16_t vid,
                               uint8_t stp_state);
   int del_port_vlan_stp_state(uint32_t port_id, uint16_t vid);
+  int set_port_vlan_stp_state(uint32_t port_id, uint16_t vid, uint8_t state);
 
   rtnl_link *bridge;
   switch_interface *sw;

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -203,7 +203,6 @@ public:
 
 private:
   struct bridge_stp_states bridge_stp_states;
-  std::string stp_state_to_string(uint8_t state);
 
   void update_vlans(rtnl_link *, rtnl_link *);
 

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -315,7 +315,7 @@ public:
   int ofdpa_stg_destroy(uint16_t vlan_id) noexcept override;
 
   int ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
-                               std::string state) noexcept override;
+                               uint8_t state) noexcept override;
 
   /* print this */
   friend std::ostream &operator<<(std::ostream &os, const controller &box) {

--- a/src/sai.h
+++ b/src/sai.h
@@ -234,7 +234,7 @@ public:
   virtual int ofdpa_stg_destroy(uint16_t vlan_id) noexcept = 0;
 
   virtual int ofdpa_stg_state_port_set(uint32_t port_id, uint16_t vlan_id,
-                                       std::string state) noexcept = 0;
+                                       uint8_t state) noexcept = 0;
   /* @} */
 };
 


### PR DESCRIPTION
Fix applying per vlan STP state for bond interfaces by applying the state to all members of the bond group.

## Description
STP state is a state of physical ports, not logical ports in the switch, so when the kernel changes the stp state of a bond interface of a bridge, we need to propagate the state to all members of the bond interface.

We also need to make sure that when adding or removing an interface to a bond group that is also part of a bridge that we apply the currently configured stp state to the new bond member, or deconfigure it when the interface leaves.

## Motivation and Context
Allows using (M)STP on bridges with bond interfaces together.

## How Has This Been Tested?
Created a bridge with two bonds between both as4610 in testing (using ports 5/10 and 15/20), and checking the resulting stg stp states.