### PR TITLE
nl_l3::del_l3_unicast_route() fix unsubscribing from nh notifications

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1998,9 +1998,8 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
   for (auto i : unresolved_nh) {
     auto it = std::find_if(nh_callbacks.begin(), nh_callbacks.end(),
                            [&](std::pair<nh_reachable *, nh_params> &cb) {
-                             return cb.first == this &&
-                                    cb.second.nh.ifindex == i.ifindex &&
-                                    !nl_addr_cmp_prefix(cb.second.np.addr, dst);
+                             return cb.first == this && cb.second.nh == i &&
+                                    !nl_addr_cmp(cb.second.np.addr, dst);
                            });
 
     if (it != nh_callbacks.end())

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -2055,6 +2055,20 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
 
   // remove egress references
   for (auto n : neighs) {
+    int ifindex = rtnl_neigh_get_ifindex(n);
+    struct nl_addr *addr = rtnl_neigh_get_dst(n);
+
+    auto it =
+        std::find_if(nh_unreach_callbacks.begin(), nh_unreach_callbacks.end(),
+                     [&](std::pair<nh_unreachable *, nh_params> &cb) {
+                       return cb.first == this &&
+                              cb.second.nh.ifindex == ifindex &&
+                              !nl_addr_cmp(cb.second.nh.nh, addr) &&
+                              !nl_addr_cmp(cb.second.np.addr, dst);
+                     });
+
+    if (it != nh_unreach_callbacks.end())
+      nh_unreach_callbacks.erase(it);
     rv = del_l3_neigh_egress(n);
 
     if (rv < 0 and rv != -EEXIST) {

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -58,6 +58,13 @@ struct nh_stub {
     return ifindex < other.ifindex;
   }
 
+  bool operator==(const nh_stub &other) const {
+    if (nl_addr_cmp(nh, other.nh) != 0)
+      return false;
+
+    return ifindex == other.ifindex;
+  }
+
   nl_addr *nh;
   int ifindex;
 };


### PR DESCRIPTION
Properly unsubscribe from nh (un)reachable notifications:

1. make sure we only try to remove the nexthop reachable notification for this route.
2. remove nh unreachable notifications for all reachable nexthops