### PR TITLE
of-dpa: enable DHCP packets to controller

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2081,6 +2081,24 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
         rofl::cauxid(0), fm_driver.enable_policy_ipv4_multicast(
                              dpt.get_version(), rofl::caddress_in4("224.0.0.0"),
                              rofl::build_mask_in4(4)));
+
+    // Enable BOOTP/DHCP client -> server to CONTROLLER
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_policy_udp(
+                             dpt.get_version(), ETH_P_IP, 67, 68));
+    // Enable BOOTP/DHCP server -> client to CONTROLLER
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_policy_udp(
+                             dpt.get_version(), ETH_P_IP, 68, 67));
+
+    // Enable DHCPv6 client -> server to CONTROLLER
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_policy_udp(
+                             dpt.get_version(), ETH_P_IPV6, 546, 547));
+    // Enable DHCPv6 server -> client to CONTROLLER
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_policy_udp(
+                             dpt.get_version(), ETH_P_IPV6, 547, 546));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;


### PR DESCRIPTION
The Switch ASIC filters DHCP packets out by default, so running a DHCP
client or a DHCP server will not work, since it will never see any
requests or replies.

Fix this by adding rules for DHCP/BOOTP and DHCPv6 to pass on UDP
packets matching the specific ports, in both directions.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
