### PR TITLE
Update source files for clang-format and add super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,56 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          # Change to 'master' if your main branch differs
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,6 +51,5 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
-          # Change to 'master' if your main branch differs
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -53,3 +53,13 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_BASH: false
+          VALIDATE_CPP: false
+          VALIDATE_DOCKERFILE_HADOLINT: false
+          VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_SHELLCHECK: false

--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -25,15 +25,14 @@ knet_manager::~knet_manager() {
     uint32_t netif_id = dev.second;
 
     int ret = system(("/usr/sbin/client_drivshell knet filter destroy " +
-                            std::to_string(netif_id + 1))
-                               .c_str());
+                      std::to_string(netif_id + 1))
+                         .c_str());
     if (!WIFEXITED(ret) || WEXITSTATUS(ret) != 0)
       LOG(WARNING) << __FUNCTION__ << ": failed to remove filter with id "
                    << netif_id + 1;
     ret = system(("/usr/sbin/client_drivshell knet netif destroy " +
-                        std::to_string(netif_id))
-                           .c_str()
-                       );
+                  std::to_string(netif_id))
+                     .c_str());
     if (!WIFEXITED(ret) || WEXITSTATUS(ret) != 0)
       LOG(WARNING) << __FUNCTION__ << ": failed to remove knet netif with id "
                    << netif_id;

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -51,11 +51,11 @@ struct nh_stub {
     nl_addr_put(nh);
   }
 
-  bool operator<(const nh_stub& other) const {
-         if (nl_addr_cmp(nh, other.nh) < 0)
-		return true;
+  bool operator<(const nh_stub &other) const {
+    if (nl_addr_cmp(nh, other.nh) < 0)
+      return true;
 
-	 return ifindex < other.ifindex;
+    return ifindex < other.ifindex;
   }
 
   nl_addr *nh;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2084,21 +2084,21 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
 
     // Enable BOOTP/DHCP client -> server to CONTROLLER
     dpt.send_flow_mod_message(
-        rofl::cauxid(0), fm_driver.enable_policy_udp(
-                             dpt.get_version(), ETH_P_IP, 67, 68));
+        rofl::cauxid(0),
+        fm_driver.enable_policy_udp(dpt.get_version(), ETH_P_IP, 67, 68));
     // Enable BOOTP/DHCP server -> client to CONTROLLER
     dpt.send_flow_mod_message(
-        rofl::cauxid(0), fm_driver.enable_policy_udp(
-                             dpt.get_version(), ETH_P_IP, 68, 67));
+        rofl::cauxid(0),
+        fm_driver.enable_policy_udp(dpt.get_version(), ETH_P_IP, 68, 67));
 
     // Enable DHCPv6 client -> server to CONTROLLER
     dpt.send_flow_mod_message(
-        rofl::cauxid(0), fm_driver.enable_policy_udp(
-                             dpt.get_version(), ETH_P_IPV6, 546, 547));
+        rofl::cauxid(0),
+        fm_driver.enable_policy_udp(dpt.get_version(), ETH_P_IPV6, 546, 547));
     // Enable DHCPv6 server -> client to CONTROLLER
     dpt.send_flow_mod_message(
-        rofl::cauxid(0), fm_driver.enable_policy_udp(
-                             dpt.get_version(), ETH_P_IPV6, 547, 546));
+        rofl::cauxid(0),
+        fm_driver.enable_policy_udp(dpt.get_version(), ETH_P_IPV6, 547, 546));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;


### PR DESCRIPTION
This project uses the .clang-format in this repo, with only a few recent commits not following the policy.

Changes created with:

find . -name '*.cc' -o -name '*.h' | xargs clang-format -style=file -i

To prevent further regressions, enable the super-linter in the CI for this repo.