### PR TITLE
nl_bridge: default stp state should be forwarding

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -1113,7 +1113,7 @@ int nl_bridge::add_port_vlan_stp_state(uint32_t port_id, uint16_t vid,
 
 int nl_bridge::del_port_vlan_stp_state(uint32_t port_id, uint16_t vid) {
   // default state when not part of the vlan
-  auto g_stp_state = BR_STATE_DISABLED;
+  auto g_stp_state = BR_STATE_FORWARDING;
 
   LOG(INFO) << __FUNCTION__ << ": set state=" << g_stp_state
             << " ifindex= " << port_id << " VLAN =" << vid;


### PR DESCRIPTION
## Description
When deleting a VLAN from an stp bridge, set the port state to BR_STATE_FORWARDING

## Motivation and Context
When removing a VLAN from a bridged port, we currently set its STP state to DISABLED, dropping all traffic on it. When the port then gets removed from the bridge, the VLAN will continue being blocked on this port. To ensure this does not happen, use FORWARDING as the default state. The VLAN flow/group memberships will still take care of filtering the traffic while being a bridge member, so this is fine to do.

This follows a change we did in creation of STG groups, where we switched the default from DISABLED to FORWARDING.

## How Has This Been Tested?
This was tested with our latest testing images, including the latest stg fixes in meta-ofdpa
This was run on the agema-ag7648, but will extend to all our supported platforms.

edit: updated context with better explanation
