### PR TITLE
Fix tmac entries not being removed when cleaning up the IP address

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1237,10 +1237,6 @@ int nl_l3::del_l3_termination(uint32_t port_id, uint16_t vid,
   }
 
   // check if not found
-
-  // Modifying the previously existing entries on the VLAN table requires
-  // removing the existing entry, since OFDPA requires that the VLAN must be
-  // configured with the same VRF
   if (i == termination_mac_mapping.end()) {
     LOG(WARNING)
         << __FUNCTION__


### PR DESCRIPTION
## Description
Deleting IP addresses from interfaces should remove references from termination MAC table, to ensure correct cleanup of state. 
As described in #362, by changing the MAC address on an interface, and attempting to delete the IP address of this interface, the entries do not seem to get removed. This is due to the cached link reference inside the address object that is about to be deleted. This reference is not updated after the MAC address change, which leads to wrong state being propagated.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is necessary for baseboxd to ensure that the state on the switch is cleanup correctly, and no flowtables are left pending.

## How Has This Been Tested?
```
ip address add 10.0.0.1/24 dev port1
ip link set port1 up 
ip link set address 02:01:01:02:01:02 dev port1
ip address delete 10.0.0.1/24 dev port1
```

Refer to #362 for further info on the output to be expected.