### PR TITLE
sysconfig.template: add GLOG_vmodule default value

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -19,3 +19,6 @@ GLOG_logtostderr=1
 
 # verbose log level:
 # GLOG_v=0
+
+# verbose per-module log level:
+# GLOG_vmodule=


### PR DESCRIPTION
## Description
Add the default value of the per-module GLOG flag

## Motivation and Context
The GLOG_vmodule is available and useful for debugging, as it allows to set per-module log levels. The default value is 0, so we can write that into the default config file to make users aware of its existense.

The documentation on how to use it is available on the GLOG docs and soon-to-be on our docs.bisdn.de page as well.

## How Has This Been Tested?
Adding the line to the baseboxd config and restarting baseboxd works fine.
I have not run any complete pipelines
