### PR TITLE
nbi_impl: do not apply port state from PORT_EVENT_ADD

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -64,8 +64,6 @@ void nbi_impl::port_notification(
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
-        port_man->change_port_status(ntfy.name, ntfy.status);
-        port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?


### PR DESCRIPTION
On the very first port event after establishing the OpenFlow connection, a port event with PORT_EVENT_ADD will be sent for all ports.

If this happens before we sent out and receive our port table reply, we will have started setting ports down since 7886f8b56c20 ("cnetlink: initialize new ports to down").

This will cause a race between ports going down and potentially subsequent port up events when e.g. systemd-networkd sets the port up again, and the generation of the port table reply.

This can result in the port table reply to contain outdated state info, which then may be processed after the latest PORT_EVENT_MODIFY event:

    Aug 29 10:34:07 accton-as4610-54 baseboxd[1057]: I20230829 10:34:07.689479  1086 nbi_impl.cc:67] port_notification: PORT_EVENT_ADD: port2 status=up
    Aug 29 10:34:12 accton-as4610-54 baseboxd[1057]: I20230829 10:34:12.297636  1086 nbi_impl.cc:55] port_notification: PORT_EVENT_MODIFY: port2 status=down
    Aug 29 10:34:12 accton-as4610-54 baseboxd[1057]: I20230829 10:34:12.304857  1086 nbi_impl.cc:55] port_notification: PORT_EVENT_MODIFY: port2 status=up
    Aug 29 10:34:12 accton-as4610-54 baseboxd[1057]: I20230829 10:34:12.305855  1086 nbi_impl.cc:67] port_notification: PORT_EVENT_ADD: port2 status=down

1. ofagent connects to baseboxd
2. port2 transitions to up => PORT_EVENT_ADD event with status up
3. baseboxd creates port2, sets it down
5. systemd-networkd sets port2 up
5. port2 transitions to down => PORT_EVENT_MODIFY with status down
6. baseboxd sets port2 up
8. baseboxd requests the port table
9. port table adds port2 as down to reply
10. port2 transitions to up => PORT_EVENT_MODIFY with status up
11. ofagent replies with port table => PORT_EVENT_ADD event with status down (!!!)

To avoid this from happening make sure to ignore the state from PORT_EVENT_ADD.

Since the very first thing we do to newly created ports is to set them down, it does not matter what their initial state is, so it's fine to ignore it.

Should fix spurious missed link states on start up.

Fixes #404.

Fixes: 7886f8b56c20 ("cnetlink: initialize new ports to down")

## How Has This Been Tested?

running the static-route-active-backup test in a loop on as4610. Without it, it would fail after a while due to port2 (and maybe even port3) having no link, despite `client_port_table_dump` showing them to be up and having one.

With the change the test still fails eventually, but this time due to a different systemd-networkd issue.
