### PR TITLE
prepare support for alternative port device implementations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ sources = files('''
   src/netlink/tap_io.h
   src/netlink/tap_manager.cc
   src/netlink/tap_manager.h
+  src/netlink/port_manager.h
   src/of-dpa/controller.cc
   src/of-dpa/controller.h
   src/of-dpa/ofdpa_client.cc

--- a/src/basebox_api.cc
+++ b/src/basebox_api.cc
@@ -17,8 +17,8 @@
 namespace basebox {
 
 ApiServer::ApiServer(std::shared_ptr<switch_interface> swi,
-                     std::shared_ptr<tap_manager> tap_man)
-    : stats(new NetworkStats(swi, tap_man)) {}
+                     std::shared_ptr<port_manager> port_man)
+    : stats(new NetworkStats(swi, port_man)) {}
 
 ApiServer::~ApiServer() { delete stats; }
 

--- a/src/basebox_api.h
+++ b/src/basebox_api.h
@@ -11,12 +11,12 @@ namespace basebox {
 // forward declarations
 class NetworkStats;
 class switch_interface;
-class tap_manager;
+class port_manager;
 
 class ApiServer final {
 public:
   ApiServer(std::shared_ptr<switch_interface> swi,
-            std::shared_ptr<tap_manager> tap_man);
+            std::shared_ptr<port_manager> port_man);
   void runGRPCServer();
   ~ApiServer();
 

--- a/src/basebox_grpc_statistics.cc
+++ b/src/basebox_grpc_statistics.cc
@@ -8,7 +8,7 @@
 
 #include "basebox_grpc_statistics.h"
 #include "sai.h"
-#include "netlink/tap_manager.h"
+#include "netlink/port_manager.h"
 
 namespace basebox {
 
@@ -18,8 +18,8 @@ using openconfig_interfaces::Interfaces;
 using openconfig_interfaces::Interfaces_Interface;
 
 NetworkStats::NetworkStats(std::shared_ptr<switch_interface> swi,
-                           std::shared_ptr<tap_manager> tap_man)
-    : swi(std::move(swi)), tap_man(std::move(tap_man)) {}
+                           std::shared_ptr<port_manager> port_man)
+    : swi(std::move(swi)), port_man(std::move(port_man)) {}
 
 ::grpc::Status NetworkStats::GetStatistics(
     __attribute__((unused))::grpc::ServerContext *context,
@@ -39,7 +39,7 @@ NetworkStats::NetworkStats(std::shared_ptr<switch_interface> swi,
       switch_interface::SAI_PORT_STAT_RX_OVER_ERR,
       switch_interface::SAI_PORT_STAT_RX_CRC_ERR,
       switch_interface::SAI_PORT_STAT_COLLISIONS};
-  std::map<std::string, uint32_t> ports = tap_man->get_registered_ports();
+  std::map<std::string, uint32_t> ports = port_man->get_registered_ports();
 
   for (const auto &port : ports) {
     std::vector<uint64_t> stats(counter_ids.size());

--- a/src/basebox_grpc_statistics.h
+++ b/src/basebox_grpc_statistics.h
@@ -12,14 +12,14 @@ namespace basebox {
 
 // forward declarations
 class switch_interface;
-class tap_manager;
+class port_manager;
 
 class NetworkStats final : public ::api::NetworkStatistics::Service {
 public:
   typedef ::empty::Empty Empty;
 
   NetworkStats(std::shared_ptr<switch_interface> swi,
-               std::shared_ptr<tap_manager> tap_man);
+               std::shared_ptr<port_manager> port_man);
 
   virtual ~NetworkStats(){};
 
@@ -29,7 +29,7 @@ public:
 
 private:
   std::shared_ptr<switch_interface> swi;
-  std::shared_ptr<tap_manager> tap_man;
+  std::shared_ptr<port_manager> port_man;
 };
 
 } // namespace basebox

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
             << ": using OpenFlow version-bitmap: " << versionbitmap;
 
   std::shared_ptr<cnetlink> nl(new cnetlink());
-  std::shared_ptr<tap_manager> tap_man(new tap_manager(nl));
+  std::shared_ptr<tap_manager> tap_man(new tap_manager());
   std::unique_ptr<nbi_impl> nbi(new nbi_impl(nl, tap_man));
   std::shared_ptr<controller> box(
       new controller(std::move(nbi), versionbitmap, FLAGS_ofdpa_grpc_port));

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -28,6 +28,7 @@ int main(int argc, char **argv) {
   using basebox::cnetlink;
   using basebox::controller;
   using basebox::nbi_impl;
+  using basebox::port_manager;
   using basebox::tap_manager;
 
   if (!gflags::RegisterFlagValidator(&FLAGS_port, &validate_port)) {
@@ -55,15 +56,15 @@ int main(int argc, char **argv) {
             << ": using OpenFlow version-bitmap: " << versionbitmap;
 
   std::shared_ptr<cnetlink> nl(new cnetlink());
-  std::shared_ptr<tap_manager> tap_man(new tap_manager());
-  std::unique_ptr<nbi_impl> nbi(new nbi_impl(nl, tap_man));
+  std::shared_ptr<port_manager> port_man(new tap_manager());
+  std::unique_ptr<nbi_impl> nbi(new nbi_impl(nl, port_man));
   std::shared_ptr<controller> box(
       new controller(std::move(nbi), versionbitmap, FLAGS_ofdpa_grpc_port));
 
   rofl::csockaddr baddr(AF_INET, std::string("0.0.0.0"), FLAGS_port);
   box->dpt_sock_listen(baddr);
 
-  basebox::ApiServer grpcConnector(box, tap_man);
+  basebox::ApiServer grpcConnector(box, port_man);
   grpcConnector.runGRPCServer();
 
   LOG(INFO) << "bye";

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -880,13 +880,13 @@ void cnetlink::set_tapmanager(std::shared_ptr<port_manager> pm) {
 
 int cnetlink::send_nl_msg(nl_msg *msg) { return nl_send_sync(sock_tx, msg); }
 
-void cnetlink::learn_l2(uint32_t port_id, int fd, basebox::packet *pkt) {
+void cnetlink::learn_l2(uint32_t port_id, basebox::packet *pkt) {
   {
     std::lock_guard<std::mutex> scoped_lock(pi_mutex);
-    packet_in.emplace_back(port_id, fd, pkt);
+    packet_in.emplace_back(port_id, pkt);
   }
 
-  VLOG(2) << __FUNCTION__ << ": got pkt " << pkt << " for fd=" << fd;
+  VLOG(2) << __FUNCTION__ << ": got pkt " << pkt << " for port_id=" << port_id;
   thread.wakeup(this);
 }
 
@@ -905,8 +905,6 @@ int cnetlink::handle_source_mac_learn() {
     auto p = _packet_in.front();
     int ifindex = port_man->get_ifindex(p.port_id);
 
-    VLOG(3) << __FUNCTION__ << ": send pkt " << p.pkt
-            << " to tap on fd=" << p.fd;
     // pass process packets to port_man
     port_man->enqueue(p.port_id, p.pkt);
     _packet_in.pop_front();

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1429,9 +1429,6 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
 
   enum link_type lt = get_link_type(link);
 
-  int ifindex(rtnl_link_get_ifindex(link));
-  std::string portname(rtnl_link_get_name(link));
-
   switch (lt) {
   case LT_BRIDGE_SLAVE:
     try {
@@ -1444,7 +1441,7 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
     }
     break;
   case LT_TUN:
-    port_man->portdev_removed(ifindex, portname);
+    port_man->portdev_removed(link);
     break;
   case LT_BRIDGE:
     if (bridge && bridge->is_bridge_interface(link)) {

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -908,7 +908,7 @@ int cnetlink::handle_source_mac_learn() {
     VLOG(3) << __FUNCTION__ << ": send pkt " << p.pkt
             << " to tap on fd=" << p.fd;
     // pass process packets to port_man
-    port_man->enqueue(p.fd, p.pkt);
+    port_man->enqueue(p.port_id, p.pkt);
     _packet_in.pop_front();
   }
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1284,7 +1284,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
     vxlan->create_endpoint(link);
   } break;
   case LT_TUN: {
-    port_man->tapdev_ready(link);
+    port_man->portdev_ready(link);
   } break;
   case LT_VLAN: {
     VLOG(1) << __FUNCTION__ << ": new vlan interface " << OBJ_CAST(link);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1446,7 +1446,7 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
     }
     break;
   case LT_TUN:
-    port_man->tapdev_removed(ifindex, portname);
+    port_man->portdev_removed(ifindex, portname);
     break;
   case LT_BRIDGE:
     if (bridge && bridge->is_bridge_interface(link)) {

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -24,7 +24,7 @@ class nl_interface;
 class nl_l3;
 class nl_vlan;
 class nl_vxlan;
-class tap_manager;
+class port_manager;
 
 class cnetlink final : public rofl::cthread_env {
   friend class nl_bond;
@@ -103,7 +103,7 @@ public:
                        struct nl_object *new_obj, uint64_t diff, int action,
                        void *data);
 
-  void set_tapmanager(std::shared_ptr<tap_manager> tm);
+  void set_tapmanager(std::shared_ptr<port_manager> pm);
 
   int send_nl_msg(nl_msg *msg);
   void learn_l2(uint32_t port_id, int fd, packet *pkt);
@@ -147,7 +147,7 @@ private:
   enum nl_state state;
   std::deque<nl_obj> nl_objs;
 
-  std::shared_ptr<tap_manager> tap_man;
+  std::shared_ptr<port_manager> port_man;
   nl_bridge *bridge;
   std::shared_ptr<nl_interface> iface;
   std::shared_ptr<nl_bond> bond;

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -106,7 +106,7 @@ public:
   void set_tapmanager(std::shared_ptr<port_manager> pm);
 
   int send_nl_msg(nl_msg *msg);
-  void learn_l2(uint32_t port_id, int fd, packet *pkt);
+  void learn_l2(uint32_t port_id, packet *pkt);
 
   void fdb_timeout(uint32_t port_id, uint16_t vid,
                    const rofl::caddress_ll &mac);
@@ -156,10 +156,8 @@ private:
   std::shared_ptr<nl_vxlan> vxlan;
 
   struct nl_pkt_in {
-    nl_pkt_in(uint32_t port_id, int fd, packet *pkt)
-        : port_id(port_id), fd(fd), pkt(pkt) {}
+    nl_pkt_in(uint32_t port_id, packet *pkt) : port_id(port_id), pkt(pkt) {}
     uint32_t port_id;
-    int fd;
     packet *pkt;
   };
 

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -64,7 +64,7 @@ void nbi_impl::port_notification(
     case PORT_EVENT_DEL:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        port_man->destroy_tapdev(ntfy.port_id, ntfy.name);
+        port_man->destroy_portdev(ntfy.port_id, ntfy.name);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -91,8 +91,7 @@ int nbi_impl::enqueue(uint32_t port_id, basebox::packet *pkt) noexcept {
   assert(pkt);
   try {
     // detour via netlink to learn the source mac
-    int fd = port_man->get_fd(port_id);
-    nl->learn_l2(port_id, fd, pkt);
+    nl->learn_l2(port_id, pkt);
   } catch (std::exception &e) {
     LOG(ERROR) << __FUNCTION__
                << ": failed to enqueue packet for port_id=" << port_id << ": "

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -48,7 +48,7 @@ void nbi_impl::port_notification(
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        port_man->create_tapdev(ntfy.port_id, ntfy.name, *this);
+        port_man->create_portdev(ntfy.port_id, ntfy.name, *this);
         port_man->change_port_status(ntfy.name, ntfy.status);
         port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;

--- a/src/netlink/nbi_impl.h
+++ b/src/netlink/nbi_impl.h
@@ -7,20 +7,21 @@
 #include <memory>
 
 #include "sai.h"
-#include "tap_manager.h"
+#include "port_manager.h"
 
 namespace basebox {
 
 class cnetlink;
-class tap_manager;
+class port_manager;
 
 class nbi_impl : public nbi, public switch_callback {
   switch_interface *swi;
   std::shared_ptr<cnetlink> nl;
-  std::shared_ptr<tap_manager> tap_man;
+  std::shared_ptr<port_manager> port_man;
 
 public:
-  nbi_impl(std::shared_ptr<cnetlink> nl, std::shared_ptr<tap_manager> tap_man);
+  nbi_impl(std::shared_ptr<cnetlink> nl,
+           std::shared_ptr<port_manager> port_man);
   virtual ~nbi_impl();
 
   // nbi
@@ -35,7 +36,7 @@ public:
   // tap_callback
   int enqueue_to_switch(uint32_t port_id, struct basebox::packet *) override;
 
-  std::shared_ptr<tap_manager> get_tapmanager() { return tap_man; }
+  std::shared_ptr<port_manager> get_tapmanager() { return port_man; }
 };
 
 } // namespace basebox

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -29,14 +29,15 @@
 #include "nl_vlan.h"
 #include "nl_vxlan.h"
 #include "sai.h"
-#include "tap_manager.h"
+#include "port_manager.h"
 
 namespace basebox {
 
-nl_bridge::nl_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
-                     cnetlink *nl, std::shared_ptr<nl_vlan> vlan,
+nl_bridge::nl_bridge(switch_interface *sw,
+                     std::shared_ptr<port_manager> port_man, cnetlink *nl,
+                     std::shared_ptr<nl_vlan> vlan,
                      std::shared_ptr<nl_vxlan> vxlan)
-    : bridge(nullptr), sw(sw), tap_man(std::move(tap_man)), nl(nl),
+    : bridge(nullptr), sw(sw), port_man(std::move(port_man)), nl(nl),
       vlan(std::move(vlan)), vxlan(std::move(vxlan)),
       l2_cache(nl_cache_alloc(nl_cache_ops_lookup("route/neigh")),
                nl_cache_free) {

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -43,7 +43,7 @@ class cnetlink;
 class nl_vlan;
 class nl_vxlan;
 class switch_interface;
-class tap_manager;
+class port_manager;
 struct packet;
 
 struct key {
@@ -149,7 +149,7 @@ struct bridge_stp_states {
 
 class nl_bridge {
 public:
-  nl_bridge(switch_interface *sw, std::shared_ptr<tap_manager> tap_man,
+  nl_bridge(switch_interface *sw, std::shared_ptr<port_manager> port_man,
             cnetlink *nl, std::shared_ptr<nl_vlan> vlan,
             std::shared_ptr<nl_vxlan> vxlan);
 
@@ -193,7 +193,7 @@ public:
                                                    nl_addr *lladdr = nullptr);
 
   void get_bridge_ports(
-      std::tuple<std::shared_ptr<tap_manager>, std::deque<rtnl_link *> *>
+      std::tuple<std::shared_ptr<port_manager>, std::deque<rtnl_link *> *>
           &params, // XXX TODO make a struct here
       rtnl_link *br_port) noexcept;
 
@@ -220,7 +220,7 @@ private:
 
   rtnl_link *bridge;
   switch_interface *sw;
-  std::shared_ptr<tap_manager> tap_man;
+  std::shared_ptr<port_manager> port_man;
   cnetlink *nl;
   std::shared_ptr<nl_vlan> vlan;
   std::shared_ptr<nl_vxlan> vxlan;

--- a/src/netlink/nl_interface.cc
+++ b/src/netlink/nl_interface.cc
@@ -5,7 +5,7 @@
 #include <netlink/route/link.h>
 
 #include "nl_interface.h"
-#include "tap_manager.h"
+#include "port_manager.h"
 
 namespace basebox {
 
@@ -14,7 +14,7 @@ nl_interface::nl_interface(cnetlink *nl) : nl(nl) {}
 int nl_interface::changed(rtnl_link *old_link, rtnl_link *new_link) noexcept {
 
   if (rtnl_link_get_mtu(old_link) != rtnl_link_get_mtu(new_link)) {
-    tm->update_mtu(new_link);
+    pm->update_mtu(new_link);
   }
 
   return 0;

--- a/src/netlink/nl_interface.h
+++ b/src/netlink/nl_interface.h
@@ -13,17 +13,17 @@ struct rtnl_link;
 namespace basebox {
 
 class cnetlink;
-class tap_manager;
+class port_manager;
 
 class nl_interface {
 public:
   nl_interface(cnetlink *nl);
 
-  void set_tapmanager(std::shared_ptr<tap_manager> tm) { this->tm = tm; }
+  void set_tapmanager(std::shared_ptr<port_manager> pm) { this->pm = pm; }
   int changed(rtnl_link *old_link, rtnl_link *new_link) noexcept;
 
 private:
-  std::shared_ptr<tap_manager> tm;
+  std::shared_ptr<port_manager> pm;
   cnetlink *nl;
 };
 

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -428,7 +428,10 @@ uint16_t nl_vlan::get_vid(rtnl_link *link) {
     vid = rtnl_link_vlan_get_id(link);
     break;
   default:
-    if (rtnl_link_get_ifindex(link) != 1)
+    // port or bond interface
+    if (nl->get_port_id(link) > 0)
+      vid = default_vid;
+    else if (rtnl_link_get_ifindex(link) != 1)
       LOG(ERROR) << __FUNCTION__ << ": unsupported link type " << lt
                  << " of link " << OBJ_CAST(link);
     break;

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -78,8 +78,8 @@ public:
                              uint8_t duplex) = 0;
 
   // access from northbound (cnetlink)
-  virtual int portdev_removed(rtnl_link *link) = 0;
-  virtual void portdev_ready(rtnl_link *link) = 0;
+  virtual bool portdev_removed(rtnl_link *link) = 0;
+  virtual bool portdev_ready(rtnl_link *link) = 0;
   virtual int update_mtu(rtnl_link *link) = 0;
 
 protected:

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -40,7 +40,7 @@ public:
   virtual int destroy_portdev(uint32_t port_id,
                               const std::string &port_name) = 0;
 
-  virtual int enqueue(int fd, basebox::packet *pkt) = 0;
+  virtual int enqueue(uint32_t port_id, basebox::packet *pkt) = 0;
 
   std::map<std::string, uint32_t> get_registered_ports() const {
     std::lock_guard<std::mutex> lock(tn_mutex);

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <deque>
+#include <string>
+#include <map>
+#include <memory>
+#include <mutex>
+
+#include "sai.h"
+#include <linux/ethtool.h>
+
+extern "C" {
+struct rtnl_link;
+}
+
+namespace basebox {
+
+class cnetlink;
+class port_manager;
+
+class switch_callback {
+public:
+  virtual ~switch_callback() = default;
+  virtual int enqueue_to_switch(uint32_t port_id, basebox::packet *) = 0;
+};
+
+class port_manager {
+
+public:
+  port_manager(){};
+  ~port_manager(){};
+
+  virtual int create_tapdev(uint32_t port_id, const std::string &port_name,
+                            switch_callback &callback) = 0;
+
+  virtual int destroy_tapdev(uint32_t port_id,
+                             const std::string &port_name) = 0;
+
+  virtual int enqueue(int fd, basebox::packet *pkt) = 0;
+
+  std::map<std::string, uint32_t> get_registered_ports() const {
+    std::lock_guard<std::mutex> lock(tn_mutex);
+    return tap_names2id;
+  }
+
+  uint32_t get_port_id(int ifindex) const noexcept {
+    // XXX TODO add assert wrt threading
+    auto it = ifindex_to_id.find(ifindex);
+    if (it == ifindex_to_id.end()) {
+      return 0;
+    } else {
+      return it->second;
+    }
+  }
+
+  int get_ifindex(uint32_t port_id) const noexcept {
+    // XXX TODO add assert wrt threading
+    auto it = id_to_ifindex.find(port_id);
+    if (it == id_to_ifindex.end()) {
+      return 0;
+    } else {
+      return it->second;
+    }
+  }
+
+  void clear() noexcept {
+    std::lock_guard<std::mutex> lock(tn_mutex);
+    ifindex_to_id.clear();
+    id_to_ifindex.clear();
+  }
+
+  virtual int get_fd(uint32_t port_id) const noexcept = 0;
+
+  virtual int change_port_status(const std::string name, bool status) = 0;
+  virtual int set_port_speed(const std::string name, uint32_t speed,
+                             uint8_t duplex) = 0;
+
+  // access from northbound (cnetlink)
+  virtual int tapdev_removed(int ifindex, const std::string &portname) = 0;
+  virtual void tapdev_ready(rtnl_link *link) = 0;
+  virtual int update_mtu(rtnl_link *link) = 0;
+
+protected:
+  port_manager(const port_manager &other) = delete; // non construction-copyable
+  port_manager &operator=(const port_manager &) = delete; // non copyable
+
+  // locked access
+  mutable std::mutex tn_mutex; // tap names mutex
+  std::map<std::string, uint32_t> tap_names2id;
+
+  // only accessible from cnetlink
+  std::map<int, uint32_t> ifindex_to_id;
+  std::map<uint32_t, int> id_to_ifindex;
+};
+
+} // namespace basebox

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -34,8 +34,8 @@ public:
   port_manager(){};
   ~port_manager(){};
 
-  virtual int create_tapdev(uint32_t port_id, const std::string &port_name,
-                            switch_callback &callback) = 0;
+  virtual int create_portdev(uint32_t port_id, const std::string &port_name,
+                             switch_callback &callback) = 0;
 
   virtual int destroy_tapdev(uint32_t port_id,
                              const std::string &port_name) = 0;

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -44,7 +44,7 @@ public:
 
   std::map<std::string, uint32_t> get_registered_ports() const {
     std::lock_guard<std::mutex> lock(tn_mutex);
-    return tap_names2id;
+    return port_names2id;
   }
 
   uint32_t get_port_id(int ifindex) const noexcept {
@@ -90,7 +90,7 @@ protected:
 
   // locked access
   mutable std::mutex tn_mutex; // tap names mutex
-  std::map<std::string, uint32_t> tap_names2id;
+  std::map<std::string, uint32_t> port_names2id;
 
   // only accessible from cnetlink
   std::map<int, uint32_t> ifindex_to_id;

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -78,7 +78,7 @@ public:
                              uint8_t duplex) = 0;
 
   // access from northbound (cnetlink)
-  virtual int portdev_removed(int ifindex, const std::string &portname) = 0;
+  virtual int portdev_removed(rtnl_link *link) = 0;
   virtual void portdev_ready(rtnl_link *link) = 0;
   virtual int update_mtu(rtnl_link *link) = 0;
 

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -81,7 +81,7 @@ public:
 
   // access from northbound (cnetlink)
   virtual int portdev_removed(int ifindex, const std::string &portname) = 0;
-  virtual void tapdev_ready(rtnl_link *link) = 0;
+  virtual void portdev_ready(rtnl_link *link) = 0;
   virtual int update_mtu(rtnl_link *link) = 0;
 
 protected:

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -37,8 +37,8 @@ public:
   virtual int create_portdev(uint32_t port_id, const std::string &port_name,
                              switch_callback &callback) = 0;
 
-  virtual int destroy_tapdev(uint32_t port_id,
-                             const std::string &port_name) = 0;
+  virtual int destroy_portdev(uint32_t port_id,
+                              const std::string &port_name) = 0;
 
   virtual int enqueue(int fd, basebox::packet *pkt) = 0;
 

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -73,8 +73,6 @@ public:
     id_to_ifindex.clear();
   }
 
-  virtual int get_fd(uint32_t port_id) const noexcept = 0;
-
   virtual int change_port_status(const std::string name, bool status) = 0;
   virtual int set_port_speed(const std::string name, uint32_t speed,
                              uint8_t duplex) = 0;

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -80,7 +80,7 @@ public:
                              uint8_t duplex) = 0;
 
   // access from northbound (cnetlink)
-  virtual int tapdev_removed(int ifindex, const std::string &portname) = 0;
+  virtual int portdev_removed(int ifindex, const std::string &portname) = 0;
   virtual void tapdev_ready(rtnl_link *link) = 0;
   virtual int update_mtu(rtnl_link *link) = 0;
 

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -230,7 +230,11 @@ int tap_manager::update_mtu(rtnl_link *link) {
   return 0;
 }
 
-int tap_manager::portdev_removed(int ifindex, const std::string &portname) {
+int tap_manager::portdev_removed(rtnl_link *link) {
+  assert(link);
+
+  int ifindex(rtnl_link_get_ifindex(link));
+  std::string portname(rtnl_link_get_name(link));
   int rv = 0;
   bool port_removed(false);
   std::lock_guard<std::mutex> lock{tn_mutex};

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -148,7 +148,7 @@ int tap_manager::get_fd(uint32_t port_id) const noexcept {
   return it->second->get_fd();
 }
 
-void tap_manager::tapdev_ready(rtnl_link *link) {
+void tap_manager::portdev_ready(rtnl_link *link) {
   assert(link);
 
   // already registered?

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -91,8 +91,8 @@ int tap_manager::create_portdev(uint32_t port_id, const std::string &port_name,
   return r;
 }
 
-int tap_manager::destroy_tapdev(uint32_t port_id,
-                                const std::string &port_name) {
+int tap_manager::destroy_portdev(uint32_t port_id,
+                                 const std::string &port_name) {
   auto it = tap_devs.find(port_id);
   if (it == tap_devs.end()) {
     LOG(WARNING) << __FUNCTION__ << ": called for invalid port_id=" << port_id

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -222,7 +222,7 @@ int tap_manager::update_mtu(rtnl_link *link) {
   return 0;
 }
 
-int tap_manager::tapdev_removed(int ifindex, const std::string &portname) {
+int tap_manager::portdev_removed(int ifindex, const std::string &portname) {
   int rv = 0;
   bool port_removed(false);
   std::lock_guard<std::mutex> lock{tn_mutex};

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -133,6 +133,8 @@ int tap_manager::enqueue(uint32_t port_id, basebox::packet *pkt) {
     return 0;
   }
 
+  VLOG(3) << __FUNCTION__ << ": send pkt " << pkt << " to tap on fd=" << fd;
+
   try {
     io->enqueue(fd, pkt);
   } catch (std::exception &e) {

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -126,7 +126,13 @@ int tap_manager::destroy_portdev(uint32_t port_id,
   return 0;
 }
 
-int tap_manager::enqueue(int fd, basebox::packet *pkt) {
+int tap_manager::enqueue(uint32_t port_id, basebox::packet *pkt) {
+  int fd = get_fd(port_id);
+  if (fd < 0) {
+    std::free(pkt);
+    return 0;
+  }
+
   try {
     io->enqueue(fd, pkt);
   } catch (std::exception &e) {

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -21,8 +21,7 @@
 
 namespace basebox {
 
-tap_manager::tap_manager(std::shared_ptr<cnetlink> nl)
-    : io(new tap_io()), nl(std::move(nl)) {}
+tap_manager::tap_manager() : io(new tap_io()) {}
 
 tap_manager::~tap_manager() {
   std::map<uint32_t, ctapdev *> ddevs;

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -31,8 +31,8 @@ tap_manager::~tap_manager() {
   }
 }
 
-int tap_manager::create_tapdev(uint32_t port_id, const std::string &port_name,
-                               switch_callback &cb) {
+int tap_manager::create_portdev(uint32_t port_id, const std::string &port_name,
+                                switch_callback &cb) {
   int r = 0;
   bool dev_exists = false;
   bool dev_name_exists = false;

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -37,8 +37,6 @@ public:
 
   int enqueue(uint32_t port_id, basebox::packet *pkt);
 
-  int get_fd(uint32_t port_id) const noexcept;
-
   int change_port_status(const std::string name, bool status);
   int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
 
@@ -60,6 +58,8 @@ private:
   std::unique_ptr<tap_io> io;
 
   int recreate_tapdev(int ifindex, const std::string &portname);
+
+  int get_fd(uint32_t port_id) const noexcept;
 };
 
 } // namespace basebox

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 
+#include "port_manager.h"
 #include "sai.h"
 #include <linux/ethtool.h>
 
@@ -23,13 +24,7 @@ class ctapdev;
 class tap_io;
 class tap_manager;
 
-class switch_callback {
-public:
-  virtual ~switch_callback() = default;
-  virtual int enqueue_to_switch(uint32_t port_id, basebox::packet *) = 0;
-};
-
-class tap_manager final {
+class tap_manager final : public port_manager {
 
 public:
   tap_manager();
@@ -41,37 +36,6 @@ public:
   int destroy_tapdev(uint32_t port_id, const std::string &port_name);
 
   int enqueue(int fd, basebox::packet *pkt);
-
-  std::map<std::string, uint32_t> get_registered_ports() const {
-    std::lock_guard<std::mutex> lock(tn_mutex);
-    return tap_names2id;
-  }
-
-  uint32_t get_port_id(int ifindex) const noexcept {
-    // XXX TODO add assert wrt threading
-    auto it = ifindex_to_id.find(ifindex);
-    if (it == ifindex_to_id.end()) {
-      return 0;
-    } else {
-      return it->second;
-    }
-  }
-
-  int get_ifindex(uint32_t port_id) const noexcept {
-    // XXX TODO add assert wrt threading
-    auto it = id_to_ifindex.find(port_id);
-    if (it == id_to_ifindex.end()) {
-      return 0;
-    } else {
-      return it->second;
-    }
-  }
-
-  void clear() noexcept {
-    std::lock_guard<std::mutex> lock(tn_mutex);
-    ifindex_to_id.clear();
-    id_to_ifindex.clear();
-  }
 
   int get_fd(uint32_t port_id) const noexcept;
 
@@ -87,18 +51,11 @@ private:
   tap_manager(const tap_manager &other) = delete; // non construction-copyable
   tap_manager &operator=(const tap_manager &) = delete; // non copyable
 
-  // locked access
-  mutable std::mutex tn_mutex; // tap names mutex
-  std::map<std::string, uint32_t> tap_names2id;
   std::map<std::string, int> tap_names2fds;
 
   // only accessible from southbound
   std::map<uint32_t, ctapdev *> tap_devs; // port id:tap_device
   std::deque<uint32_t> port_deleted;
-
-  // only accessible from cnetlink
-  std::map<int, uint32_t> ifindex_to_id;
-  std::map<uint32_t, int> id_to_ifindex;
 
   std::unique_ptr<tap_io> io;
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -35,7 +35,7 @@ public:
 
   int destroy_portdev(uint32_t port_id, const std::string &port_name);
 
-  int enqueue(int fd, basebox::packet *pkt);
+  int enqueue(uint32_t port_id, basebox::packet *pkt);
 
   int get_fd(uint32_t port_id) const noexcept;
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -33,7 +33,7 @@ public:
   int create_portdev(uint32_t port_id, const std::string &port_name,
                      switch_callback &callback);
 
-  int destroy_tapdev(uint32_t port_id, const std::string &port_name);
+  int destroy_portdev(uint32_t port_id, const std::string &port_name);
 
   int enqueue(int fd, basebox::packet *pkt);
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -43,7 +43,7 @@ public:
   int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
 
   // access from northbound (cnetlink)
-  int tapdev_removed(int ifindex, const std::string &portname);
+  int portdev_removed(int ifindex, const std::string &portname);
   void tapdev_ready(rtnl_link *link);
   int update_mtu(rtnl_link *link);
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -41,7 +41,7 @@ public:
   int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
 
   // access from northbound (cnetlink)
-  int portdev_removed(int ifindex, const std::string &portname);
+  int portdev_removed(rtnl_link *link);
   void portdev_ready(rtnl_link *link);
   int update_mtu(rtnl_link *link);
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -41,8 +41,8 @@ public:
   int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
 
   // access from northbound (cnetlink)
-  int portdev_removed(rtnl_link *link);
-  void portdev_ready(rtnl_link *link);
+  bool portdev_removed(rtnl_link *link);
+  bool portdev_ready(rtnl_link *link);
   int update_mtu(rtnl_link *link);
 
 private:

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -19,7 +19,6 @@ struct rtnl_link;
 
 namespace basebox {
 
-class cnetlink;
 class ctapdev;
 class tap_io;
 class tap_manager;
@@ -33,7 +32,7 @@ public:
 class tap_manager final {
 
 public:
-  tap_manager(std::shared_ptr<cnetlink> nl);
+  tap_manager();
   ~tap_manager();
 
   int create_tapdev(uint32_t port_id, const std::string &port_name,
@@ -102,7 +101,6 @@ private:
   std::map<uint32_t, int> id_to_ifindex;
 
   std::unique_ptr<tap_io> io;
-  std::shared_ptr<cnetlink> nl;
 
   int recreate_tapdev(int ifindex, const std::string &portname);
 };

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -30,8 +30,8 @@ public:
   tap_manager();
   ~tap_manager();
 
-  int create_tapdev(uint32_t port_id, const std::string &port_name,
-                    switch_callback &callback);
+  int create_portdev(uint32_t port_id, const std::string &port_name,
+                     switch_callback &callback);
 
   int destroy_tapdev(uint32_t port_id, const std::string &port_name);
 

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -44,7 +44,7 @@ public:
 
   // access from northbound (cnetlink)
   int portdev_removed(int ifindex, const std::string &portname);
-  void tapdev_ready(rtnl_link *link);
+  void portdev_ready(rtnl_link *link);
   int update_mtu(rtnl_link *link);
 
 private:


### PR DESCRIPTION
Abtract out relevant code for managing port devices and replace any references to tap devices to be able to support alternative port implementations in the future.

## Description
To be able to cleanly support e..g knet based port interfaces, we need to refactor our current code to work in a way it does not matter anymore if interfaces are tap interfaces or not.

The steps to reach this are
1. create an interface for creating/destroying/matching port net devices, and sending packets to them.
2. rework basebox::tap_manager to implement that interface.
3. Let all code in baseboxd use the interface instead of tap_manager directly.
4. replace all direct checks for LT_TUN with a check wether the interface has a port_id assigned.

## Motivation and Context
We want to be able to use bcm-knet based interfaces when running on switch, which gives us greatly reduced latencies (on TH+ pings to the switch go from ~3 ms to ~0.2 ms).

This also lays some ground work for eventually supporting other interfaces for configuring switch ASICs than OF-DPA.

## How Has This Been Tested?
Running a pipeline on Agema ag5648s, with no breakage being introduced.