### PR TITLE
nl_l3: properly handle default routes

### DIFF
--- a/src/utils/rofl-utils.h
+++ b/src/utils/rofl-utils.h
@@ -11,7 +11,10 @@ namespace rofl {
 
 inline caddress_in4 build_mask_in4(unsigned prefix_len) {
   caddress_in4 mask;
-  uint32_t m = ~((UINT32_C(1) << (32 - prefix_len)) - 1);
+  uint32_t m = 0;
+
+  if (prefix_len > 0)
+    m = ~((UINT32_C(1) << (32 - prefix_len)) - 1);
   mask.set_addr_hbo(m);
   return mask;
 }


### PR DESCRIPTION
RTM_GETROUTE (as done via `nl_route_query`) does not actually give us the route for a destination net, it gives us the route to a destination host, with an implicit /32 resp. /128. This works by accident for all non-default routes (since the first IP is part of the network), but falls apart for IPv4 default routes, since 0.0.0.0/32 is the any address, which aliases to localhost.

To fix this, actually ask the netlink cache for a route with the appropriate destination. As a bonus side effect, the dst of the route
will already have the correct prefix length, and we do not need to modify it anymore.

In addition, fix mask calculation for prefix length 0 on x86 by avoiding undefined behaviour.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
