### PR TITLE
nl_bridge: take over fdb entries instead of creating them

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -905,17 +905,6 @@ int cnetlink::handle_source_mac_learn() {
     auto p = _packet_in.front();
     int ifindex = tap_man->get_ifindex(p.port_id);
 
-    if (ifindex && bridge) {
-      rtnl_link *br_link = get_link(ifindex, AF_BRIDGE);
-      VLOG(3) << __FUNCTION__ << ": ifindex=" << ifindex
-              << ", bridge=" << bridge << ", br_link=" << OBJ_CAST(br_link);
-
-      if (br_link) {
-        // learn the source mac
-        bridge->learn_source_mac(br_link, p.pkt);
-      }
-    }
-
     VLOG(3) << __FUNCTION__ << ": send pkt " << p.pkt
             << " to tap on fd=" << p.fd;
     // pass process packets to tap_man

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -173,7 +173,6 @@ public:
   int mdb_entry_remove(rtnl_mdb *mdb_entry);
 
   bool is_mac_in_l2_cache(rtnl_neigh *n);
-  int learn_source_mac(rtnl_link *br_link, packet *p);
   int fdb_timeout(rtnl_link *br_link, uint16_t vid,
                   const rofl::caddress_ll &mac);
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -1356,12 +1356,8 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, uint32_t lport,
     return -EINVAL;
   }
 
-  bool permanent = true;
-
-  assert(bridge);
-  if (bridge->is_mac_in_l2_cache(neigh)) {
-    permanent = false;
-  }
+  bool permanent =
+      !!(rtnl_neigh_get_state(neigh) & (NUD_NOARP | NUD_PERMANENT));
 
   auto neigh_mac = rtnl_neigh_get_lladdr(neigh);
   rofl::caddress_ll mac((uint8_t *)nl_addr_get_binary_addr(neigh_mac),


### PR DESCRIPTION
A recent fix for the kernel allows fdb entries to be switched to/from
ext_lern, so instead of inspecting every packet on reception, let the
kernel learn and take over fdb entries as ncessary.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Instead of trying to parse every incoming packet and try to learn the neighbors, just pass them on to the kernel and let it parse them, then handle the new neighbor notification.

This allows dropping the special handling in the RX path for bridges.

## Motivation and Context

Adding support for Broadcom KNET intertfaces means we will not be able to inspect every packet, so we need to instead take over learned neighbors.

## How Has This Been Tested?

Running a pipeline on switches, but should be tested more.