### PR TITLE
nbi_impl: set link state last for tap devices

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -37,8 +37,8 @@ void nbi_impl::port_notification(
     case PORT_EVENT_MODIFY:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        tap_man->change_port_status(ntfy.name, ntfy.status);
         tap_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
+        tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
@@ -49,8 +49,8 @@ void nbi_impl::port_notification(
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
         tap_man->create_tapdev(ntfy.port_id, ntfy.name, *this);
-        tap_man->change_port_status(ntfy.name, ntfy.status);
         tap_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
+        tap_man->change_port_status(ntfy.name, ntfy.status);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?


### PR DESCRIPTION
Software or drivers like the bonding may try to read out the speed only
at link state changes, so we need to make sure that the link speed is
already set to the expected value when setting the link itself.

Else it may lead to e.g. bond interfaces with wrong link speeds with 10
Mbit/s, despite both links being up with 100Gbit/s.

Fixes: b5fe46c ("tap_manager: set port speed on tap interfaces")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>