### PR TITLE
nl_l3: fix nh_stub::operator<() strict weak ordering

### DIFF
--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -52,8 +52,12 @@ struct nh_stub {
   }
 
   bool operator<(const nh_stub &other) const {
-    if (nl_addr_cmp(nh, other.nh) < 0)
+    int cmp = nl_addr_cmp(nh, other.nh);
+
+    if (cmp < 0)
       return true;
+    if (cmp > 0)
+      return false;
 
     return ifindex < other.ifindex;
   }


### PR DESCRIPTION
According to [1], std::set requires a Compare function that has strict weak ordering [2], but the current implementation violates the second requirement:

* If `comp(a, b) == true` then `comp(b, a) == false`.

E.g. given the nh_stubs a = <169.254.0.1,62> and b = <172.16.111.1,4>:

* `comp(a, b) == true`, as 172.16.111.1 isn't < 169.254.0.1, but 4 < 62
* `comp(b, a) == true`, as 169.254.0.1 < 172.16.111.1.

This breaks e.g. lookups in sets, causing element not being deleted or being found.

Fix this by comparing the ifindex only if the addresses are equal, not only if the other one's is larger.

[1] https://en.cppreference.com/w/cpp/container/set
[2] https://en.cppreference.com/w/cpp/named_req/Compare

Fixes: 0fdba0d69587 ("nl_l3: only route l3 neighs if we have a route for them")