### PR TITLE
drop the need for OBJ_CAST() when logging netlink objects

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -313,7 +313,7 @@ struct rtnl_link *cnetlink::get_link(int ifindex, int family) const {
 
       if (nl_object_match_filter(obj.get_old_obj(), OBJ_CAST(filter.get()))) {
         _link = LINK_CAST(obj.get_old_obj());
-        VLOG(1) << __FUNCTION__ << ": found deleted link " << OBJ_CAST(_link);
+        VLOG(1) << __FUNCTION__ << ": found deleted link " << _link;
         break;
       }
     }
@@ -454,7 +454,7 @@ int cnetlink::add_l3_addresses(rtnl_link *link) {
   l3->get_l3_addrs(link, &addresses);
 
   for (auto i : addresses) {
-    LOG(INFO) << __FUNCTION__ << ": adding address=" << OBJ_CAST(i);
+    LOG(INFO) << __FUNCTION__ << ": adding address=" << i;
 
     switch (rtnl_addr_get_family(i)) {
     case AF_INET:
@@ -466,16 +466,16 @@ int cnetlink::add_l3_addresses(rtnl_link *link) {
     default:
       LOG(ERROR) << __FUNCTION__
                  << ": unsupported family=" << rtnl_addr_get_family(i)
-                 << " for address=" << OBJ_CAST(i);
+                 << " for address=" << i;
       rv = -EINVAL;
       break;
     }
 
     if (rv < 0)
-      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 address " << OBJ_CAST(i)
-                 << " to " << OBJ_CAST(link);
+      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 address " << i << " to "
+                 << link;
   }
-  LOG(INFO) << __FUNCTION__ << ": added l3 addresses to " << OBJ_CAST(link);
+  LOG(INFO) << __FUNCTION__ << ": added l3 addresses to " << link;
 
   return rv;
 }
@@ -491,7 +491,7 @@ int cnetlink::remove_l3_addresses(rtnl_link *link) {
     rv = l3->del_l3_addr(i);
     if (rv < 0)
       LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 address from "
-                 << OBJ_CAST(link);
+                 << link;
   }
 
   return rv;
@@ -505,7 +505,7 @@ int cnetlink::add_l3_routes(rtnl_link *link) {
   l3->get_l3_routes(link, &routes);
 
   for (auto i : routes) {
-    LOG(INFO) << __FUNCTION__ << ": adding route=" << OBJ_CAST(i);
+    LOG(INFO) << __FUNCTION__ << ": adding route=" << i;
 
     switch (rtnl_route_get_family(i)) {
     case AF_INET:
@@ -515,16 +515,16 @@ int cnetlink::add_l3_routes(rtnl_link *link) {
     default:
       LOG(WARNING) << __FUNCTION__
                    << ": family not supported: " << rtnl_route_get_family(i)
-                   << " for route=" << OBJ_CAST(i);
+                   << " for route=" << i;
       rv = -EINVAL;
       break;
     }
 
     if (rv < 0)
-      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 route " << OBJ_CAST(i)
-                 << " to " << OBJ_CAST(link);
+      LOG(ERROR) << __FUNCTION__ << ":failed to add l3 route " << i << " to "
+                 << link;
   }
-  LOG(INFO) << __FUNCTION__ << ": added l3 routes to " << OBJ_CAST(link);
+  LOG(INFO) << __FUNCTION__ << ": added l3 routes to " << link;
 
   return rv;
 }
@@ -545,14 +545,13 @@ int cnetlink::remove_l3_routes(rtnl_link *link) {
     default:
       LOG(WARNING) << __FUNCTION__
                    << ": family not supported: " << rtnl_route_get_family(i)
-                   << " for route=" << OBJ_CAST(i);
+                   << " for route=" << i;
       rv = -EINVAL;
       break;
     }
 
     if (rv < 0)
-      LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 route from "
-                 << OBJ_CAST(link);
+      LOG(ERROR) << __FUNCTION__ << ":failed to remove l3 route from " << link;
   }
 
   return rv;
@@ -571,12 +570,12 @@ int cnetlink::add_l3_configuration(rtnl_link *link) {
     rv = add_l3_addresses(l);
     if (rv < 0)
       LOG(WARNING) << __FUNCTION__ << ": failed to add l3 addresses (" << rv
-                   << ") for link " << OBJ_CAST(l);
+                   << ") for link " << l;
 
     rv = add_l3_routes(l);
     if (rv < 0)
       LOG(WARNING) << __FUNCTION__ << ": failed to add l3 routes (" << rv
-                   << ") for link " << OBJ_CAST(l);
+                   << ") for link " << l;
   }
 
   return rv;
@@ -595,12 +594,12 @@ int cnetlink::remove_l3_configuration(rtnl_link *link) {
     rv = remove_l3_routes(l);
     if (rv < 0)
       LOG(WARNING) << __FUNCTION__ << ": failed to remove l3 routes (" << rv
-                   << " from link " << OBJ_CAST(l);
+                   << " from link " << l;
 
     rv = remove_l3_addresses(l);
     if (rv < 0)
       LOG(WARNING) << __FUNCTION__ << ": failed to remove l3 addresses (" << rv
-                   << " from link " << OBJ_CAST(l);
+                   << " from link " << l;
   }
 
   return rv;
@@ -615,8 +614,9 @@ int cnetlink::update_on_mac_change(rtnl_link *old_link, rtnl_link *new_link) {
 
   rv = l3->update_l3_termination(port_id, vid, old_mac, new_mac);
   if (rv < 0)
-    VLOG(1) << __FUNCTION__ << ": failed to update termination MAC, old link="
-            << OBJ_CAST(old_link) << " new link=" << OBJ_CAST(new_link);
+    VLOG(1) << __FUNCTION__
+            << ": failed to update termination MAC, old link=" << old_link
+            << " new link=" << new_link;
 
   // In response to the MAC address change on the interface, linux deletes the
   // neighbors configured on the interface. We are tracking the state
@@ -630,8 +630,8 @@ int cnetlink::update_on_mac_change(rtnl_link *old_link, rtnl_link *new_link) {
   rv = l3->update_l3_egress(port_id, vid, old_mac, new_mac);
   if (rv < 0)
     VLOG(1) << __FUNCTION__
-            << ": failed to update l3 egress, old link=" << OBJ_CAST(old_link)
-            << " new link=" << OBJ_CAST(new_link);
+            << ": failed to update l3 egress, old link=" << old_link
+            << " new link=" << new_link;
 
   return rv;
 }
@@ -675,7 +675,7 @@ bool cnetlink::is_bridge_interface(rtnl_link *l) const {
 
     auto lt = get_link_type(_l.get());
 
-    LOG(INFO) << __FUNCTION__ << ": lt=" << lt << " " << OBJ_CAST(_l.get());
+    LOG(INFO) << __FUNCTION__ << ": lt=" << lt << " " << _l.get();
     if (lt == LT_BRIDGE) {
       LOG(INFO) << __FUNCTION__ << ": vlan ok";
 
@@ -769,8 +769,7 @@ uint16_t cnetlink::get_vrf_table_id(rtnl_link *link) {
   if (vrf.get() && !rtnl_link_is_vrf(link) && rtnl_link_is_vrf(vrf.get())) {
     link = vrf.get();
   } else {
-    VLOG(2) << __FUNCTION__ << ": link=" << OBJ_CAST(link)
-            << " is not a VRF interface ";
+    VLOG(2) << __FUNCTION__ << ": link=" << link << " is not a VRF interface ";
     return 0;
   }
 
@@ -779,7 +778,7 @@ uint16_t cnetlink::get_vrf_table_id(rtnl_link *link) {
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__
-               << ": error fetching vrf table id for link=" << OBJ_CAST(link);
+               << ": error fetching vrf table id for link=" << link;
     return 0;
   }
 
@@ -1283,7 +1282,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
   // link objects, which may lead to duplicated creation handling, so
   // ignore it.
   if (rtnl_link_get_family(link) == AF_INET6) {
-    VLOG(1) << __FUNCTION__ << ": ignoring link " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": ignoring link " << link;
     return;
   }
 
@@ -1297,8 +1296,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
 
       // check for new bridge slaves
       if (master == 0) {
-        LOG(ERROR) << __FUNCTION__ << ": bridge slave without master "
-                   << OBJ_CAST(link);
+        LOG(ERROR) << __FUNCTION__ << ": bridge slave without master " << link;
         return;
       }
 
@@ -1321,7 +1319,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
       }
 
       auto br_link = get_link_by_ifindex(master);
-      LOG(INFO) << __FUNCTION__ << ": using bridge " << OBJ_CAST(br_link.get());
+      LOG(INFO) << __FUNCTION__ << ": using bridge " << br_link.get();
 
       // we only support vlan aware bridges
       if (rtnl_link_bridge_get_vlan_filtering(br_link.get(), &vlan_filtering) <
@@ -1369,22 +1367,21 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
     int rv = vxlan->create_vni(link);
 
     if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": failed to create vni for link "
-                 << OBJ_CAST(link);
+      LOG(ERROR) << __FUNCTION__ << ": failed to create vni for link " << link;
       break;
     }
   } break;
   case LT_VLAN: {
-    VLOG(1) << __FUNCTION__ << ": new vlan interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": new vlan interface " << link;
     uint16_t vid = rtnl_link_vlan_get_id(link);
     vlan->add_vlan(link, vid, true);
   } break;
   case LT_BOND: {
-    VLOG(1) << __FUNCTION__ << ": new bond interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": new bond interface " << link;
     bond->add_lag(link);
   } break;
   case LT_VRF: {
-    VLOG(1) << __FUNCTION__ << ": new vrf interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": new vrf interface " << link;
   } break;
   default: {
     bool handled = port_man->portdev_ready(link);
@@ -1395,7 +1392,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
       swi->port_set_config(port_id, port_man->get_hwaddr(port_id), false);
     } else {
       LOG(WARNING) << __FUNCTION__ << ": ignoring link with lt=" << lt
-                   << " link:" << OBJ_CAST(link);
+                   << " link:" << link;
     }
   } break;
   } // switch link type
@@ -1420,8 +1417,8 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
   // libnl 3.6+ sends IPv6 configuration updates as incomplete AF_INET6
   // link objects, which may lead to unexpected side effects, so ignore it.
   if (af_old == AF_INET6 || af_new == AF_INET6) {
-    VLOG(1) << __FUNCTION__ << ": ignoring old link " << OBJ_CAST(old_link)
-            << " new link " << OBJ_CAST(new_link);
+    VLOG(1) << __FUNCTION__ << ": ignoring old link " << old_link
+            << " new link " << new_link;
     return;
   }
 
@@ -1429,8 +1426,8 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
       is_switch_interface(old_link)) {
     if (update_on_mac_change(old_link, new_link) < 0)
       LOG(ERROR) << __FUNCTION__
-                 << ": failed to update MAC old_link=" << OBJ_CAST(old_link)
-                 << " new_link=" << OBJ_CAST(new_link);
+                 << ": failed to update MAC old_link=" << old_link
+                 << " new_link=" << new_link;
   }
 
   if (af_old != af_new) {
@@ -1474,8 +1471,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     }
     LOG(INFO) << __FUNCTION__ << ": link enslaved "
               << rtnl_link_get_name(new_link) << " to vrf "
-              << OBJ_CAST(
-                     get_link_by_ifindex(rtnl_link_get_master(new_link)).get());
+              << get_link_by_ifindex(rtnl_link_get_master(new_link)).get();
     // Lookup l3 addresses to delete
     // We can delete the addresses on the interface because we will later
     // receive a notification readding the addresses, that time with the correct
@@ -1486,8 +1482,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
   } break;
   case LT_VRF_SLAVE: {
     if (lt_new == LT_VLAN) {
-      LOG(INFO) << __FUNCTION__ << ": freed vrf slave interface "
-                << OBJ_CAST(old_link);
+      LOG(INFO) << __FUNCTION__ << ": freed vrf slave interface " << old_link;
 
       // Lookup l3 addresses to delete
       // We can delete the addresses on the interface because we will later
@@ -1496,7 +1491,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
       remove_l3_addresses(old_link);
       vlan->vrf_detach(old_link, new_link);
     } else if (lt_new == LT_VRF_SLAVE) {
-      LOG(INFO) << __FUNCTION__ << ": link updated " << OBJ_CAST(new_link);
+      LOG(INFO) << __FUNCTION__ << ": link updated " << new_link;
       vlan->vrf_attach(old_link, new_link);
     }
     // TODO handle LT_TAP/LT_BOND, currently unimplemented
@@ -1510,8 +1505,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
   case LT_BRIDGE:
     VLOG(2) << __FUNCTION__
             << ": ignoring update (not supported) of old_lt=" << lt_old
-            << " old link: " << OBJ_CAST(old_link)
-            << ", new link: " << OBJ_CAST(new_link);
+            << " old link: " << old_link << ", new link: " << new_link;
     break;
   default:
     if (port_id > 0) {
@@ -1531,7 +1525,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
       iface->changed(old_link, new_link);
     } else {
       LOG(ERROR) << __FUNCTION__ << ": link type not handled lt=" << lt_old
-                 << ", link: " << OBJ_CAST(old_link);
+                 << ", link: " << old_link;
     }
     break;
   }
@@ -1544,7 +1538,7 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
   // link objects, which may lead to duplicated deletion handling, so
   // ignore it.
   if (rtnl_link_get_family(link) == AF_INET6) {
-    VLOG(1) << __FUNCTION__ << ": ignoring link " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": ignoring link " << link;
     return;
   }
 
@@ -1581,16 +1575,16 @@ void cnetlink::link_deleted(rtnl_link *link) noexcept {
 
     if (rv < 0) {
       LOG(WARNING) << __FUNCTION__ << ": could not remove vni represented by "
-                   << OBJ_CAST(link);
+                   << link;
     }
 
   } break;
   case LT_VLAN:
-    VLOG(1) << __FUNCTION__ << ": removed vlan interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": removed vlan interface " << link;
     vlan->remove_vlan(link, rtnl_link_vlan_get_id(link), true);
     break;
   case LT_BOND: {
-    VLOG(1) << __FUNCTION__ << ": removed bond interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": removed bond interface " << link;
     bond->remove_lag(link);
   } break;
   case LT_VRF:
@@ -1650,10 +1644,10 @@ void cnetlink::neigh_ll_created(rtnl_neigh *neigh) noexcept {
 
   if (VLOG_IS_ON(2)) {
     if (base_link) {
-      LOG(INFO) << __FUNCTION__ << ": base link: " << OBJ_CAST(base_link);
+      LOG(INFO) << __FUNCTION__ << ": base link: " << base_link;
     }
     if (br_link) {
-      LOG(INFO) << __FUNCTION__ << ": br link: " << OBJ_CAST(br_link);
+      LOG(INFO) << __FUNCTION__ << ": br link: " << br_link;
     }
   }
 

--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -268,14 +268,12 @@ bool knet_manager::portdev_removed(rtnl_link *link) {
   auto pd_it =
       std::find(port_deleted.begin(), port_deleted.end(), ifi2id_it->second);
   if (pd_it == port_deleted.end()) {
-    LOG(FATAL) << __FUNCTION__ << ": unexpected port removal of "
-               << OBJ_CAST(link);
+    LOG(FATAL) << __FUNCTION__ << ": unexpected port removal of " << link;
   }
 
   auto id2ifi_it = id_to_ifindex.find(ifi2id_it->second);
   if (id2ifi_it == id_to_ifindex.end()) {
-    LOG(FATAL) << __FUNCTION__ << ": unexpected port removal of "
-               << OBJ_CAST(link);
+    LOG(FATAL) << __FUNCTION__ << ": unexpected port removal of " << link;
   }
 
   ifindex_to_id.erase(ifi2id_it);

--- a/src/netlink/netlink-utils.cc
+++ b/src/netlink/netlink-utils.cc
@@ -68,7 +68,7 @@ enum link_type get_link_type(rtnl_link *link) noexcept {
 
   VLOG(4) << __FUNCTION__ << ": type=" << safe_string_view(type)
           << ", slave=" << slave << ", af=" << rtnl_link_get_family(link)
-          << " of link " << OBJ_CAST(link);
+          << " of link " << link;
 
   // lo has no type
   if (!type) {

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -329,14 +329,12 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
     nl->get_bridge_ports(rtnl_link_get_master(_link), &bridge_ports);
 
     if (vxlan->get_tunnel_id(_link, nullptr, &tunnel_id) != 0) {
-      LOG(ERROR) << __FUNCTION__ << ": failed to get vni of link "
-                 << OBJ_CAST(_link);
+      LOG(ERROR) << __FUNCTION__ << ": failed to get vni of link " << _link;
     }
   } else {
     pport_no = nl->get_port_id(_link);
     if (pport_no == 0) {
-      LOG(ERROR) << __FUNCTION__
-                 << ": invalid pport_no=0 of link: " << OBJ_CAST(_link);
+      LOG(ERROR) << __FUNCTION__ << ": invalid pport_no=0 of link: " << _link;
       return;
     }
   }
@@ -350,7 +348,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__
                  << ": failed to remove ingress vlan=" << old_br_vlan->pvid
-                 << " link=" << OBJ_CAST(_link);
+                 << " link=" << _link;
       return;
     }
   }
@@ -417,8 +415,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
           } else {
             // normal vlan port
             VLOG(3) << __FUNCTION__ << ": add vid=" << vid
-                    << " on pport_no=" << pport_no
-                    << " link: " << OBJ_CAST(_link);
+                    << " on pport_no=" << pport_no << " link: " << _link;
 
             // the PVID is already being handled outside of the loop
             vlan->add_bridge_vlan(_link, vid, false, !egress_untagged);
@@ -444,8 +441,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
               }
               VLOG(3) << __FUNCTION__ << ": initialize vid=" << vid
                       << " on pport_no=" << pport_no
-                      << " to stp state=" << state
-                      << " link: " << OBJ_CAST(_link);
+                      << " to stp state=" << state << " link: " << _link;
               add_port_vlan_stp_state(pport_no, vid, state);
             }
 #endif
@@ -462,8 +458,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
                               tunnel_id, bridge_ports, false);
         } else {
           VLOG(3) << __FUNCTION__ << ": remove vid=" << vid
-                  << " on pport_no=" << pport_no
-                  << " link: " << OBJ_CAST(_link);
+                  << " on pport_no=" << pport_no << " link: " << _link;
 
           // delete all cache entries first
           std::unique_ptr<rtnl_neigh, decltype(&rtnl_neigh_put)> filter(
@@ -509,8 +504,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
 
       VLOG(3) << __FUNCTION__ << ": change vid=" << vid
               << " on pport_no=" << pport_no
-              << " egress untagged=" << egress_untagged
-              << " link: " << OBJ_CAST(_link);
+              << " egress untagged=" << egress_untagged << " link: " << _link;
 
       vlan->update_egress_bridge_vlan(_link, vid, egress_untagged);
     }
@@ -524,7 +518,7 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__
                  << ": failed to update pvid=" << new_br_vlan->pvid
-                 << " link=" << OBJ_CAST(_link);
+                 << " link=" << _link;
       return;
     }
   }
@@ -547,7 +541,7 @@ std::deque<rtnl_neigh *> nl_bridge::get_fdb_entries_of_port(rtnl_link *br_port,
   if (lladdr)
     rtnl_neigh_set_lladdr(filter.get(), lladdr);
 
-  VLOG(3) << __FUNCTION__ << ": searching for " << OBJ_CAST(filter.get());
+  VLOG(3) << __FUNCTION__ << ": searching for " << filter.get();
   std::deque<rtnl_neigh *> neighs;
   nl_cache_foreach_filter(
       nl->get_cache(cnetlink::NL_NEIGH_CACHE), OBJ_CAST(filter.get()),
@@ -626,8 +620,7 @@ void nl_bridge::update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
     uint32_t pport_no = nl->get_port_id(ifindex);
 
     if (pport_no == 0) {
-      LOG(WARNING) << __FUNCTION__ << ": ignoring unknown port "
-                   << OBJ_CAST(_br_port);
+      LOG(WARNING) << __FUNCTION__ << ": ignoring unknown port " << _br_port;
       continue;
     }
 
@@ -636,7 +629,7 @@ void nl_bridge::update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
     VLOG(2) << __FUNCTION__ << ": vid=" << vid << ", untagged=" << untagged
             << ", tunnel_id=" << tunnel_id << ", add=" << add
             << ", ifindex=" << ifindex << ", pport_no=" << pport_no
-            << ", port: " << OBJ_CAST(_br_port);
+            << ", port: " << _br_port;
 
     if (add) {
       std::string port_name = std::string(rtnl_link_get_name(_br_port));
@@ -655,7 +648,7 @@ void nl_bridge::update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
             0) {
           continue;
         }
-        VLOG(3) << ": needs to be updated " << OBJ_CAST(n);
+        VLOG(3) << ": needs to be updated " << n;
         vxlan->add_l2_neigh(n, link, br_link);
       }
 
@@ -673,7 +666,7 @@ void nl_bridge::update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
             0) {
           continue;
         }
-        VLOG(3) << ": needs to be updated " << OBJ_CAST(n);
+        VLOG(3) << ": needs to be updated " << n;
         add_neigh_to_fdb(n);
       }
       sw->l2_multicast_group_rejoin_all_in_vlan(pport_no, vid);
@@ -688,7 +681,7 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
   int ifindex = rtnl_neigh_get_ifindex(neigh);
   uint32_t port = nl->get_port_id(ifindex);
   if (port == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown port for neigh " << OBJ_CAST(neigh);
+    VLOG(1) << __FUNCTION__ << ": unknown port for neigh " << neigh;
     return;
   }
 
@@ -699,8 +692,7 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
   // rtnl_neigh_get_vlan() returns -1 when vid is unset,
   // which is not a valid VID.
   if (vid < 0) {
-    VLOG(2) << __FUNCTION__
-            << ": vlan not set, skipping add neigh=" << OBJ_CAST(neigh);
+    VLOG(2) << __FUNCTION__ << ": vlan not set, skipping add neigh=" << neigh;
     return;
   }
 
@@ -742,7 +734,7 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
   LOG(INFO) << __FUNCTION__ << ": add mac=" << _mac << " to bridge "
             << rtnl_link_get_name(bridge) << " on port=" << port
             << " vlan=" << (unsigned)vid << ", permanent=" << permanent;
-  LOG(INFO) << __FUNCTION__ << ": object: " << OBJ_CAST(neigh);
+  LOG(INFO) << __FUNCTION__ << ": object: " << neigh;
   sw->l2_addr_add(port, vid, _mac, true, permanent, update);
 
   if (!permanent) {
@@ -762,7 +754,7 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
     // cache the entry
     if (nl_cache_add(l2_cache.get(), OBJ_CAST(n.get())) < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed to add entry to l2_cache "
-                 << OBJ_CAST(n.get());
+                 << n.get();
     }
   }
 }
@@ -778,7 +770,7 @@ void nl_bridge::remove_neigh_from_fdb(rtnl_neigh *neigh) {
   // as well
   if (vid < 0) {
     VLOG(2) << __FUNCTION__
-            << ": vlan not set, skipping remove neigh=" << OBJ_CAST(neigh);
+            << ": vlan not set, skipping remove neigh=" << neigh;
     return;
   }
 
@@ -813,7 +805,7 @@ bool nl_bridge::is_mac_in_l2_cache(rtnl_neigh *n) {
 
   if (n_lookup) {
     VLOG(2) << __FUNCTION__ << ": found existing l2_cache entry "
-            << OBJ_CAST(n_lookup.get());
+            << n_lookup.get();
     return true;
   }
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -167,7 +167,7 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
   int ifindex = rtnl_addr_get_ifindex(a);
   auto l = nl->get_link_by_ifindex(ifindex);
   if (l == nullptr) {
-    LOG(ERROR) << __FUNCTION__ << ": no link for addr a=" << OBJ_CAST(a);
+    LOG(ERROR) << __FUNCTION__ << ": no link for addr a=" << a;
     return -EINVAL;
   }
   struct rtnl_link *link = l.get();
@@ -179,7 +179,7 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
 
   // if it isn't on loopback and not our interfaces, ignore it
   if (!is_loopback && !nl->is_switch_interface(link)) {
-    VLOG(1) << __FUNCTION__ << ": ignoring " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": ignoring " << link;
     return -EINVAL;
   }
 
@@ -187,7 +187,7 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
   int master_id = rtnl_link_get_master(link);
   if (master_id && is_bridge &&
       rtnl_link_get_addr(nl->get_link(master_id, AF_BRIDGE))) {
-    VLOG(1) << __FUNCTION__ << ": ignoring address on " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": ignoring address on " << link;
     return -EINVAL;
   }
 
@@ -263,7 +263,7 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
     rv = vlan->add_vlan(link, vid, tagged);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed to add vlan id " << vid
-                 << " (tagged=" << tagged << " to link " << OBJ_CAST(link);
+                 << " (tagged=" << tagged << " to link " << link;
     }
   }
 
@@ -284,7 +284,7 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
   int ifindex = rtnl_addr_get_ifindex(a);
   auto l = nl->get_link_by_ifindex(ifindex);
   if (l == nullptr) {
-    LOG(ERROR) << __FUNCTION__ << ": no link for addr a=" << OBJ_CAST(a);
+    LOG(ERROR) << __FUNCTION__ << ": no link for addr a=" << a;
     return -EINVAL;
   }
   struct rtnl_link *link = l.get();
@@ -293,7 +293,7 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
 
   // if it isn't on loopback and not our interfaces, ignore it
   if (!is_loopback && !nl->is_switch_interface(link)) {
-    VLOG(1) << __FUNCTION__ << ": ignoring " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": ignoring " << link;
     return -EINVAL;
   }
 
@@ -344,7 +344,7 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
   if (prefixlen == 128) {
     rv = sw->l3_unicast_host_add(ipv6_dst, 0, false, update, 0);
     if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": failed to setup address " << OBJ_CAST(a);
+      LOG(ERROR) << __FUNCTION__ << ": failed to setup address " << a;
       return rv;
     }
   }
@@ -358,11 +358,11 @@ int nl_l3::add_l3_addr_v6(struct rtnl_addr *a) {
     rv = vlan->add_vlan(link, vid, tagged);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed to add vlan id " << vid
-                 << " (tagged=" << tagged << " to link " << OBJ_CAST(link);
+                 << " (tagged=" << tagged << " to link " << link;
     }
   }
 
-  VLOG(1) << __FUNCTION__ << ": added addr " << OBJ_CAST(a);
+  VLOG(1) << __FUNCTION__ << ": added addr " << a;
 
   return rv;
 }
@@ -413,7 +413,7 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
   if (link == nullptr) {
     LOG(ERROR) << __FUNCTION__
                << ": unknown link ifindex=" << rtnl_addr_get_ifindex(a)
-               << " of addr=" << OBJ_CAST(a);
+               << " of addr=" << a;
     return -EINVAL;
   }
 
@@ -429,7 +429,7 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
 
   // if it isn't on loopback and not our interfaces, ignore it
   if (!is_loopback && !nl->is_switch_interface(link)) {
-    VLOG(1) << __FUNCTION__ << ": ignoring " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": ignoring " << link;
     return -EINVAL;
   }
 
@@ -514,7 +514,7 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
     rv = vlan->remove_vlan(link, vid, tagged);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed to remove vlan id " << vid
-                 << " (tagged=" << tagged << " to link " << OBJ_CAST(link);
+                 << " (tagged=" << tagged << " to link " << link;
     }
   }
 
@@ -530,8 +530,7 @@ int nl_l3::get_l3_addrs(struct rtnl_link *link,
   if (af != AF_UNSPEC)
     rtnl_addr_set_family(filter.get(), af);
 
-  VLOG(1) << __FUNCTION__
-          << ": searching l3 addresses from interface=" << OBJ_CAST(link);
+  VLOG(1) << __FUNCTION__ << ": searching l3 addresses from interface=" << link;
 
   nl_cache_foreach_filter(
       nl->get_cache(cnetlink::NL_ADDR_CACHE), OBJ_CAST(filter.get()),
@@ -553,8 +552,7 @@ int nl_l3::get_l3_routes(struct rtnl_link *link,
   rtnl_route_add_nexthop(filter.get(), nh);
   rtnl_route_set_type(filter.get(), RTN_UNICAST);
 
-  VLOG(1) << __FUNCTION__
-          << ": searching l3 routes from interface=" << OBJ_CAST(link);
+  VLOG(1) << __FUNCTION__ << ": searching l3 routes from interface=" << link;
 
   nl_cache_foreach_filter(
       nl->get_cache(cnetlink::NL_ROUTE_CACHE), OBJ_CAST(filter.get()),
@@ -605,8 +603,8 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
 
     auto fdb_neigh = nl->search_fdb(vid, lladdr);
     for (auto neigh : fdb_neigh) {
-      VLOG(2) << __FUNCTION__ << ": found iface=" << OBJ_CAST(neigh);
-      VLOG(2) << __FUNCTION__ << ": found link=" << OBJ_CAST(link.get());
+      VLOG(2) << __FUNCTION__ << ": found iface=" << neigh;
+      VLOG(2) << __FUNCTION__ << ": found link=" << link.get();
 
       auto neigh_ifindex = rtnl_neigh_get_ifindex(neigh);
       auto neigh_link = nl->get_link_by_ifindex(neigh_ifindex);
@@ -615,7 +613,7 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
       if (rv < 0) {
         LOG(ERROR) << __FUNCTION__
                    << ": failed to setup vid ingress vid=" << vid << " on link "
-                   << OBJ_CAST(link.get());
+                   << link.get();
         return rv;
       }
 
@@ -624,7 +622,7 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
       if (rv < 0) {
         LOG(ERROR) << __FUNCTION__
                    << ": failed to setup vid ingress vid=" << vid << " on link "
-                   << OBJ_CAST(link.get());
+                   << link.get();
       }
     }
     return rv;
@@ -634,7 +632,7 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
   rv = vlan->add_vlan(link.get(), vid, tagged);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed to setup vid ingress vid=" << vid
-               << " on link " << OBJ_CAST(link.get());
+               << " on link " << link.get();
     return rv;
   }
 
@@ -683,7 +681,7 @@ int nl_l3::del_l3_neigh_egress(struct rtnl_neigh *n) {
         LOG(ERROR) << __FUNCTION__
                    << ": failed to determine physical port of l3 egress entry "
                       "for neigh "
-                   << OBJ_CAST(n);
+                   << n;
         return -ENODATA;
       }
 
@@ -744,12 +742,11 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
     }
 
     rv = add_l3_neigh_egress(n, &l3_interface_id, &vrf_id);
-    LOG(INFO) << __FUNCTION__ << ": adding l3 neigh egress for neigh "
-              << OBJ_CAST(n);
+    LOG(INFO) << __FUNCTION__ << ": adding l3 neigh egress for neigh " << n;
 
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": add l3 neigh egress failed for neigh "
-                 << OBJ_CAST(n);
+                 << n;
       return rv;
     }
 
@@ -776,8 +773,7 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
     }
 
     if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": add l3 unicast host failed for "
-                 << OBJ_CAST(n);
+      LOG(ERROR) << __FUNCTION__ << ": add l3 unicast host failed for " << n;
       return rv;
     }
   }
@@ -950,7 +946,7 @@ int nl_l3::del_l3_neigh(struct rtnl_neigh *n) {
   };
   if (unroutable_l3_neighs.erase(nh) > 0) {
     VLOG(2) << __FUNCTION__ << ": l3 neigh was disabled, nothing to do for "
-            << OBJ_CAST(n);
+            << n;
     return 0;
   }
 
@@ -1463,12 +1459,11 @@ int nl_l3::get_neighbours_of_route(
       }
 
       neigh = nl->get_neighbour(ifindex, nh_addr);
-      VLOG(2) << __FUNCTION__ << ": get neigh=" << OBJ_CAST(neigh)
+      VLOG(2) << __FUNCTION__ << ": get neigh=" << neigh
               << " of nh_addr=" << nh_addr;
 
       if (neigh && rtnl_neigh_get_lladdr(neigh) == nullptr) {
-        VLOG(2) << __FUNCTION__ << ": neigh=" << OBJ_CAST(neigh)
-                << " is not reachable";
+        VLOG(2) << __FUNCTION__ << ": neigh=" << neigh << " is not reachable";
         rtnl_neigh_put(neigh);
         neigh = nullptr;
       }
@@ -1658,7 +1653,7 @@ int nl_l3::add_l3_ecmp_route(rtnl_route *r,
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__
                << ": failed to create l3 unicast route with ecmp_id="
-               << l3_ecmp_id << ", route: " << OBJ_CAST(r);
+               << l3_ecmp_id << ", route: " << r;
   }
 
   return rv;
@@ -1688,7 +1683,7 @@ int nl_l3::del_l3_ecmp_route(rtnl_route *r,
       i->second.refcnt--;
       VLOG(4) << __FUNCTION__ << ": found l3 interface id for ecmp route id="
               << i->second.l3_interface_id << ", refcount=" << i->second.refcnt
-              << ", route " << OBJ_CAST(r);
+              << ", route " << r;
 
       if (i->second.refcnt <= 0) {
         int rv = sw->l3_ecmp_remove(i->second.l3_interface_id);
@@ -1700,8 +1695,7 @@ int nl_l3::del_l3_ecmp_route(rtnl_route *r,
   }
 
   LOG(ERROR) << __FUNCTION__
-             << ": tried to delete invalid ecmp interface for route "
-             << OBJ_CAST(r);
+             << ": tried to delete invalid ecmp interface for route " << r;
 
   return -EINVAL;
 }
@@ -1750,11 +1744,11 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
   if (vrf_id == MAIN_ROUTING_TABLE)
     vrf_id = 0;
 
-  VLOG(2) << __FUNCTION__ << ": adding route= " << OBJ_CAST(r)
+  VLOG(2) << __FUNCTION__ << ": adding route= " << r
           << " update=" << update_route;
 
   if (nnhs == 0) {
-    LOG(WARNING) << __FUNCTION__ << ": no neighbours of route " << OBJ_CAST(r);
+    LOG(WARNING) << __FUNCTION__ << ": no neighbours of route " << r;
     return -ENOTSUP;
   }
 
@@ -1769,8 +1763,8 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
 
     if (route) {
       bool duplicate = false;
-      VLOG(2) << __FUNCTION__ << ": got route " << OBJ_CAST(route)
-              << " for dst " << OBJ_CAST(rtnl_route_get_dst(r));
+      VLOG(2) << __FUNCTION__ << ": got route " << route << " for dst "
+              << rtnl_route_get_dst(r);
       if (rtnl_route_get_protocol(route) == RTPROT_KERNEL &&
           nl_addr_cmp_prefix(rtnl_route_get_dst(r),
                              rtnl_route_get_dst(route)) == 0) {
@@ -1784,8 +1778,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
         return 0;
     } else {
       // huh?
-      VLOG(2) << __FUNCTION__ << ": no route for dst "
-              << OBJ_CAST(rtnl_route_get_dst(r));
+      VLOG(2) << __FUNCTION__ << ": no route for dst " << rtnl_route_get_dst(r);
     }
   }
 
@@ -1795,7 +1788,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
 
   // no neighbours reachable
   if (rv < 0) {
-    LOG(ERROR) << __FUNCTION__ << ": no next hops for route " << OBJ_CAST(r);
+    LOG(ERROR) << __FUNCTION__ << ": no next hops for route " << r;
     return rv;
   }
 
@@ -1837,8 +1830,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
     // add neigh
     rv = add_l3_egress(ifindex, vid, s_mac, d_mac, &l3_interface_id);
     if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": add l3 egress failed for neigh "
-                 << OBJ_CAST(n);
+      LOG(ERROR) << __FUNCTION__ << ": add l3 egress failed for neigh " << n;
       // XXX TODO create l3 neigh later
       continue;
     }
@@ -1878,8 +1870,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
                << " rv=" << rv;
   }
 
-  VLOG(2) << __FUNCTION__ << ": enabling l3 neighs reachable by route "
-          << OBJ_CAST(r);
+  VLOG(2) << __FUNCTION__ << ": enabling l3 neighs reachable by route " << r;
   auto l3_neighs =
       get_l3_neighs_of_prefix(unroutable_l3_neighs, rtnl_route_get_dst(r));
   for (auto n : l3_neighs) {
@@ -1891,7 +1882,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
       continue;
     }
 
-    VLOG(2) << __FUNCTION__ << ": enabling l3 neigh " << OBJ_CAST(neigh);
+    VLOG(2) << __FUNCTION__ << ": enabling l3 neigh " << neigh;
     unroutable_l3_neighs.erase(n);
     add_l3_neigh(neigh);
     rtnl_neigh_put(neigh);
@@ -1945,8 +1936,8 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
 
     if (route) {
       bool duplicate = false;
-      VLOG(2) << __FUNCTION__ << ": got route " << OBJ_CAST(route)
-              << " for dst " << OBJ_CAST(rtnl_route_get_dst(r));
+      VLOG(2) << __FUNCTION__ << ": got route " << route << " for dst "
+              << rtnl_route_get_dst(r);
       if (rtnl_route_get_protocol(route) == RTPROT_KERNEL &&
           nl_addr_cmp_prefix(rtnl_route_get_dst(r),
                              rtnl_route_get_dst(route)) == 0) {
@@ -1960,8 +1951,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
         return 0;
     } else {
       // no route anymore, this is fine
-      VLOG(2) << __FUNCTION__ << ": no route for dst "
-              << OBJ_CAST(rtnl_route_get_dst(r));
+      VLOG(2) << __FUNCTION__ << ": no route for dst " << rtnl_route_get_dst(r);
     }
   }
 
@@ -1973,8 +1963,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
     }
   }
 
-  VLOG(2) << __FUNCTION__ << ": disabling l3 neighs reachable by route "
-          << OBJ_CAST(r);
+  VLOG(2) << __FUNCTION__ << ": disabling l3 neighs reachable by route " << r;
   auto l3_neighs =
       get_l3_neighs_of_prefix(routable_l3_neighs, rtnl_route_get_dst(r));
   for (auto n : l3_neighs) {
@@ -1988,7 +1977,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
       continue;
     }
 
-    VLOG(2) << __FUNCTION__ << ": disabling l3 neigh " << OBJ_CAST(neigh);
+    VLOG(2) << __FUNCTION__ << ": disabling l3 neigh " << neigh;
     del_l3_neigh(neigh);
     rtnl_neigh_put(neigh);
     unroutable_l3_neighs.emplace(n);
@@ -2018,7 +2007,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
   }
 
   if (neighs.size() == 0) {
-    VLOG(2) << __FUNCTION__ << ": no nexthop for this route " << OBJ_CAST(r);
+    VLOG(2) << __FUNCTION__ << ": no nexthop for this route " << r;
     return rv;
   }
 
@@ -2048,8 +2037,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
 
       if (rv < 0) {
         LOG(ERROR) << __FUNCTION__
-                   << ": could not retrieve l3 interface id for neigh "
-                   << OBJ_CAST(n);
+                   << ": could not retrieve l3 interface id for neigh " << n;
         // XXX TODO check how this can be handled
         continue;
       }
@@ -2061,8 +2049,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
     // XXX FIXME delete ecmp first then delete all l3_interfaces
     rv = del_l3_ecmp_route(r, l3_interfaces);
     if (rv < 0) {
-      LOG(ERROR) << __FUNCTION__ << ": failed to delete l3 ecmp route "
-                 << OBJ_CAST(r);
+      LOG(ERROR) << __FUNCTION__ << ": failed to delete l3 ecmp route " << r;
     }
   }
 
@@ -2072,8 +2059,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
 
     if (rv < 0 and rv != -EEXIST) {
       // clean up
-      LOG(ERROR) << __FUNCTION__ << ": del l3 egress failed for neigh "
-                 << OBJ_CAST(n);
+      LOG(ERROR) << __FUNCTION__ << ": del l3 egress failed for neigh " << n;
       // fallthrough
     }
 
@@ -2090,8 +2076,7 @@ bool nl_l3::is_l3_neigh_routable(struct rtnl_neigh *n) {
 
   auto route = rq.query_route(rtnl_neigh_get_dst(n));
   if (route) {
-    VLOG(2) << __FUNCTION__ << ": got route " << OBJ_CAST(route)
-            << " for neigh " << OBJ_CAST(n);
+    VLOG(2) << __FUNCTION__ << ": got route " << route << " for neigh " << n;
     if (rtnl_route_get_nnexthops(route) > 0) {
       std::deque<struct rtnl_nexthop *> nhs;
       get_nexthops_of_route(route, &nhs);
@@ -2102,7 +2087,7 @@ bool nl_l3::is_l3_neigh_routable(struct rtnl_neigh *n) {
     }
     nl_object_put(OBJ_CAST(route));
   } else {
-    VLOG(2) << __FUNCTION__ << ": no route for neigh " << OBJ_CAST(n);
+    VLOG(2) << __FUNCTION__ << ": no route for neigh " << n;
   }
 
   return routable;

--- a/src/netlink/nl_output.h
+++ b/src/netlink/nl_output.h
@@ -14,6 +14,24 @@ std::ostream &operator<<(std::ostream &stream, struct nl_object *n);
 
 std::ostream &operator<<(std::ostream &stream, struct rtnl_nexthop *nh);
 
+inline std::ostream &operator<<(std::ostream &stream, struct rtnl_addr *addr) {
+  return operator<<(stream, OBJ_CAST(addr));
+}
+
+inline std::ostream &operator<<(std::ostream &stream, struct rtnl_link *link) {
+  return operator<<(stream, OBJ_CAST(link));
+}
+
+inline std::ostream &operator<<(std::ostream &stream,
+                                struct rtnl_neigh *neigh) {
+  return operator<<(stream, OBJ_CAST(neigh));
+}
+
+inline std::ostream &operator<<(std::ostream &stream,
+                                struct rtnl_route *route) {
+  return operator<<(stream, OBJ_CAST(route));
+}
+
 inline std::string_view safe_string_view(const char *str) {
   return std::string_view(str ? str : "(null)");
 }

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -35,7 +35,7 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return -EINVAL;
   }
 
@@ -175,7 +175,7 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown link " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown link " << link;
     return -EINVAL;
   }
 
@@ -195,7 +195,7 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv=" << rv
                << " to remove vid=" << vid << "(tagged=" << tagged
-               << ") of link " << OBJ_CAST(link);
+               << ") of link " << link;
   }
 
   return rv;
@@ -260,7 +260,7 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv=" << rv
                << " to remove vid=" << vid << "(tagged=" << tagged
-               << ") of link " << OBJ_CAST(link);
+               << ") of link " << link;
     return rv;
   }
 
@@ -270,7 +270,7 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv= " << rv
                << " to remove all bridge entries in vid=" << vid << " link "
-               << OBJ_CAST(link);
+               << link;
     return rv;
   }
 
@@ -285,7 +285,7 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv= " << rv
-               << " to remove vid=" << vid << " of link " << OBJ_CAST(link);
+               << " to remove vid=" << vid << " of link " << link;
     return rv;
   }
 
@@ -298,7 +298,7 @@ int nl_vlan::enable_vlans(rtnl_link *link) {
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return -EINVAL;
   }
 
@@ -322,7 +322,7 @@ int nl_vlan::disable_vlans(rtnl_link *link) {
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return -EINVAL;
   }
 
@@ -358,7 +358,7 @@ int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return -EINVAL;
   }
 
@@ -401,7 +401,7 @@ int nl_vlan::update_egress_bridge_vlan(rtnl_link *link, uint16_t vid,
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return -EINVAL;
   }
 
@@ -430,7 +430,7 @@ void nl_vlan::remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
   uint32_t port_id = nl->get_port_id(link);
 
   if (port_id == 0) {
-    VLOG(1) << __FUNCTION__ << ": unknown interface " << OBJ_CAST(link);
+    VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return;
   }
 
@@ -476,11 +476,11 @@ uint16_t nl_vlan::get_vid(rtnl_link *link) {
       vid = default_vid;
     else if (rtnl_link_get_ifindex(link) != 1)
       LOG(ERROR) << __FUNCTION__ << ": unsupported link type " << lt
-                 << " of link " << OBJ_CAST(link);
+                 << " of link " << link;
     break;
   }
 
-  VLOG(2) << __FUNCTION__ << ": vid=" << vid << " interface=" << OBJ_CAST(link);
+  VLOG(2) << __FUNCTION__ << ": vid=" << vid << " interface=" << link;
 
   return vid;
 }
@@ -525,8 +525,7 @@ void nl_vlan::vrf_attach(rtnl_link *old_link, rtnl_link *new_link) {
     add_ingress_vlan(nl->get_port_id(link.get()), vid, true, vrf);
   }
 
-  VLOG(1) << __FUNCTION__ << ": attached=" << OBJ_CAST(new_link)
-          << " to VRF id=" << vrf;
+  VLOG(1) << __FUNCTION__ << ": attached=" << new_link << " to VRF id=" << vrf;
 }
 
 void nl_vlan::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
@@ -554,7 +553,7 @@ void nl_vlan::vrf_detach(rtnl_link *old_link, rtnl_link *new_link) {
     add_ingress_vlan(nl->get_port_id(link.get()), vid, true);
   }
 
-  VLOG(1) << __FUNCTION__ << ": detached=" << OBJ_CAST(new_link)
+  VLOG(1) << __FUNCTION__ << ": detached=" << new_link
           << " to VRF id=" << vrf->second;
   vlan_vrf.erase(vrf);
 }

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -260,7 +260,7 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv=" << rv
                << " to remove vid=" << vid << "(tagged=" << tagged
-               << ") of link " << link;
+               << ") of port_id " << port_id;
     return rv;
   }
 
@@ -269,8 +269,8 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv= " << rv
-               << " to remove all bridge entries in vid=" << vid << " link "
-               << link;
+               << " to remove all bridge entries in vid=" << vid << " port_id "
+               << port_id;
     return rv;
   }
 
@@ -285,7 +285,7 @@ int nl_vlan::disable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
 
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed with rv= " << rv
-               << " to remove vid=" << vid << " of link " << link;
+               << " to remove vid=" << vid << " of port_id " << port_id;
     return rv;
   }
 

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -671,7 +671,7 @@ int nl_vxlan::create_endpoint(rtnl_link *vxlan_link, rtnl_link *br_link,
     rv = add_l2_neigh(neigh, lport_id, tunnel_id);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed (rv=" << rv
-                 << ") to add l2 neigh " << link;
+                 << ") to add l2 neigh " << neigh;
     }
   }
 

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -201,8 +201,7 @@ void nl_vxlan::net_reachable_notification(struct net_params params) noexcept {
   }
 
   if (!rtnl_link_is_vxlan(vxlan_link)) {
-    VLOG(1) << __FUNCTION__ << ": not a vxlan interface "
-            << OBJ_CAST(vxlan_link);
+    VLOG(1) << __FUNCTION__ << ": not a vxlan interface " << vxlan_link;
     return;
   }
 
@@ -248,7 +247,7 @@ void nl_vxlan::register_bridge(nl_bridge *bridge) {
 
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed (rv=" << rv
-                 << ") to create vni for link " << OBJ_CAST(link);
+                 << ") to create vni for link " << link;
       continue;
     }
 
@@ -260,7 +259,7 @@ void nl_vxlan::register_bridge(nl_bridge *bridge) {
     rv = create_endpoint(link);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed (rv=" << rv
-                 << ") to create create endpoint " << OBJ_CAST(link);
+                 << ") to create create endpoint " << link;
     }
 
     // get neighs on vxlan link
@@ -286,7 +285,7 @@ void nl_vxlan::register_bridge(nl_bridge *bridge) {
       rv = add_l2_neigh(neigh, link, br_link);
       if (rv < 0) {
         LOG(ERROR) << __FUNCTION__ << ": failed (rv=" << rv
-                   << ") to add l2 neigh " << OBJ_CAST(link);
+                   << ") to add l2 neigh " << link;
       }
     }
   }
@@ -500,7 +499,7 @@ int nl_vxlan::remove_vni(rtnl_link *link) {
   auto v2t_it = vni2tunnel.find(vni);
 
   if (v2t_it == vni2tunnel.end()) {
-    LOG(ERROR) << __FUNCTION__ << ": could not delete vni " << OBJ_CAST(link);
+    LOG(ERROR) << __FUNCTION__ << ": could not delete vni " << link;
     return -EINVAL;
   }
 
@@ -547,8 +546,7 @@ int nl_vxlan::create_endpoint(rtnl_link *vxlan_link) {
 
   if (nl_addr_get_family(addr) != AF_INET) {
     LOG(ERROR) << __FUNCTION__
-               << ": detected unsupported remote address family "
-               << OBJ_CAST(vxlan_link);
+               << ": detected unsupported remote address family " << vxlan_link;
     return -ENOTSUP;
   }
 
@@ -673,7 +671,7 @@ int nl_vxlan::create_endpoint(rtnl_link *vxlan_link, rtnl_link *br_link,
     rv = add_l2_neigh(neigh, lport_id, tunnel_id);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": failed (rv=" << rv
-                 << ") to add l2 neigh " << OBJ_CAST(link);
+                 << ") to add l2 neigh " << link;
     }
   }
 
@@ -839,7 +837,7 @@ static auto lookup_endpoint(rtnl_link *vxlan_link, nl_addr *local_,
   int rv = rtnl_link_vxlan_get_id(vxlan_link, &vni);
 
   if (rv < 0) {
-    LOG(FATAL) << __FUNCTION__ << ": not a vxlan link " << OBJ_CAST(vxlan_link);
+    LOG(FATAL) << __FUNCTION__ << ": not a vxlan link " << vxlan_link;
   }
 
   uint32_t initiator_udp_dst_port = 4789;
@@ -857,7 +855,7 @@ static auto lookup_endpoint(rtnl_link *vxlan_link, nl_addr *local_,
     VLOG(1) << __FUNCTION__
             << ": endpoint not found having the following parameter local addr "
             << local_ << ", remote addr " << remote_ << ", on link "
-            << OBJ_CAST(vxlan_link);
+            << vxlan_link;
     return endpoint_id.end();
   }
 
@@ -885,14 +883,14 @@ int nl_vxlan::delete_endpoint(rtnl_link *vxlan_link, nl_addr *local_,
   int rv = get_tunnel_id(vxlan_link, &vni, &tunnel_id);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": cannot retrieve tunnel ids of "
-               << OBJ_CAST(vxlan_link);
+               << vxlan_link;
     return -EINVAL;
   }
 
   auto ep_it = lookup_endpoint(vxlan_link, local_, remote_);
   if (ep_it == endpoint_id.end()) {
     LOG(WARNING) << __FUNCTION__ << ": endpoint already deleted for "
-                 << OBJ_CAST(vxlan_link);
+                 << vxlan_link;
     return 0;
   }
 
@@ -959,8 +957,8 @@ int nl_vxlan::create_next_hop(rtnl_link *vxlan_link, nl_addr *remote,
 
   int nnh = rtnl_route_get_nnexthops(route.get());
 
-  VLOG(2) << __FUNCTION__ << ": route " << OBJ_CAST(route.get()) << " with "
-          << nnh << " next hop(s)";
+  VLOG(2) << __FUNCTION__ << ": route " << route.get() << " with " << nnh
+          << " next hop(s)";
   // XXX TODO implement ecmp
   if (nnh > 1) {
     // ecmp
@@ -1006,8 +1004,7 @@ int nl_vxlan::create_next_hop(rtnl_link *vxlan_link, nl_addr *remote,
 
   rv = create_next_hop(neigh, next_hop_id);
   if (rv < 0) {
-    LOG(ERROR) << __FUNCTION__ << ": failed to create next hop "
-               << OBJ_CAST(neigh);
+    LOG(ERROR) << __FUNCTION__ << ": failed to create next hop " << neigh;
     return -EINVAL;
   }
 
@@ -1040,7 +1037,7 @@ int nl_vxlan::create_next_hop(rtnl_neigh *neigh, uint32_t *next_hop_id) {
   nl_addr *addr = rtnl_link_get_addr(local_link.get());
   if (addr == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": invalid link (no ll addr) "
-               << OBJ_CAST(local_link.get());
+               << local_link.get();
     return -EINVAL;
   }
 
@@ -1049,8 +1046,7 @@ int nl_vxlan::create_next_hop(rtnl_neigh *neigh, uint32_t *next_hop_id) {
   // get neigh and set dst_mac
   addr = rtnl_neigh_get_lladdr(neigh);
   if (addr == nullptr) {
-    LOG(ERROR) << __FUNCTION__ << ": invalid neigh (no ll addr) "
-               << OBJ_CAST(neigh);
+    LOG(ERROR) << __FUNCTION__ << ": invalid neigh (no ll addr) " << neigh;
     return -EINVAL;
   }
 
@@ -1117,7 +1113,7 @@ int nl_vxlan::delete_next_hop(rtnl_neigh *neigh) {
   nl_addr *addr = rtnl_link_get_addr(local_link.get());
   if (addr == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": invalid link (no ll addr) "
-               << OBJ_CAST(local_link.get());
+               << local_link.get();
     return -EINVAL;
   }
 
@@ -1126,8 +1122,7 @@ int nl_vxlan::delete_next_hop(rtnl_neigh *neigh) {
   // get neigh and set dst_mac
   addr = rtnl_neigh_get_lladdr(neigh);
   if (addr == nullptr) {
-    LOG(ERROR) << __FUNCTION__ << ": invalid neigh (no ll addr) "
-               << OBJ_CAST(neigh);
+    LOG(ERROR) << __FUNCTION__ << ": invalid neigh (no ll addr) " << neigh;
     return -EINVAL;
   }
 
@@ -1203,8 +1198,7 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
 
   if (nl_addr_cmp(neigh_mac, link_mac) == 0) {
     VLOG(2) << __FUNCTION__
-            << ": (silently) ignoring interface address of link "
-            << OBJ_CAST(link);
+            << ": (silently) ignoring interface address of link " << link;
     return 0;
   }
 
@@ -1212,8 +1206,8 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
     /* find according endpoint port */
   case LT_VXLAN: {
 
-    LOG(INFO) << __FUNCTION__ << ": add neigh " << OBJ_CAST(neigh)
-              << " on vxlan interface " << OBJ_CAST(link);
+    LOG(INFO) << __FUNCTION__ << ": add neigh " << neigh
+              << " on vxlan interface " << link;
 
     bool is_endpoint = nl_addr_iszero(neigh_mac);
 
@@ -1252,7 +1246,7 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
     rv = get_tunnel_id(link, &vni, &tunnel_id);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": could not look up vni/tunnel id of "
-                 << OBJ_CAST(link);
+                 << link;
       return -EINVAL;
     }
 
@@ -1309,7 +1303,7 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
     // TODO second check on the same here
     if (ep_it == endpoint_id.end()) {
       LOG(ERROR) << __FUNCTION__ << ": found no endpoint for neighbour "
-                 << OBJ_CAST(neigh);
+                 << neigh;
       return -EINVAL;
     }
 
@@ -1334,8 +1328,7 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
     uint32_t pport = nl->get_port_id(ifindex);
 
     if (pport == 0) {
-      LOG(WARNING) << __FUNCTION__ << ": ignoring unknown link "
-                   << OBJ_CAST(link);
+      LOG(WARNING) << __FUNCTION__ << ": ignoring unknown link " << link;
       return -EINVAL;
     }
 
@@ -1354,9 +1347,8 @@ int nl_vxlan::add_l2_neigh(rtnl_neigh *neigh, uint32_t lport,
                            uint32_t tunnel_id) {
   if (lport == 0 || tunnel_id == 0) {
     LOG(ERROR) << __FUNCTION__
-               << ": could not find vxlan port details to add neigh "
-               << OBJ_CAST(neigh) << ", lport=" << lport
-               << ", tunnel_id=" << tunnel_id;
+               << ": could not find vxlan port details to add neigh " << neigh
+               << ", lport=" << lport << ", tunnel_id=" << tunnel_id;
     return -EINVAL;
   }
 
@@ -1385,8 +1377,8 @@ int nl_vxlan::delete_l2_neigh(rtnl_neigh *neigh, rtnl_link *link,
   switch (lt) {
   case LT_VXLAN: {
     /* find according endpoint port */
-    LOG(INFO) << __FUNCTION__ << ": neigh " << OBJ_CAST(neigh)
-              << " on vxlan interface " << OBJ_CAST(link);
+    LOG(INFO) << __FUNCTION__ << ": neigh " << neigh << " on vxlan interface "
+              << link;
 
     uint32_t dst_port;
     int rv = rtnl_link_vxlan_get_port(link, &dst_port);
@@ -1480,8 +1472,7 @@ int nl_vxlan::delete_l2_neigh_endpoint(rtnl_link *vxlan_link, nl_addr *local,
     LOG(ERROR)
         << __FUNCTION__
         << ": endpoint not found having the following parameter local addr "
-        << local << ", remote addr " << remote << ", on link "
-        << OBJ_CAST(vxlan_link);
+        << local << ", remote addr " << remote << ", on link " << vxlan_link;
     return -EINVAL;
   }
 
@@ -1527,8 +1518,7 @@ int nl_vxlan::delete_l2_neigh_access(rtnl_link *link, uint16_t vlan,
   uint32_t pport = nl->get_port_id(ifindex);
 
   if (pport == 0) {
-    LOG(WARNING) << __FUNCTION__ << ": ignoring unknown link "
-                 << OBJ_CAST(link);
+    LOG(WARNING) << __FUNCTION__ << ": ignoring unknown link " << link;
     return -EINVAL;
   }
 


### PR DESCRIPTION
Provide appropriate ``operator<<``s for various `rtnl_*` structs instead of forcing callers to `OBJ_CAST()` them, and drop `OBJ_CAST()` from all users.

## Motivation and Context

For some netlink structs we have a `operator<<`, for others these must be cast to `nl_object *` via `OBJ_CAST()`. This makes this error prone, as one might forget to hast (which then causes just he object's address to be printed, or add a `OBJ_CAST()` when one isn't needed, which may even cause crashes if the cast object isn't a `nl_object` (e.g. `nl_addr`).

So handle this casting via appropriate `operator<<`s, and reduce the possibilities of errors.

## How Has This Been Tested?

Built and run tested with debugging enabled.