### PR TITLE
nl_l3: ignore duplicated link routes from FRR

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1758,6 +1758,37 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
     return -ENOTSUP;
   }
 
+  // FRR may occationally install link-local routes again with a different
+  // priority. Since we cannot handle multiple routes with different
+  // priorities/metrics yet, ignore the duplicated route.
+  if (rtnl_route_get_priority(r) > 0 &&
+      rtnl_route_get_protocol(r) != RTPROT_KERNEL) {
+    nl_route_query rq;
+
+    auto route = rq.query_route(rtnl_route_get_dst(r));
+
+    if (route) {
+      bool duplicate = false;
+      VLOG(2) << __FUNCTION__ << ": got route " << OBJ_CAST(route)
+              << " for dst " << OBJ_CAST(rtnl_route_get_dst(r));
+      if (rtnl_route_get_protocol(route) == RTPROT_KERNEL &&
+          nl_addr_cmp_prefix(rtnl_route_get_dst(r),
+                             rtnl_route_get_dst(route)) == 0) {
+        // we already have a kernel route for the same dst
+        duplicate = true;
+      }
+      nl_object_put(OBJ_CAST(route));
+
+      // there already is a kernel route, so ignore this one
+      if (duplicate)
+        return 0;
+    } else {
+      // huh?
+      VLOG(2) << __FUNCTION__ << ": no route for dst "
+              << OBJ_CAST(rtnl_route_get_dst(r));
+    }
+  }
+
   std::deque<struct rtnl_neigh *> neighs;
   std::deque<nh_stub> unresolved_nh;
   int rv = get_neighbours_of_route(r, &neighs, &unresolved_nh);
@@ -1905,6 +1936,34 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
   // table, but will enter the wrong info into the OFDPA tables
   if (vrf_id == MAIN_ROUTING_TABLE)
     vrf_id = 0;
+
+  if (rtnl_route_get_priority(r) > 0 &&
+      rtnl_route_get_protocol(r) != RTPROT_KERNEL) {
+    nl_route_query rq;
+
+    auto route = rq.query_route(rtnl_route_get_dst(r));
+
+    if (route) {
+      bool duplicate = false;
+      VLOG(2) << __FUNCTION__ << ": got route " << OBJ_CAST(route)
+              << " for dst " << OBJ_CAST(rtnl_route_get_dst(r));
+      if (rtnl_route_get_protocol(route) == RTPROT_KERNEL &&
+          nl_addr_cmp_prefix(rtnl_route_get_dst(r),
+                             rtnl_route_get_dst(route)) == 0) {
+        // we have a kernel route for the same dst
+        duplicate = true;
+      }
+      nl_object_put(OBJ_CAST(route));
+
+      // there is still a kernel route, so ignore this one
+      if (duplicate)
+        return 0;
+    } else {
+      // no route anymore, this is fine
+      VLOG(2) << __FUNCTION__ << ": no route for dst "
+              << OBJ_CAST(rtnl_route_get_dst(r));
+    }
+  }
 
   if (!keep_route) {
     rv = del_l3_unicast_route(dst, vrf_id);

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1146,16 +1146,6 @@ int nl_l3::add_l3_route(struct rtnl_route *r) {
     return -EINVAL;
   }
 
-  // check for reachable addresses
-  for (auto cb = std::begin(net_callbacks); cb != std::end(net_callbacks);) {
-    if (nl_addr_cmp_prefix(cb->second.addr, rtnl_route_get_dst(r)) == 0) {
-      cb->first->net_reachable_notification(cb->second);
-      cb = net_callbacks.erase(cb);
-    } else {
-      ++cb;
-    }
-  }
-
   return rv;
 }
 
@@ -1879,6 +1869,18 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
   // cleanup
   for (auto n : neighs)
     rtnl_neigh_put(n);
+
+  if (!update_route) {
+    // check for reachable addresses
+    for (auto cb = std::begin(net_callbacks); cb != std::end(net_callbacks);) {
+      if (nl_addr_cmp_prefix(cb->second.addr, rtnl_route_get_dst(r)) == 0) {
+        cb->first->net_reachable_notification(cb->second);
+        cb = net_callbacks.erase(cb);
+      } else {
+        ++cb;
+      }
+    }
+  }
 
   return rv;
 }


### PR DESCRIPTION
Ignore duplicate routes installed by FRR to not break networking.

## Description
OSPF from FRR 9.0 will sometimes install a duplicate route to an on-link
route, then delete it shortly after:

```
Oct 04 08:50:41 accton-as5835-54x baseboxd[2145]: I20231004 08:50:41.874454  2171 cnetlink.cc:1223] route_route_apply: new route (nl_obj=0x7fa654022370) inet 10.0.0.0/24 table main type unicast
Oct 04 08:50:41 accton-as5835-54x baseboxd[2145]:     preferred-src 10.0.0.1 scope link priority 0 protocol kernel
Oct 04 08:50:41 accton-as5835-54x baseboxd[2145]:     nexthop dev port54 <>
...
Oct 04 08:50:42 accton-as5835-54x baseboxd[2145]: I20231004 08:50:42.178130  2171 cnetlink.cc:1223] route_route_apply: new route (nl_obj=0x7fa654022c30) inet 10.0.0.0/24 table main type unicast
Oct 04 08:50:42 accton-as5835-54x baseboxd[2145]:     scope global priority 0x14 protocol 0xbc
Oct 04 08:50:42 accton-as5835-54x baseboxd[2145]:     nexthop dev port54 <>
...
Oct 04 08:50:42 accton-as5835-54x baseboxd[2145]: I20231004 08:50:42.188859  2171 cnetlink.cc:1258] route_route_apply: del route (nl_obj=0x7fa654022c30) inet 10.0.0.0/24 table main type unicast
Oct 04 08:50:42 accton-as5835-54x baseboxd[2145]:     scope global priority 0x14 protocol 0xbc
Oct 04 08:50:42 accton-as5835-54x baseboxd[2145]:     nexthop dev port54 <>
```

This causes baseboxd to first (try to) install the route a second time,
then delete it when deleting the duplicate route, landing in a state
where the route is missing from the flows.

To work around this, check routes if they have an associated protocol
that isn't kernel, and a priority higher than zero, and if so, if we
already have a route for that destination. If so, ignore the route.

## Motivation and Context

Missing flows makes switch sad.

## How Has This Been Tested?

Ran ospf-ipv4 test with FRR 9.0 installed in a loop for > 1h with no failures, while it failed after a few runs without it.

It also seemed to be timing sensitive, as it wasn't happening on AS4630-54*, but happened on AS5835-54X.

Currently running a pipeline on the latter systems to ensure no unexpected breakage.