### PR TITLE
nl_bridge: flush cache before removing entries

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -477,10 +477,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
                     << " on pport_no=" << pport_no
                     << " link: " << OBJ_CAST(_link);
 
-            // delete all FM pointing to this group first
-            sw->l2_addr_remove_all_in_vlan(pport_no, vid);
-            sw->l2_multicast_group_leave_all_in_vlan(pport_no, vid);
-
+            // delete all cache entries first
             std::unique_ptr<rtnl_neigh, decltype(&rtnl_neigh_put)> filter(
                 rtnl_neigh_alloc(), rtnl_neigh_put);
 
@@ -498,6 +495,10 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
                   nl_cache_remove(o);
                 },
                 nullptr);
+
+            // then delete all FM pointing to this group
+            sw->l2_addr_remove_all_in_vlan(pport_no, vid);
+            sw->l2_multicast_group_leave_all_in_vlan(pport_no, vid);
 
             // the PVID is already being handled outside of the loop
             vlan->remove_bridge_vlan(_link, vid, false, !egress_untagged);


### PR DESCRIPTION
Avoid a race between flow removed modifications and removing the cache
entries.

Removing the L2 entries from the switch will result in flow removed
notifications. If we are fast enough handling them, we will handle them
before we get to remove the cache entries, the flow removed handler will
try to remote the entries from the kernel. This will fail, since we may
not modify the fdb of a non-existing vlan.

To avoid even trying, we need to remove the entries from the cache
first, so we never try to remove the kernel entries.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
