### PR TITLE
fix initial l3 address scan of lo interface

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -795,7 +795,6 @@ void cnetlink::handle_wakeup(rofl::cthread &thread) {
 
   switch (state) {
   case NL_STATE_INIT:
-    init_subsystems();
     state = NL_STATE_RUNNING;
     break;
   case NL_STATE_RUNNING:
@@ -1724,6 +1723,8 @@ void cnetlink::stop() noexcept {
   state = NL_STATE_SHUTDOWN;
   thread.wakeup(this);
 }
+
+void cnetlink::switch_connected() noexcept { init_subsystems(); }
 
 bool cnetlink::is_bridge_configured(rtnl_link *l) {
   assert(l);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -96,6 +96,7 @@ public:
   void unregister_switch(switch_interface *) noexcept;
   void start() noexcept;
   void stop() noexcept;
+  void switch_connected() noexcept;
 
   static void nl_cb_v2(struct nl_cache *cache, struct nl_object *old_obj,
                        struct nl_object *new_obj, uint64_t diff, int action,

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -32,6 +32,8 @@ void nbi_impl::register_switch(switch_interface *swi) noexcept {
 void nbi_impl::switch_state_notification(enum switch_state state) noexcept {
   switch (state) {
   case SWITCH_STATE_UP:
+    nl->switch_connected();
+    break;
   case SWITCH_STATE_DOWN:
   case SWITCH_STATE_FAILED:
   case SWITCH_STATE_UNKNOWN:

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -29,6 +29,19 @@ void nbi_impl::register_switch(switch_interface *swi) noexcept {
   nl->register_switch(swi);
 }
 
+void nbi_impl::switch_state_notification(enum switch_state state) noexcept {
+  switch (state) {
+  case SWITCH_STATE_UP:
+  case SWITCH_STATE_DOWN:
+  case SWITCH_STATE_FAILED:
+  case SWITCH_STATE_UNKNOWN:
+    break;
+  default:
+    LOG(FATAL) << __FUNCTION__ << ": invalid state";
+    break;
+  }
+}
+
 void nbi_impl::port_notification(
     std::deque<port_notification_data> &notifications) noexcept {
 

--- a/src/netlink/nbi_impl.h
+++ b/src/netlink/nbi_impl.h
@@ -26,6 +26,7 @@ public:
 
   // nbi
   void register_switch(switch_interface *) noexcept override;
+  void switch_state_notification(enum switch_state) noexcept override;
   void resend_state() noexcept override;
   void
   port_notification(std::deque<port_notification_data> &) noexcept override;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -129,6 +129,8 @@ void controller::handle_dpt_close(const rofl::cdptid &dptid) {
   }
 
   this->dptid = rofl::cdptid(0);
+
+  nb->switch_state_notification(nbi::SWITCH_STATE_DOWN);
 }
 
 void controller::handle_conn_terminated(rofl::crofdpt &dpt,
@@ -195,6 +197,7 @@ void controller::handle_desc_stats_reply(
 
   // TODO evaluate switch here?
 
+  nb->switch_state_notification(nbi::SWITCH_STATE_UP);
   dpt.send_port_desc_stats_request(rofl::cauxid(0), 0, 2);
 }
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -273,6 +273,13 @@ public:
     port_type_lag = 2,
   };
 
+  enum switch_state {
+    SWITCH_STATE_UNKNOWN,
+    SWITCH_STATE_UP,
+    SWITCH_STATE_DOWN,
+    SWITCH_STATE_FAILED,
+  };
+
   static uint32_t combine_port_type(uint16_t port_num, enum port_type type) {
     return (uint32_t)port_num | type << 16;
   }
@@ -286,6 +293,7 @@ public:
   }
 
   virtual void register_switch(switch_interface *) noexcept = 0;
+  virtual void switch_state_notification(enum switch_state) noexcept = 0;
   virtual void resend_state() noexcept = 0;
   virtual void
   port_notification(std::deque<port_notification_data> &) noexcept = 0;


### PR DESCRIPTION
Fix handling of IP addresses on the lo interfaces added before baseboxd was started.

## Description

baseboxd scans for ip addresses on the lo interface on startup, since we won't be getting notifications about them if they were added before libnl was enabled.

Unfortunately this scan is being done potentially before the OpenFlow connection is up, so adding flows will (not quite so silently) fail, and subsequently the IP address handing is broken for those addresses.

Fix this by deferring the scan until the OpenFlow connection is established.

As a side effect this fixes the EVPN test, as here addresses were configured on lo via systemd-networkd, triggering the defect.

## Motivation and Context

It breaks stuff.

## How Has This Been Tested?

Running the (currently allowed to fail) evpn-ipv4 test. Without it, it fails early due to missing flows, with the fix it succeeds.