### PR TITLE
cnetlink: propagate admin port config

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1403,6 +1403,11 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
   }
 
   uint32_t port_id = port_man->get_port_id(rtnl_link_get_ifindex(new_link));
+  if (port_id > 0 && (rtnl_link_get_flags(old_link) & IFF_UP) !=
+                         (rtnl_link_get_flags(new_link) & IFF_UP)) {
+    swi->port_set_config(port_id, port_man->get_hwaddr(port_id),
+                         !!(rtnl_link_get_flags(new_link) & IFF_UP));
+  }
 
   switch (lt_old) {
   case LT_BOND_SLAVE:

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1402,12 +1402,13 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     return;
   }
 
+  uint32_t port_id = port_man->get_port_id(rtnl_link_get_ifindex(new_link));
+
   switch (lt_old) {
   case LT_BOND_SLAVE:
     if (lt_new == LT_BOND_SLAVE) { // bond slave updated
       bond->update_lag_member(old_link, new_link);
-    } else if (port_man->get_port_id(rtnl_link_get_ifindex(new_link)) >
-               0) { // bond slave removed
+    } else if (port_id > 0) { // bond slave removed
       bond->remove_lag_member(old_link);
     }
     break;
@@ -1468,7 +1469,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
             << ", new link: " << OBJ_CAST(new_link);
     break;
   default:
-    if (port_man->get_port_id(rtnl_link_get_ifindex(new_link)) > 0) {
+    if (port_id > 0) {
       if (lt_new == LT_BOND_SLAVE) {
         // XXX link enslaved
         LOG(INFO) << __FUNCTION__ << ": link enslaved "

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1353,11 +1353,15 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
   } break;
   default: {
     bool handled = port_man->portdev_ready(link);
-    if (handled)
+    if (handled) {
+      uint32_t port_id = get_port_id(link);
+
       port_man->set_offloaded(link, FLAGS_mark_fwd_offload);
-    else
+      swi->port_set_config(port_id, port_man->get_hwaddr(port_id), false);
+    } else {
       LOG(WARNING) << __FUNCTION__ << ": ignoring link with lt=" << lt
                    << " link:" << OBJ_CAST(link);
+    }
   } break;
   } // switch link type
 }

--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -84,8 +84,15 @@ int knet_manager::create_portdev(uint32_t port_id, const std::string &port_name,
         auto rv = port_names2id.emplace(std::make_pair(port_name, port_id));
 
         if (!rv.second) {
-          LOG(FATAL) << __FUNCTION__ << ": failed to insert";
+          LOG(FATAL) << __FUNCTION__ << ": failed to insert port name";
         }
+
+        auto rv2 = id_to_hwaddr.emplace(std::make_pair(port_id, hwaddr));
+
+        if (!rv2.second) {
+          LOG(FATAL) << __FUNCTION__ << ": failed to insert hwaddr";
+        }
+
         r = system(("/usr/sbin/client_drivshell knet netif create port=" +
                     std::to_string(port_id) + " ifname=" + port_name +
                     " mac=" + mac_string + " keeprxtag=yes")

--- a/src/netlink/port_manager.h
+++ b/src/netlink/port_manager.h
@@ -68,10 +68,21 @@ public:
     }
   }
 
+  const rofl::caddress_ll get_hwaddr(uint32_t port_id) const noexcept {
+    // XXX TODO add assert wrt threading
+    auto it = id_to_hwaddr.find(port_id);
+    if (it == id_to_hwaddr.end()) {
+      return nulladdr;
+    } else {
+      return it->second;
+    }
+  }
+
   void clear() noexcept {
     std::lock_guard<std::mutex> lock(tn_mutex);
     ifindex_to_id.clear();
     id_to_ifindex.clear();
+    id_to_hwaddr.clear();
   }
 
   virtual int change_port_status(const std::string name, bool status) = 0;
@@ -95,6 +106,9 @@ protected:
   // only accessible from cnetlink
   std::map<int, uint32_t> ifindex_to_id;
   std::map<uint32_t, int> id_to_ifindex;
+  std::map<uint32_t, rofl::caddress_ll> id_to_hwaddr;
+
+  const rofl::caddress_ll nulladdr;
 };
 
 } // namespace basebox

--- a/src/netlink/tap_manager.cc
+++ b/src/netlink/tap_manager.cc
@@ -64,7 +64,13 @@ int tap_manager::create_portdev(uint32_t port_id, const std::string &port_name,
         auto rv = port_names2id.emplace(std::make_pair(port_name, port_id));
 
         if (!rv.second) {
-          LOG(FATAL) << __FUNCTION__ << ": failed to insert";
+          LOG(FATAL) << __FUNCTION__ << ": failed to insert port name";
+        }
+
+        auto rv2 = id_to_hwaddr.emplace(std::make_pair(port_id, hwaddr));
+
+        if (!rv2.second) {
+          LOG(FATAL) << __FUNCTION__ << ": failed to insert hwaddr";
         }
 
         dev->tap_open();

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2042,6 +2042,28 @@ int controller::delete_egress_tpid(uint32_t port) noexcept {
   }
   return rv;
 }
+
+int controller::port_set_config(uint32_t port, const rofl::caddress_ll &mac,
+                                bool up) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_port_mod_message(rofl::cauxid(0), port, mac,
+                              up ? 0 : rofl::openflow13::OFPPC_PORT_DOWN,
+                              rofl::openflow13::OFPPC_PORT_DOWN, 0);
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+
 int controller::subscribe_to(enum swi_flags flags) noexcept {
   int rv = 0;
   this->flags = this->flags | flags;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -267,6 +267,9 @@ public:
                      const sai_port_stat_t *counter_ids,
                      uint64_t *counters) noexcept override;
 
+  int port_set_config(uint32_t port_id, const rofl::caddress_ll &mac,
+                      bool up) noexcept override;
+
   /* IO */
   int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept override;
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -183,6 +183,11 @@ public:
   virtual int delete_egress_tpid(uint32_t port) noexcept = 0;
   /* @} */
 
+  /* @ port  { */
+  virtual int port_set_config(uint32_t port_id, const rofl::caddress_ll &mac,
+                              bool up) noexcept = 0;
+  /* @} */
+
   /* @ control  { */
   virtual int enqueue(uint32_t port_id, basebox::packet *pkt) noexcept = 0;
   virtual int subscribe_to(enum swi_flags flags) noexcept = 0;


### PR DESCRIPTION
Propagate admin state/config of physical ports to the hardware via port_mod messages.

OpenFlow expects the mac address of the port according to the port table in the message, so store it when registering a port, and use it regardless of the current mac address of the port.

To have a defined initial state, set all newly registered ports as down. This avoid having to modify OF-DPA default, but may cause ports to be up for a short time until baseboxd initialized the ports.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>