### PR TITLE
mark packets as offloaded when using KNET

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -11,6 +11,9 @@
 #
 # Use KNET interfaces:
 # FLAGS_use_knet=true
+#
+# Mark switched packets as offloaded:
+# FLAGS_mark_fwd_offload=true
 
 ### glog
 #

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -20,6 +20,7 @@ DEFINE_bool(multicast, true, "Enable multicast support");
 DEFINE_int32(port, 6653, "Listening port");
 DEFINE_int32(ofdpa_grpc_port, 50051, "Listening port of ofdpa gRPC server");
 DEFINE_bool(use_knet, true, "Use KNET interfaces");
+DEFINE_bool(mark_fwd_offload, true, "Mark switched packets as offloaded");
 
 static bool validate_port(const char *flagname, gflags::int32 value) {
   VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;
@@ -48,7 +49,8 @@ int main(int argc, char **argv) {
   }
 
   // all variables can be set from env
-  FLAGS_tryfromenv = std::string("multicast,port,ofdpa_grpc_port,use_knet");
+  FLAGS_tryfromenv =
+      std::string("multicast,port,ofdpa_grpc_port,use_knet,mark_fwd_offload");
   gflags::SetUsageMessage("");
   gflags::SetVersionString(PROJECT_VERSION);
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -42,6 +42,7 @@
 #include "nl_vxlan.h"
 
 DECLARE_bool(multicast);
+DECLARE_bool(mark_fwd_offload);
 
 namespace basebox {
 
@@ -1352,7 +1353,9 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
   } break;
   default: {
     bool handled = port_man->portdev_ready(link);
-    if (!handled)
+    if (handled)
+      port_man->set_offloaded(link, FLAGS_mark_fwd_offload);
+    else
       LOG(WARNING) << __FUNCTION__ << ": ignoring link with lt=" << lt
                    << " link:" << OBJ_CAST(link);
   } break;

--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -313,6 +313,15 @@ int knet_manager::set_port_speed(const std::string name, uint32_t speed,
   return 1;
 }
 
-int knet_manager::set_offloaded(rtnl_link *link, bool offloaded) { return 0; }
+int knet_manager::set_offloaded(rtnl_link *link, bool offloaded) {
+  std::string name(rtnl_link_get_name(link));
+  std::ofstream file("/proc/bcm/knet/link");
+
+  if (file.is_open()) {
+    file << (name + (offloaded ? "=offload" : "=no-offload"));
+    file.close();
+  }
+  return 0;
+}
 
 } // namespace basebox

--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -313,4 +313,6 @@ int knet_manager::set_port_speed(const std::string name, uint32_t speed,
   return 1;
 }
 
+int knet_manager::set_offloaded(rtnl_link *link, bool offloaded) { return 0; }
+
 } // namespace basebox

--- a/src/netlink/knet_manager.h
+++ b/src/netlink/knet_manager.h
@@ -37,6 +37,7 @@ public:
 
   int change_port_status(const std::string name, bool status);
   int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
+  int set_offloaded(rtnl_link *link, bool offloaded);
 
   // access from northbound (cnetlink)
   bool portdev_removed(rtnl_link *link);

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -77,6 +77,7 @@ public:
   virtual int change_port_status(const std::string name, bool status) = 0;
   virtual int set_port_speed(const std::string name, uint32_t speed,
                              uint8_t duplex) = 0;
+  virtual int set_offloaded(rtnl_link *link, bool offloaded) = 0;
 
   // access from northbound (cnetlink)
   virtual bool portdev_removed(rtnl_link *link) = 0;

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -425,4 +425,6 @@ int tap_manager::set_port_speed(const std::string name, uint32_t speed,
   return error;
 }
 
+int tap_manager::set_offloaded(rtnl_link *link, bool offloaded) { return 0; }
+
 } // namespace basebox

--- a/src/netlink/tap_manager.h
+++ b/src/netlink/tap_manager.h
@@ -40,6 +40,7 @@ public:
 
   int change_port_status(const std::string name, bool status);
   int set_port_speed(const std::string name, uint32_t speed, uint8_t duplex);
+  int set_offloaded(rtnl_link *link, bool offloaded);
 
   // access from northbound (cnetlink)
   bool portdev_removed(rtnl_link *link);


### PR DESCRIPTION
Linux will flood/forward any packets it sees on a bridge by default. This can lead to packet duplication if the packet was already forwarded/flooded by the ASIC. This can be avoided by marking packets as forwarding being offloaded, so tell KNET to mark any received packets as such.

To allow disabling it in case of unexpected side effects, add a flag for controlling the behavior.

The implementation is kept as generic as possible, in case we ever implement it for TAP interfaces as well.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>