### PR TITLE
fix duplicate route check for FRR

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1765,7 +1765,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
       rtnl_route_get_protocol(r) != RTPROT_KERNEL) {
     nl_route_query rq;
 
-    auto route = rq.query_route(rtnl_route_get_dst(r));
+    auto route = rq.query_route(rtnl_route_get_dst(r), RTM_F_FIB_MATCH);
 
     if (route) {
       bool duplicate = false;
@@ -1941,7 +1941,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
       rtnl_route_get_protocol(r) != RTPROT_KERNEL) {
     nl_route_query rq;
 
-    auto route = rq.query_route(rtnl_route_get_dst(r));
+    auto route = rq.query_route(rtnl_route_get_dst(r), RTM_F_FIB_MATCH);
 
     if (route) {
       bool duplicate = false;

--- a/src/netlink/nl_route_query.h
+++ b/src/netlink/nl_route_query.h
@@ -58,13 +58,14 @@ public:
   /**
    * return object has to be freed using nl_object_put
    */
-  struct rtnl_route *query_route(struct nl_addr *dst) {
+  struct rtnl_route *query_route(struct nl_addr *dst, uint32_t flags = 0) {
     int err = 1;
     struct nl_msg *m;
     struct rtmsg rmsg;
     memset(&rmsg, 0, sizeof(rmsg));
     rmsg.rtm_family = nl_addr_get_family(dst);
     rmsg.rtm_dst_len = nl_addr_get_prefixlen(dst);
+    rmsg.rtm_flags = flags;
 
     struct nl_object *route = nullptr;
     nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, cb, &route);


### PR DESCRIPTION
By default the kernel replies with an artifical host route when using `RTM_GETROUTE`. This means that comparing the route's dst with prefix will never be identical, unless the route added is a host route as well. To get the actual route in the kernel, we need to pass `RTM_F_FIB_MATCH` in the flags. This makes it return the full route including protocol and priority.

Difference via ip:

```
$ ip route get to 172.16.103.1
172.16.103.1 dev enp2s0 src 172.16.103.202 uid 1000 
    cache 

$ ip route get fibmatch to 172.16.103.1
172.16.103.0/24 dev enp2s0 proto kernel scope link src 172.16.103.202 metric 100 
```

Fixes: https://github.com/bisdn/basebox/commit/96e14a879fde8a24350f35c55ff9b286c9503eac ("nl_l3: ignore duplicated link routes from FRR")