### PR TITLE
properly handle route lookups when no default route

### DIFF
--- a/src/netlink/nl_route_query.h
+++ b/src/netlink/nl_route_query.h
@@ -83,7 +83,7 @@ public:
     if (err < 0)
       LOG(FATAL) << __FUNCTION__ << ":%s" << nl_geterror(err);
 
-    if (nl_recvmsgs_default(sock) < 0)
+    if ((err = nl_recvmsgs_default(sock)) < 0)
       LOG(FATAL) << __FUNCTION__ << ":%s" << nl_geterror(err);
 
     VLOG(3) << __FUNCTION__ << ": got route " << route;

--- a/src/netlink/nl_route_query.h
+++ b/src/netlink/nl_route_query.h
@@ -83,8 +83,17 @@ public:
     if (err < 0)
       LOG(FATAL) << __FUNCTION__ << ":%s" << nl_geterror(err);
 
-    if ((err = nl_recvmsgs_default(sock)) < 0)
+    if ((err = nl_recvmsgs_default(sock)) < 0) {
+      /*
+       * if there is no default route, and no matching route, the kernel will
+       * respond with -ENETUNREACH or -EHOSTUNREACH, which libnl translates to
+       * -NLE_FAILURE.
+       */
+      if (err == -NLE_FAILURE)
+        return nullptr;
+
       LOG(FATAL) << __FUNCTION__ << ":%s" << nl_geterror(err);
+    }
 
     VLOG(3) << __FUNCTION__ << ": got route " << route;
 


### PR DESCRIPTION
When there is no route for a host, the kernel may respond with an error, which we treat as fatal and crash. Fix this by accepting the error as normal.

## Description
When there is no default route, the kernel may respond with -ENETUNREACH or -EHOSTUNREACH instead of a route. libnl then translates this error as -NLE_FAILURE, so treat -NLE_FAILURE as no route found and just return a nullptr.

## Motivation and Context
We should not crash when failing lookups because the management interface is (temporarily) down.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran a pipeline on as4630-54pe, which succeeded.