### PR TITLE
nl_l3: only route l3 neighs if we have a route for them

### DIFF
--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -51,6 +51,13 @@ struct nh_stub {
     nl_addr_put(nh);
   }
 
+  bool operator<(const nh_stub& other) const {
+         if (nl_addr_cmp(nh, other.nh) < 0)
+		return true;
+
+	 return ifindex < other.ifindex;
+  }
+
   nl_addr *nh;
   int ifindex;
 };


### PR DESCRIPTION
Make sure we do not add host entries for l3 neighs for which we do not
have a route until we a route gets added, and drop the host entries
again when the route gets removed.

To do this, we need to start keeping track of all l3 neighs we currently
handle. To make this easy, use set, and reuse the nh_stub to store the
neighbor information.

To allow nh_stub to be used in a set, we need to make it comparable, so
implement the < operator for it.

Using this we can then determine the routability of a l3 neigh we add by
asking the kernel for the route to it, then checking if it has a nexthop
that exist on one of our interfaces.

Only if this is true, add a host route for it and add it to the set of
routed l3 neighbours, in all other cases add it to the set of unrouted
l3 neighbours.

Then when adding a route, add all currently unrouted l3 neighbors
matching this route, and conversely, when removing a route remove all
matching l3 neighbors that are currently routed.

Fixes l3 neighbours learned on an additional on-link staying reachable
after removing the on-link route.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
Using the commands from https://github.com/bisdn/basebox/issues/364 and verified that no host entries get added without a on-link route, and the host entry appearing and vanashing when adding and removing the on-link route.

Running a pipeline on ag5648 to check for regressions.