### PR TITLE
nl_l3::add_l3_neigh(): fix potentially random return value

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -727,6 +727,7 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
       VLOG(1) << __FUNCTION__ << ": skipping fe80::/10";
       // we must not route IPv6 LL addresses, so do not add a host entry
       add_host_entry = false;
+      rv = 0;
     }
   }
 


### PR DESCRIPTION
For IPv6LL neighbors we don't add a host entry, so we never call a function that returns an error code, keeping rv initialized.

Fix this by setting rv to 0 to restore the old behaviour before 55fe0693eaee ("nl_l3: notify routes about IPv6 link local nexthops").

Found by cppcheck:

```
src/netlink/nl_l3.cc:796:10: warning: Uninitialized variable: rv [uninitvar]
  return rv;
         ^
src/netlink/nl_l3.cc:733:7: note: Assuming condition is false
  if (add_host_entry) {
      ^
src/netlink/nl_l3.cc:796:10: note: Uninitialized variable: rv
  return rv;
         ^
```

Fixes: 55fe0693eaee ("nl_l3: notify routes about IPv6 link local nexthops")