### PR TITLE
nl_bridge: properly handle L2 neighbors moving between ports

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -725,8 +725,11 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
       NEIGH_CAST(nl_cache_search(l2_cache.get(), OBJ_CAST(n.get()))),
       rtnl_neigh_put);
 
-  if (n_lookup && rtnl_neigh_get_ifindex(n_lookup.get()) == ifindex) {
-    return;
+  if (n_lookup) {
+    if (rtnl_neigh_get_ifindex(n_lookup.get()) == ifindex)
+      return;
+
+    nl_cache_remove(OBJ_CAST(n_lookup.get()));
   }
   rtnl_neigh_set_ifindex(n.get(), ifindex);
 


### PR DESCRIPTION
Properly handle L2 neighbors moving between ports without corrupting the cache.

## Description
Due to bad assumptions, the code handling L2 neighbors moving between ports corrupts the local neighbor cache, poentially breaking additional moves or maybe even timouts.

1. When updating the port, updating the cache fails as the new entry is considered identical.
2. subsequently when moving to the original port back we think we already have a flow, and don't update it again.
3. `nl_bridge::fdb_timeout()` does not check the port of the returned entry from the cache, potentially deleting the wrong neighbor.

Fix both issues to allow proper updating of flows when L2 neighbors move between ports.

## How Has This Been Tested?

Extending the neighbor moving test to move twice, which then fails.