### PR TITLE
port_manager: make destructor virtual

### DIFF
--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -32,7 +32,7 @@ class port_manager {
 
 public:
   port_manager(){};
-  ~port_manager(){};
+  virtual ~port_manager(){};
 
   virtual int create_portdev(uint32_t port_id, const std::string &port_name,
                              switch_callback &callback) = 0;


### PR DESCRIPTION
The port_manager is an interface class. The destructor should be
implemented by whatever class inherits port_manager.

Avoids the compilation warning

```
```[3/18] Compiling C++ object baseboxd.p/src_netlink_ctapdev.cc.o
In file included from ../src/netlink/tap_manager.h:13,
from ../src/netlink/ctapdev.cc:18:
../src/netlink/port_manager.h:31:7: warning: 'class
basebox::port_manager' has virtual functions and accessible non-virtual
destructor [-Wnon-virtual-dtor]
31 | class port_manager {
|       ^~~~~~~~~~~~
```

Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
