### PR TITLE
nl_bridge: always set port stp state

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -82,10 +82,6 @@ public:
   int get_port_id(rtnl_link *l) const;
   int get_port_id(int ifindex) const;
   int get_ifindex_by_port_id(uint32_t port_id) const;
-  int get_bridge_stp_state() {
-    assert(bridge);
-    return bridge->get_stp_state();
-  }
 
   std::map<uint16_t, uint8_t> get_port_vlan_stp_states(rtnl_link *link) {
     assert(bridge);

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -235,9 +235,6 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
               << ": bond was already bridge slave: " << OBJ_CAST(br_link);
       nl->link_created(br_link);
 
-      if (nl->get_bridge_stp_state() == 0)
-        return rv;
-
       auto new_state = rtnl_link_bridge_get_port_state(br_link);
       swi->ofdpa_stg_state_port_set(port_id, 0, new_state);
       auto pv_states = nl->get_port_vlan_stp_states(bond);

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -21,10 +21,6 @@
 #define BR_STATE_FORWARDING 3
 #define BR_STATE_BLOCKING 4
 
-#define STP_STATE_DISABLED 0
-#define STP_STATE_KERNEL 1
-#define STP_STATE_USERSPACE 2
-
 extern "C" {
 struct rtnl_bridge_vlan;
 struct rtnl_link;
@@ -177,7 +173,6 @@ public:
                   const rofl::caddress_ll &mac);
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
 
-  uint32_t get_stp_state();
   uint32_t get_vlan_proto();
   int set_vlan_proto(rtnl_link *link);
   int delete_vlan_proto(rtnl_link *link);


### PR DESCRIPTION
The kernel will set ports to disabled while the bridge interface is down to inhibit forwarding regardless wether STP is enabled for the bridge, and we should be doing the same.

So do not ignore port STP state changes when STP is disabled.

Fixes: ee54b7ae49d2 ("nl_bridge: implement tracking global and pervlan stp state;       * adds struct to track g/pv stp states;         * adds setting of stp state in the ASIC")

<!--- Provide a general summary of your changes in the Title above -->

## Description

see above

## Motivation and Context

Bridges while down should not allow communication between ports at all.

## How Has This Been Tested?

Pinging between hosts via switch, once with the bridge interface down, once up (e.g. vlan-bridge test).

Before pinging succeeds always regardless of admin state of bridge, after only if the bridge is up.