### PR TITLE
properly ignore AF_INET6 link objects in libnl 3.6+

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -164,15 +164,16 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
     return -EINVAL;
   }
 
-  struct rtnl_link *link = rtnl_addr_get_link(a);
-  if (link == nullptr) {
+  int ifindex = rtnl_addr_get_ifindex(a);
+  auto l = nl->get_link_by_ifindex(ifindex);
+  if (l == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": no link for addr a=" << OBJ_CAST(a);
     return -EINVAL;
   }
+  struct rtnl_link *link = l.get();
 
   bool is_loopback = (rtnl_link_get_flags(link) & IFF_LOOPBACK);
   bool is_bridge = rtnl_link_is_bridge(link); // XXX TODO svi as well?
-  int ifindex = 0;
   uint16_t vid = vlan->get_vid(link);
   uint32_t vrf_id = vlan->get_vrf_id(vid, link);
 
@@ -192,7 +193,6 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
 
   // XXX TODO split this into several functions
   if (!is_loopback) {
-    ifindex = rtnl_addr_get_ifindex(a);
     int port_id = nl->get_port_id(link);
     auto addr = rtnl_link_get_addr(link);
     rofl::caddress_ll mac = libnl_lladdr_2_rofl(addr);
@@ -281,11 +281,13 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
     return -EINVAL;
   }
 
-  struct rtnl_link *link = rtnl_addr_get_link(a);
-  if (link == nullptr) {
+  int ifindex = rtnl_addr_get_ifindex(a);
+  auto l = nl->get_link_by_ifindex(ifindex);
+  if (l == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": no link for addr a=" << OBJ_CAST(a);
     return -EINVAL;
   }
+  struct rtnl_link *link = l.get();
 
   bool is_loopback = (rtnl_link_get_flags(link) & IFF_LOOPBACK);
 


### PR DESCRIPTION
properly ignore AF_INET6 link objects in libnl 3.6+ that otherwise cause unexpected behavior in baseboxd.

## Description
libnl 3.6.0 introduced listening for IPv6 configuration changes on links. Due to the design of libnl, these are tracked as additional link objects in the cache with the address family AF_INET6, and they only contain basic link information in addition to the IPv6 configuration.

These can easily show up when using rtnl_link_get(ifindex), which is also used internally by rtnl_addr_get_link(). These incomplete link objects then cannot be properly handled by baseboxd, so we need to make sure to get the right objects from the cache (AF_UNSPEC/AF_BRIDGE).

## How Has This Been Tested?

Running a pipeline with this change and libnl 3.7, and having seen no failures related to this anymore.