### PR TITLE
of-dpa: reset switch state on connect

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -14,6 +14,9 @@
 #
 # Mark switched packets as offloaded:
 # FLAGS_mark_fwd_offload=true
+#
+# Clear switch configuration on connect
+# FLAGS_clear_switch_configuration=true
 
 ### glog
 #

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -21,6 +21,8 @@ DEFINE_int32(port, 6653, "Listening port");
 DEFINE_int32(ofdpa_grpc_port, 50051, "Listening port of ofdpa gRPC server");
 DEFINE_bool(use_knet, true, "Use KNET interfaces");
 DEFINE_bool(mark_fwd_offload, true, "Mark switched packets as offloaded");
+DEFINE_bool(clear_switch_configuration, true,
+            "Clear switch configuration on connect");
 
 static bool validate_port(const char *flagname, gflags::int32 value) {
   VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -14,6 +14,23 @@ namespace basebox {
 ofdpa_client::ofdpa_client(std::shared_ptr<Channel> channel)
     : stub_(ofdpa::OfdpaRpc::NewStub(channel)) {}
 
+OfdpaStatus::OfdpaStatusCode ofdpa_client::ofdpaTunnelReset() {
+  ::Empty request;
+  ::OfdpaStatus response;
+  ::ClientContext context;
+
+  context.set_wait_for_ready(true);
+
+  ::Status rv = stub_->ofdpaTunnelReset(&context, request, &response);
+
+  if (not rv.ok()) {
+    // LOG status
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
 OfdpaStatus::OfdpaStatusCode
 ofdpa_client::ofdpaTunnelTenantCreate(uint32_t tunnel_id, uint32_t vni) {
   // TODO maybe use ofdpa_datatypes as parameters
@@ -291,6 +308,23 @@ ofdpa_client::ofdpaTunnelPortTenantDelete(uint32_t port_id,
       stub_->ofdpaTunnelPortTenantDelete(&context, request, &response);
 
   if (not rv.ok()) {
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+OfdpaStatus::OfdpaStatusCode ofdpa_client::ofdpaStgReset() {
+  ::Empty request;
+  ::OfdpaStatus response;
+  ::ClientContext context;
+
+  context.set_wait_for_ready(true);
+
+  ::Status rv = stub_->ofdpaStgReset(&context, request, &response);
+
+  if (not rv.ok()) {
+    // LOG status
     return ofdpa::OfdpaStatus::OFDPA_E_RPC;
   }
 

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -16,6 +16,7 @@ class ofdpa_client {
 public:
   ofdpa_client(std::shared_ptr<grpc::Channel> channel);
 
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaTunnelReset();
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelTenantCreate(uint32_t tunnel_id, uint32_t vni);
 
@@ -54,6 +55,7 @@ public:
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelPortTenantDelete(uint32_t port_id, uint32_t tunnel_id);
 
+  ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgReset();
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgCreate(uint16_t stg_id);
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaStgDestroy(uint16_t stg_id);
 


### PR DESCRIPTION
To ensure that the baseboxd and switch state are in sync, reset the switch state on connect:

* delete all flows
* delete all groups
* delete all tunnels and their tenents and nexthops
* delete all bond ports
* reset STG groups to default (all vlans in group 1)

This ensures that the we have a valid state if baseboxd was restarted, either voluntarily (due to a restart) or involuntarily (due to a crash).