### PR TITLE
add a post exit script to remove KNET interfaces

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -239,3 +239,6 @@ executable('baseboxd',
   ],
   install: true,
   install_dir: bindir)
+
+install_data('scripts/baseboxd-knet-reset.py',
+  install_dir: bindir)

--- a/pkg/systemd/baseboxd.service.in
+++ b/pkg/systemd/baseboxd.service.in
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=notify
 ExecStart=@bindir@/baseboxd
+ExecStopPost=@bindir@/baseboxd-knet-reset.py
 EnvironmentFile=-@sysconfdir@/sysconfig/baseboxd
 Restart=always
 NotifyAccess=main

--- a/scripts/baseboxd-knet-reset.py
+++ b/scripts/baseboxd-knet-reset.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Helper script for resetting KNET to its initial state by removing all
+# added interfaces and filters, intended to be called after stopping
+# baseboxd.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+from ctypes import *
+import fcntl
+import os
+
+class bkn_ioctl_t(Structure):
+    _fields_ = [("rc", c_int),
+                ("len", c_int),
+                ("bufsz", c_int),
+                ("reserved", c_int),
+                ("buf", c_uint64)]
+
+class kcom_msg_hdr_t(Structure):
+    _fields_ = [("type", c_uint8),
+                ("opcode", c_uint8),
+                ("seqno", c_uint8),
+                ("status", c_uint8),
+                ("unit", c_uint8),
+                ("reserved", c_uint8),
+                ("id", c_uint16)]
+
+class kcom_msg_list_t(Structure):
+    _fields_ = [("hdr", kcom_msg_hdr_t),
+                ("fcnt", c_uint16),
+                ("id", c_uint16 * 128)]
+
+KCOM_MSG_TYPE_CMD = 1
+
+KCOM_M_NETIF_DESTROY = 12
+KCOM_M_NETIF_LIST = 13
+
+KCOM_M_FILTER_DESTROY = 22
+KCOM_M_FILTER_LIST = 23
+
+# Used for NETIF_DESTROY and FILTER_DESTROY.
+#
+# Both use only the id field of the header to identify the filter/netif
+# to destroy.
+def delete_kcom_object(fd, obj_id, opcode):
+    hdr = kcom_msg_hdr_t()
+    hdr.type = KCOM_MSG_TYPE_CMD
+    hdr.opcode = opcode
+    hdr.unit = 0
+    hdr.id = obj_id
+
+    io = bkn_ioctl_t()
+    io.len = sizeof(hdr)
+    io.buf = addressof(hdr)
+
+    fcntl.ioctl(fd, 0, io)
+
+# Used for NETIF_LIST and FILTER_LIST
+#
+# Technically they use different structs passed to the kernel module,
+# practically they have identical layouts, so we can just use one type.
+def get_kcom_obj_list(fd, opcode):
+    obj_list = kcom_msg_list_t()
+    obj_list.hdr.type = KCOM_MSG_TYPE_CMD
+    obj_list.hdr.opcode = opcode
+    obj_list.hdr.unit = 0
+
+    io = bkn_ioctl_t()
+    io.len = sizeof(obj_list)
+    io.buf = addressof(obj_list)
+
+    fcntl.ioctl(fd, 0, io)
+
+    return obj_list
+
+try:
+    fd = os.open("/dev/linux-bcm-knet", os.O_RDWR | os.O_NONBLOCK)
+
+    kcom_filters = get_kcom_obj_list(fd, KCOM_M_FILTER_LIST)
+    for i in range(1, kcom_filters.fcnt + 1):
+        # do not delete the default RxAPI filter
+        if kcom_filters.id[i] == 1:
+            continue
+        delete_kcom_object(fd, kcom_filters.id[i], KCOM_M_FILTER_DESTROY)
+
+    kcom_netifs = get_kcom_obj_list(fd, KCOM_M_NETIF_LIST)
+    for i in range(1, kcom_netifs.fcnt + 1):
+        delete_kcom_object(fd, kcom_netifs.id[i], KCOM_M_NETIF_DESTROY)
+except FileNotFoundError:
+    # BCM KNET support module not loaded or supported, so nothing to do for us
+    pass


### PR DESCRIPTION
Make sure that all KNET interfaces are removed after baseboxd stopped,
so restarting baseboxd (either intentional or because it crashed) does
not fail due to already existing knet interfaces.

This aligns the behaviour with how it works with the default tap
interfaces, which get removed when baseboxd closes.

The tap interfaces are removed automatically since they are owned by
baseboxd and dropped once baseboxd goes away, but this does not work for
the KNET interfaces, since they are neither owned by baseboxd, nor do
they have any facility to remove them automatically.

The proper way to fix this would be for baseboxd handle sigterm and
gracefully remove them, but the code is currently not equipped well for
that, and will require a larger rework.

As an interim smaller solution, add a python script that directly talks
with the KNET kernel module's ioctl interface to remove all interfaces
and filters, with the exception of the default RxAPI filter, which needs
to be kept.

The IOCTL interface definition is taken from

* https://github.com/Broadcom-Network-Switching-Software/OpenBCM/blob/0b149ddfa3878e65eb217a11dddb999d3e205d03/sdk-6.5.24/include/kcom.h
* https://github.com/Broadcom-Network-Switching-Software/OpenBCM/blob/0b149ddfa3878e65eb217a11dddb999d3e205d03/sdk-6.5.24/systems/linux/kernel/modules/include/bcm-knet.h

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
