### PR TITLE
fix port state race properly

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -64,6 +64,8 @@ void nbi_impl::port_notification(
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
+        port_man->change_port_status(ntfy.name, ntfy.status);
+        port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -60,6 +60,7 @@ void nbi_impl::port_notification(
         break;
       }
       break;
+    case PORT_EVENT_TABLE:
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -49,6 +49,16 @@ void nbi_impl::port_notification(
 
   for (auto &&ntfy : notifications) {
     switch (ntfy.ev) {
+    case PORT_EVENT_TABLE:
+      switch (get_port_type(ntfy.port_id)) {
+      case nbi::port_type_physical:
+        port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
+        break;
+      default:
+        LOG(ERROR) << __FUNCTION__ << ": unknown port";
+        break;
+      }
+      break;
     case PORT_EVENT_MODIFY:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
@@ -60,11 +70,9 @@ void nbi_impl::port_notification(
         break;
       }
       break;
-    case PORT_EVENT_TABLE:
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
         port_man->change_port_status(ntfy.name, ntfy.status);
         port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -286,7 +286,7 @@ void controller::handle_port_desc_stats_reply(
     uint8_t duplex = get_duplex(port.get_ethernet().get_curr());
 
     notifications.emplace_back(nbi::port_notification_data{
-        nbi::PORT_EVENT_ADD, port.get_port_no(), port.get_hwaddr(),
+        nbi::PORT_EVENT_TABLE, port.get_port_no(), port.get_hwaddr(),
         port.get_name(), status, speed, duplex});
   }
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -250,6 +250,7 @@ public:
     PORT_EVENT_ADD,
     PORT_EVENT_DEL,
     PORT_EVENT_MODIFY,
+    PORT_EVENT_TABLE,
   };
 
   enum port_status {


### PR DESCRIPTION
Make sure that the link state of ports matches the state after the first port event from OF-DPA.

## Description
https://github.com/bisdn/basebox/pull/412 tried to fix the startup race between the port desc reply and the first link state event. While the solution fixed the case where the link state event was first, it broke the case where the first link state comes in after the port desc reply, as it now was ignored as the very first link state change event is sent as `PORT_STATE_NEW`.

To fix this properly, introduce a new (internal) event type `PORT_EVENT_TABLE` to mark the reply, and use this for port creation, and then treat `PORT_STATE_NEW` and `PORT_STATE_MODIFY` as the same, and let them only update state.

## Motivation and Context

Fixes link states changes being lost on start up.

## How Has This Been Tested?

Run a pipeline on as4610.