### PR TITLE
restore vlan configuration when detaching port from bridge

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1316,6 +1316,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
       LOG(INFO) << __FUNCTION__ << ": enslaving interface "
                 << rtnl_link_get_name(link);
 
+      vlan->disable_vlans(link);
       bridge->add_interface(link);
 
       // Scan the bridge for L3 addresses and routes we ignored previously
@@ -1504,8 +1505,10 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
   case LT_BRIDGE_SLAVE:
     try {
       if (bridge) {
-        if (rtnl_link_get_family(link) == AF_BRIDGE)
+        if (rtnl_link_get_family(link) == AF_BRIDGE) {
           bridge->delete_interface(link);
+          vlan->enable_vlans(link);
+        }
       }
     } catch (std::exception &e) {
       LOG(ERROR) << __FUNCTION__ << ": failed: " << e.what();

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -292,6 +292,54 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
   return rv;
 }
 
+int nl_vlan::enable_vlans(rtnl_link *link) {
+  assert(swi);
+
+  uint32_t port_id = nl->get_port_id(link);
+
+  if (port_id == 0) {
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    return -EINVAL;
+  }
+
+  for (auto const &it : port_vlan) {
+    if (it.first.first != port_id)
+      continue;
+
+    uint16_t vid = it.first.second;
+    uint16_t vrf_id = get_vrf_id(vid, link);
+
+    // assume the default vlan is untagged
+    (void)enable_vlan(port_id, it.first.second, vid != default_vid, vrf_id);
+  }
+
+  return 0;
+}
+
+int nl_vlan::disable_vlans(rtnl_link *link) {
+  assert(swi);
+
+  uint32_t port_id = nl->get_port_id(link);
+
+  if (port_id == 0) {
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    return -EINVAL;
+  }
+
+  for (auto const &it : port_vlan) {
+    if (it.first.first != port_id)
+      continue;
+
+    uint16_t vid = it.first.second;
+    uint16_t vrf_id = get_vrf_id(vid, link);
+
+    // assume the default vlan is untagged
+    (void)disable_vlan(port_id, it.first.second, vid != default_vid, vrf_id);
+  }
+
+  return 0;
+}
+
 int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
                              bool tagged) {
   int rv;

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -46,32 +46,12 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
     return 0;
   }
 
-  int rv = swi->ingress_port_vlan_add(port_id, vid, !tagged, vrf_id);
+  int rv = add_ingress_vlan(port_id, vid, tagged, vrf_id);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed to setup ingress vlan " << vid
                << (tagged ? " (tagged)" : " (untagged)")
                << " on port_id=" << port_id << "; rv=" << rv;
     return rv;
-  }
-
-  if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
-    auto members = nl->get_bond_members_by_port_id(port_id);
-    for (auto mem : members) {
-      rv = swi->ingress_port_vlan_add(mem, vid, !tagged, vrf_id);
-      if (rv < 0) {
-        LOG(ERROR) << __FUNCTION__ << ": failed to setup ingress vlan " << vid
-                   << (tagged ? " (tagged)" : " (untagged)")
-                   << " on port_id=" << port_id << "; rv=" << rv;
-        break;
-      }
-    }
-
-    if (rv < 0) {
-      for (auto mem : members) {
-        (void)swi->ingress_port_vlan_remove(mem, vid, !tagged, vrf_id);
-      }
-      return rv;
-    }
   }
 
   // setup egress interface
@@ -81,14 +61,7 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
     LOG(ERROR) << __FUNCTION__ << ": failed to setup egress vlan " << vid
                << (tagged ? " (tagged)" : " (untagged)")
                << " on port_id=" << port_id << "; rv=" << rv;
-    (void)swi->ingress_port_vlan_remove(port_id, vid, !tagged);
-
-    if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
-      auto members = nl->get_bond_members_by_port_id(port_id);
-      for (auto mem : members) {
-        (void)swi->ingress_port_vlan_remove(mem, vid, !tagged, vrf_id);
-      }
-    }
+    (void)remove_ingress_vlan(port_id, vid, tagged, vrf_id);
 
     return rv;
   }
@@ -110,10 +83,9 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
     if (rv < 0) {
       for (auto mem : members) {
         (void)swi->egress_port_vlan_remove(mem, vid);
-        (void)swi->ingress_port_vlan_remove(mem, vid, !tagged, vrf_id);
       }
       (void)swi->egress_port_vlan_remove(port_id, vid);
-      (void)swi->ingress_port_vlan_remove(port_id, vid, !tagged);
+      (void)remove_ingress_vlan(port_id, vid, tagged, vrf_id);
 
       return rv;
     }
@@ -254,14 +226,7 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   port_vlan.erase(refcount);
 
   // remove vid at ingress
-  if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
-    auto members = nl->get_bond_members_by_port_id(port_id);
-    for (auto mem : members) {
-      (void)swi->ingress_port_vlan_remove(mem, vid, !tagged, vrf_id);
-    }
-  }
-  rv = swi->ingress_port_vlan_remove(port_id, vid, !tagged, vrf_id);
-
+  rv = remove_ingress_vlan(port_id, vid, tagged, vrf_id);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv=" << rv
                << " to remove vid=" << vid << "(tagged=" << tagged

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -57,6 +57,11 @@ private:
   static const uint16_t vid_high = 0xfff;
   static const uint16_t default_vid = vid_low;
 
+  int enable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+                  uint16_t vrf_id = 0);
+  int disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
+                   uint16_t vrf_id = 0);
+
   // ifindex - vlan - refcount
   std::map<std::pair<uint32_t, uint16_t>, uint32_t> port_vlan;
   // vlan - vrf

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -28,6 +28,9 @@ public:
   int add_ingress_vlan(uint32_t port_id, uint16_t vid, bool pvid,
                        uint16_t vrf_id = 0);
 
+  int enable_vlans(rtnl_link *link);
+  int disable_vlans(rtnl_link *link);
+
   int add_ingress_pvid(rtnl_link *link, uint16_t pvid);
   int remove_ingress_pvid(rtnl_link *link, uint16_t vid);
 


### PR DESCRIPTION
Apply any required vlans to ports on detachment to allow configured IP configuration to work again..

## Description
Attaching a port to a bridge will remove its internal vlan configuration, so that the bridge vlans will take precedence. On detachment, the configured bridge vlans get removed, but the original vlan configuration is not restored. This can cause IP addresses configured on the port to stop working.

This is not a complete fix, as instead of replacing the normal (reference) counted vlan configuration the bridge should also make use of it (and taking/dropping references for all vlans). Also any IP addresses configuration changes while attached to a bridge will also lead to a potentially broken state.

## How Has This Been Tested?
Running a pipeline with the changes applied, and configuring an ip address to a port, attaching it to a bridge, detaching it, then trying to ping from the ip address of the port. Without the changes it fails, with it it succeeds.