### PR TITLE
cnetlink: fix handling of bond mode changes

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1455,6 +1455,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     // happens when a bond/tap interface enslaved directly to a VRF and you set
     // nomaster
   } break;
+  case LT_BOND:
     bond->update_lag(old_link, new_link);
     break;
   case LT_VRF: // No need to care about the vrf interface itself


### PR DESCRIPTION
Restore an accidentally removed case statement causing bond mode changes to be ignored.

Fixes: 7d10d3b8486f ("replace checks for LT_TUN with check for having a port_id")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>