### PR TITLE
ctapdev: create tap devices with carrier off

### DIFF
--- a/src/netlink/ctapdev.cc
+++ b/src/netlink/ctapdev.cc
@@ -43,7 +43,7 @@ void ctapdev::tap_open() {
   }
 
   memset(&ifr, 0, sizeof(ifr));
-  ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+  ifr.ifr_flags = IFF_TAP | IFF_NO_PI | IFF_NO_CARRIER;
   strncpy(ifr.ifr_name, devname.c_str(), IFNAMSIZ - 1);
   hwaddr.pack(reinterpret_cast<uint8_t *>(ifr.ifr_hwaddr.sa_data), ETH_ALEN);
 


### PR DESCRIPTION
Since linux 6.0 it is possible to create tap devices with the carrier off instead of needing to set it off after creation [1].

This prevents a race between bring up and setting the carrier off.

[1] https://github.com/torvalds/linux/commit/195624d9c26b64c6856863da30ec578a790feec4

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
