### PR TITLE
cnetlink: just ignore bridges with unsupported configuration

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -220,6 +220,9 @@ private:
   int remove_l3_addresses(rtnl_link *link);
   int add_l3_routes(rtnl_link *link);
   int remove_l3_routes(rtnl_link *link);
+
+  // bridges with unsupported configuration
+  std::set<int> ignored_bridges;
 };
 
 } // end of namespace basebox


### PR DESCRIPTION
Ignore bridges with unsupported configuration instead of treating it as fatal state and crashing.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ignore bridges with unsupported configuration instead of treating it as fatal state and crashing. Do this by keeping a list of ignored bridges, and ignoring them for attach/detatchment until the bridges get deleted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This avoid baseboxd getting in a broken state, as we won't apply any configuration from these bridges.

This avoids getting in an invalid OF-DPA state requiring a reboot to recover, and potentially going into a crash loop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

create a non vlan-aware bridge, see if attaching a port gets ignored
create a vlan aware bridge, see if attaching a port is processed
create a second vlan aware bridge, see if attaching a different port is ignored