### PR TITLE
enable KNET interfaces by default 

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -10,7 +10,7 @@
 # FLAGS_ofdpa_grpc_port=50051
 #
 # Use KNET interfaces:
-# FLAGS_use_knet=false
+# FLAGS_use_knet=true
 
 ### glog
 #

--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -9,7 +9,7 @@
 # gRPC listening port:
 # FLAGS_ofdpa_grpc_port=50051
 #
-# Use KNET interfaces (experimental):
+# Use KNET interfaces:
 # FLAGS_use_knet=false
 
 ### glog

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -19,7 +19,7 @@ DECLARE_string(tryfromenv); // from gflags
 DEFINE_bool(multicast, true, "Enable multicast support");
 DEFINE_int32(port, 6653, "Listening port");
 DEFINE_int32(ofdpa_grpc_port, 50051, "Listening port of ofdpa gRPC server");
-DEFINE_bool(use_knet, false, "Use KNET interfaces (experimental)");
+DEFINE_bool(use_knet, false, "Use KNET interfaces");
 
 static bool validate_port(const char *flagname, gflags::int32 value) {
   VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -19,7 +19,7 @@ DECLARE_string(tryfromenv); // from gflags
 DEFINE_bool(multicast, true, "Enable multicast support");
 DEFINE_int32(port, 6653, "Listening port");
 DEFINE_int32(ofdpa_grpc_port, 50051, "Listening port of ofdpa gRPC server");
-DEFINE_bool(use_knet, false, "Use KNET interfaces");
+DEFINE_bool(use_knet, true, "Use KNET interfaces");
 
 static bool validate_port(const char *flagname, gflags::int32 value) {
   VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;


### PR DESCRIPTION
KNET interfaces on switch work stable, and offer more throughput and
lower latency, and avoid the issue of traffic to/from controller
overloading the OpenFlow connection.

So switch to them as default and drop the experimental tag.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>