### PR TITLE
nl_bridge: fix local cache flush on vlan removal

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -468,8 +468,8 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
             std::unique_ptr<rtnl_neigh, decltype(&rtnl_neigh_put)> filter(
                 rtnl_neigh_alloc(), rtnl_neigh_put);
 
-            rtnl_neigh_set_ifindex(filter.get(), rtnl_link_get_ifindex(bridge));
-            rtnl_neigh_set_master(filter.get(), rtnl_link_get_master(bridge));
+            rtnl_neigh_set_ifindex(filter.get(), rtnl_link_get_ifindex(_link));
+            rtnl_neigh_set_master(filter.get(), rtnl_link_get_master(_link));
             rtnl_neigh_set_family(filter.get(), AF_BRIDGE);
             rtnl_neigh_set_vlan(filter.get(), vid);
             rtnl_neigh_set_flags(filter.get(), NTF_MASTER | NTF_EXT_LEARNED);


### PR DESCRIPTION
When deleting a vlan on a port, we need to flush the local cache entries
for the link, not the bridge.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>