### PR TITLE
nl_bridge: do not try to set stp states on non-port interfaces

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -195,7 +195,8 @@ void nl_bridge::add_interface(rtnl_link *link) {
 
   auto state = rtnl_link_bridge_get_port_state(link);
   auto port_id = nl->get_port_id(link);
-  set_port_stp_state(port_id, state);
+  if (port_id > 0)
+    set_port_stp_state(port_id, state);
 
   // configure bonds and physical ports (non members of bond)
   update_vlans(nullptr, link);
@@ -228,7 +229,8 @@ void nl_bridge::update_interface(rtnl_link *old_link, rtnl_link *new_link) {
               << " new=" << new_state;
 
     auto port_id = nl->get_port_id(new_link);
-    set_port_stp_state(port_id, new_state);
+    if (port_id > 0)
+      set_port_stp_state(port_id, new_state);
     return;
   }
 
@@ -256,7 +258,8 @@ void nl_bridge::delete_interface(rtnl_link *link) {
 
   auto port_id = nl->get_port_id(link);
   // interface default is to STP state forward by default
-  set_port_stp_state(port_id, BR_STATE_FORWARDING);
+  if (port_id > 0)
+    set_port_stp_state(port_id, BR_STATE_FORWARDING);
 }
 
 void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
@@ -1139,7 +1142,8 @@ int nl_bridge::set_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
   if (is_bridge_interface(ifindex))
     return err;
 
-  err = add_port_vlan_stp_state(port_id, vlan_id, stp_state);
+  if (port_id > 0)
+    err = add_port_vlan_stp_state(port_id, vlan_id, stp_state);
 #endif
   return err;
 }
@@ -1155,7 +1159,8 @@ int nl_bridge::drop_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
   if (is_bridge_interface(ifindex))
     return err;
 
-  err = del_port_vlan_stp_state(port_id, vlan_id);
+  if (port_id > 0)
+    err = del_port_vlan_stp_state(port_id, vlan_id);
 #endif
   return err;
 }


### PR DESCRIPTION
The bridge may contain other interfaces than port and bond interfaces, like vxlan interfaces, so we need to make sure that we have a valid port_id before trying to assign STP state.

Silences errors like:

    Mar 21 21:56:10 delta-ag7648 kernel: swbridge: port 2(vxlan50000) entered forwarding state
    Mar 21 21:56:10 delta-ag7648 baseboxd[1169]: I20230321 21:56:10.493907  1331 nl_bridge.cc:227] update_interface STP state changed, old=0 new=3
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]: Usage (STG): Usages:
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg create [<id>]            - Create a STG; optionally specify ID
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg destroy <id>             - Destroy a STG
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg show [<id>]              - List STG(s)
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg add <id> <vlan_id> [...]     - Add VLAN(s) to a STG
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg remove <id> <vlan_id> [...]  - Remove VLAN(s) from a STG
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg stp                      - Get span tree state, all ports/STGs
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg stp <id>                 - Get span tree state of ports in STG
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg stp <id> <pbmp> <state>  - Set span tree state of ports in STG
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:                                          (disable/block/listen/learn/forward)
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]:           stg default [<id>]           - Show or set the default STG
    Mar 21 21:56:10 delta-ag7648 ofdpa[1197]: driverProcessCommand: Platform command "stg stp 2 0 forward" failed, rc = -2.

Fixes: 02402b9cb452 ("nl_bridge: always set port stp state")

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
