### PR TITLE
cnetlink: get_link_by_ifindex: fix af family check

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -258,7 +258,7 @@ cnetlink::get_link_by_ifindex(int ifindex) const {
       [](struct nl_object *obj, void *arg) {
         assert(arg);
 
-        if (rtnl_link_get_family(LINK_CAST(arg)) != AF_INET6) {
+        if (rtnl_link_get_family(LINK_CAST(obj)) != AF_INET6) {
           nl_object_get(obj);
           *static_cast<nl_object **>(arg) = obj;
         }


### PR DESCRIPTION
We need to check the family of the passed cache object, not the
argument. Else we read random garbage from the stack, and sometimes it
might or might not be equal to AF_INET6.

Fixes get_link_by_ifindex sometimes failing to find a link object, which
may even crash baseboxd:

```
Jul 07 23:31:22 accton-as4610 baseboxd[1121]: I0707 23:31:22.864306  1129 cnetlink.cc:679] is_bridge_interface: vlan ok
Jul 07 23:31:22 accton-as4610 baseboxd[1121]: baseboxd: ../git/src/netlink/cnetlink.cc:660: bool basebox::cnetlink::is_bridge_interface(rtnl_link*) const: Assertion `l' failed.
Jul 07 23:31:22 accton-as4610 systemd[1]: Created slice system-systemd\x2dcoredump.slice.
Jul 07 23:31:22 accton-as4610 systemd[1]: Started Process Core Dump (PID 1741/UID 0).
```

Fixes: 50fe194b8f79 ("cnetlink: fetch bridge object with ifindex and address family")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
