### PR TITLE
implement proper ECMP route handling

### DIFF
--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -10,6 +10,7 @@
 #include <tuple>
 
 #include <netlink/cache.h>
+#include <netlink/route/route.h>
 #include <rofl/common/cthread.hpp>
 
 #include "nl_bridge.h"
@@ -62,6 +63,9 @@ public:
    * @return rtnl_neigh* which needs to be freed using rtnl_neigh_put
    */
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
+
+  std::unique_ptr<struct rtnl_route, decltype(&rtnl_route_put)>
+  get_route_by_dst_ifindex(struct nl_addr *dst, int ifindex) const;
 
   int add_l3_configuration(rtnl_link *link);
   int remove_l3_configuration(rtnl_link *link);

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1466,39 +1466,6 @@ int nl_l3::get_neighbours_of_route(rtnl_route *route,
   return nhs->size();
 }
 
-int nl_l3::get_neighbours_of_route(
-    rtnl_route *route, std::deque<struct rtnl_neigh *> *neighs,
-    std::deque<nh_stub> *unresolved_nh) noexcept {
-
-  std::set<nh_stub> nhs;
-
-  assert(route);
-  assert(neighs);
-  assert(unresolved_nh);
-
-  auto ret = get_neighbours_of_route(route, &nhs);
-  if (ret < 0)
-    return ret;
-
-  for (auto nh : nhs) {
-    neigh = nl->get_neighbour(nh.ifindex, nh.nh);
-    VLOG(2) << __FUNCTION__ << ": get neigh=" << neigh
-            << " of nh_addr=" << nh.addr;
-
-    if (neigh && rtnl_neigh_get_lladdr(neigh) == nullptr) {
-      VLOG(2) << __FUNCTION__ << ": neigh=" << neigh << " is not reachable";
-      rtnl_neigh_put(neigh);
-      neigh = nullptr;
-    }
-    if (neigh)
-      neighs->push_back(neigh);
-    else
-      unresolved_nh->push_back(nh);
-  }
-
-  return nhs.size();
-}
-
 void nl_l3::register_switch_interface(switch_interface *sw) { this->sw = sw; }
 
 void nl_l3::notify_on_net_reachable(net_reachable *f,

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1648,39 +1648,19 @@ int nl_l3::del_l3_unicast_route(nl_addr *rt_dst, uint16_t vrf_id) {
 
 void nl_l3::nh_reachable_notification(struct rtnl_neigh *n,
                                       struct nh_params p) noexcept {
-  std::unique_ptr<rtnl_route, decltype(&rtnl_route_put)> filter(
-      rtnl_route_alloc(), rtnl_route_put);
-  std::deque<rtnl_route *> routes;
-  auto nh = rtnl_route_nh_alloc();
-
-  rtnl_route_nh_set_ifindex(nh, p.np.ifindex);
-  rtnl_route_add_nexthop(filter.get(), nh);
-
-  rtnl_route_set_type(filter.get(), RTN_UNICAST);
-  rtnl_route_set_dst(filter.get(), p.np.addr);
-
-  nl_cache_foreach_filter(
-      nl->get_cache(cnetlink::NL_ROUTE_CACHE), OBJ_CAST(filter.get()),
-      [](struct nl_object *o, void *arg) {
-        auto *route = (std::deque<rtnl_route *> *)arg;
-        route->push_back(ROUTE_CAST(o));
-      },
-      &routes);
-
-  if (routes.size() == 0) {
+  auto route = nl->get_route_by_dst_ifindex(p.np.addr, p.nh.ifindex);
+  if (route == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": failed to find route for dst=" << p.np.addr
                << " on ifindex=" << p.nh.ifindex << " for nh" << p.nh.nh;
     return;
   }
 
-  auto route = routes.front();
-
   std::set<nh_stub> nhs;
   std::set<uint32_t> l3_interface_ids;
-  get_neighbours_of_route(route, &nhs);
+  get_neighbours_of_route(route.get(), &nhs);
 
   uint32_t route_dst;
-  uint32_t vrf_id = rtnl_route_get_table(route);
+  uint32_t vrf_id = rtnl_route_get_table(route.get());
   if (vrf_id == MAIN_ROUTING_TABLE)
     vrf_id = 0;
 
@@ -1714,42 +1694,23 @@ void nl_l3::nh_reachable_notification(struct rtnl_neigh *n,
 
 void nl_l3::nh_unreachable_notification(struct rtnl_neigh *n,
                                         struct nh_params p) noexcept {
-  std::unique_ptr<rtnl_route, decltype(&rtnl_route_put)> filter(
-      rtnl_route_alloc(), rtnl_route_put);
-  std::deque<rtnl_route *> routes;
-  auto nh = rtnl_route_nh_alloc();
-
-  rtnl_route_nh_set_ifindex(nh, p.np.ifindex);
-  rtnl_route_add_nexthop(filter.get(), nh);
-
-  rtnl_route_set_type(filter.get(), RTN_UNICAST);
-  rtnl_route_set_dst(filter.get(), p.np.addr);
-
-  nl_cache_foreach_filter(
-      nl->get_cache(cnetlink::NL_ROUTE_CACHE), OBJ_CAST(filter.get()),
-      [](struct nl_object *o, void *arg) {
-        auto *route = (std::deque<rtnl_route *> *)arg;
-        route->push_back(ROUTE_CAST(o));
-      },
-      &routes);
-
-  if (routes.size() == 0) {
-    VLOG(1) << __FUNCTION__ << ": failed to find route for dst=" << p.np.addr
-            << " on ifindex=" << p.nh.ifindex << " for nh" << p.nh.nh;
+  auto route = nl->get_route_by_dst_ifindex(p.np.addr, p.nh.ifindex);
+  if (route == nullptr) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to find route for dst=" << p.np.addr
+               << " on ifindex=" << p.nh.ifindex << " for nh" << p.nh.nh;
     // let's assume we failed to removed the notification, but the route is
     // already removed
     del_l3_neigh_egress(n);
     return;
   }
 
-  auto route = routes.front();
-  uint32_t vrf_id = rtnl_route_get_table(route);
+  uint32_t vrf_id = rtnl_route_get_table(route.get());
   if (vrf_id == MAIN_ROUTING_TABLE)
     vrf_id = 0;
 
   std::set<nh_stub> nhs;
   std::set<uint32_t> l3_interface_ids;
-  get_neighbours_of_route(route, &nhs);
+  get_neighbours_of_route(route.get(), &nhs);
 
   uint32_t route_dst;
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -602,7 +602,8 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
     // attached to the bridge
     auto lladdr = rtnl_neigh_get_lladdr(n);
     uint16_t vid = vlan->get_vid(link.get());
-    *vrf_id = vlan->get_vrf_id(vid, link.get());
+    if (vrf_id)
+      *vrf_id = vlan->get_vrf_id(vid, link.get());
 
     auto fdb_neigh = nl->search_fdb(vid, lladdr);
     for (auto neigh : fdb_neigh) {

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -811,7 +811,7 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
     if (cb->second.nh.ifindex == rtnl_neigh_get_ifindex(n) &&
         nl_addr_cmp(cb->second.nh.nh, rtnl_neigh_get_dst(n)) == 0) {
       // XXX TODO add l3_interface?
-      cb->first->nh_reachable_notification(cb->second);
+      cb->first->nh_reachable_notification(n, cb->second);
       cb = nh_callbacks.erase(cb);
     } else {
       ++cb;
@@ -1646,7 +1646,8 @@ int nl_l3::del_l3_unicast_route(nl_addr *rt_dst, uint16_t vrf_id) {
   return rv;
 }
 
-void nl_l3::nh_reachable_notification(struct nh_params p) noexcept {
+void nl_l3::nh_reachable_notification(struct rtnl_neigh *n,
+                                      struct nh_params p) noexcept {
   std::unique_ptr<rtnl_route, decltype(&rtnl_route_put)> filter(
       rtnl_route_alloc(), rtnl_route_put);
   std::deque<rtnl_route *> routes;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1817,22 +1817,8 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
     uint32_t l3_interface_id = 0;
     auto ifindex = rtnl_neigh_get_ifindex(n);
 
-    auto link = nl->get_link_by_ifindex(ifindex);
-    auto vid = vlan->get_vid(link.get());
-    struct nl_addr *s_mac = rtnl_link_get_addr(link.get());
-    struct nl_addr *d_mac = rtnl_neigh_get_lladdr(n);
-
-    // For the Bridge SVI, the l3 interface already exists
-    // so we can just get that one
-    if (nl->is_bridge_interface(ifindex)) {
-      auto fdb_res = nl->search_fdb(vid, d_mac);
-
-      assert(fdb_res.size() == 1);
-      ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
-    }
-
     // add neigh
-    rv = add_l3_egress(ifindex, vid, s_mac, d_mac, &l3_interface_id);
+    rv = add_l3_neigh_egress(n, &l3_interface_id);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": add l3 egress failed for neigh " << n;
       // XXX TODO create l3 neigh later

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1599,7 +1599,6 @@ int nl_l3::add_l3_ecmp_route(rtnl_route *r,
   int rv = 0;
   uint32_t vrf_id = rtnl_route_get_table(r);
   uint32_t l3_ecmp_id = -1;
-  static uint32_t l3_ecmp_id_next = 1;
   auto it_range = l3_ecmp_mapping.equal_range(l3_interface_ids);
   auto i = it_range.first;
 
@@ -1618,8 +1617,7 @@ int nl_l3::add_l3_ecmp_route(rtnl_route *r,
 
   // no l3_ecmp_id found -> create a new one
   if (l3_ecmp_id == (uint32_t)-1) {
-    l3_ecmp_id = l3_ecmp_id_next;
-    rv = sw->l3_ecmp_add(l3_ecmp_id, l3_interface_ids);
+    rv = sw->l3_ecmp_add(&l3_ecmp_id, l3_interface_ids);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__
                  << ": failed to create l3 ecmp id=" << l3_ecmp_id;
@@ -1630,9 +1628,6 @@ int nl_l3::add_l3_ecmp_route(rtnl_route *r,
     // register the new l3_ecmp_id
     l3_ecmp_mapping.emplace(
         std::make_pair(l3_interface_ids, l3_interface(l3_ecmp_id)));
-
-    // increment l3_ecmp_id
-    l3_ecmp_id_next++;
   }
 
   // create route

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -126,6 +126,10 @@ private:
   int search_neigh_cache(int ifindex, struct nl_addr *addr, int family,
                          std::list<struct rtnl_neigh *> *neigh);
 
+  int add_l3_ecmp_group(const std::set<nh_stub> &nhs, uint32_t *l3_ecmp_id);
+  int get_l3_ecmp_group(const std::set<nh_stub> &nhs, uint32_t *l3_ecmp_id);
+  int del_l3_ecmp_group(const std::set<nh_stub> &nhs);
+
   bool is_ipv6_link_local_address(const struct nl_addr *addr) {
     auto p = nl_addr_alloc(16);
     nl_addr_parse("fe80::/10", AF_INET6, &p);

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -93,6 +93,7 @@ private:
   int get_l3_interface_id(int ifindex, const struct nl_addr *s_mac,
                           const struct nl_addr *d_mac,
                           uint32_t *l3_interface_id, uint16_t vid = 0);
+  int get_l3_interface_id(const nh_stub &nh, uint32_t *l3_interface_id);
 
   int add_l3_termination(uint32_t port_id, uint16_t vid,
                          const rofl::caddress_ll &mac, int af) noexcept;

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -78,9 +78,6 @@ public:
                              std::deque<struct rtnl_nexthop *> *nhs) noexcept;
 
   int get_neighbours_of_route(rtnl_route *r, std::set<nh_stub> *nhs) noexcept;
-  int get_neighbours_of_route(rtnl_route *r,
-                              std::deque<struct rtnl_neigh *> *neighs,
-                              std::deque<nh_stub> *unresolved_nh) noexcept;
 
   void register_switch_interface(switch_interface *sw);
 

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -85,7 +85,8 @@ public:
   void notify_on_nh_reachable(nh_reachable *f, struct nh_params p) noexcept;
   void notify_on_nh_unreachable(nh_unreachable *f, struct nh_params p) noexcept;
 
-  void nh_reachable_notification(struct nh_params) noexcept override;
+  void nh_reachable_notification(struct rtnl_neigh *,
+                                 struct nh_params) noexcept override;
   void nh_unreachable_notification(struct rtnl_neigh *,
                                    struct nh_params) noexcept override;
 

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -108,12 +108,6 @@ private:
                            uint16_t vrf_id = 0);
   int del_l3_unicast_route(nl_addr *rt_dst, uint16_t vrf_id = 0);
 
-  int add_l3_ecmp_route(rtnl_route *r,
-                        const std::set<uint32_t> &l3_interface_ids,
-                        bool update_route);
-  int del_l3_ecmp_route(rtnl_route *r,
-                        const std::set<uint32_t> &l3_interface_ids);
-
   int add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
                           uint16_t *vrf_id = nullptr);
   int del_l3_neigh_egress(struct rtnl_neigh *n);

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -77,6 +77,7 @@ public:
   void get_nexthops_of_route(rtnl_route *route,
                              std::deque<struct rtnl_nexthop *> *nhs) noexcept;
 
+  int get_neighbours_of_route(rtnl_route *r, std::set<nh_stub> *nhs) noexcept;
   int get_neighbours_of_route(rtnl_route *r,
                               std::deque<struct rtnl_neigh *> *neighs,
                               std::deque<nh_stub> *unresolved_nh) noexcept;

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -88,7 +88,8 @@ public:
 class nh_reachable {
 public:
   virtual ~nh_reachable() = default;
-  virtual void nh_reachable_notification(struct nh_params) noexcept = 0;
+  virtual void nh_reachable_notification(struct rtnl_neigh *,
+                                         struct nh_params) noexcept = 0;
 };
 
 class nh_unreachable {

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -214,7 +214,8 @@ void nl_vxlan::net_reachable_notification(struct net_params params) noexcept {
   create_endpoint(vxlan_link, br_link, params.addr);
 }
 
-void nl_vxlan::nh_reachable_notification(struct nh_params p) noexcept {
+void nl_vxlan::nh_reachable_notification(struct rtnl_neigh *n,
+                                         struct nh_params p) noexcept {
   // call create endpoint?
   net_reachable_notification(p.np);
 }

--- a/src/netlink/nl_vxlan.h
+++ b/src/netlink/nl_vxlan.h
@@ -30,7 +30,8 @@ public:
   ~nl_vxlan() {}
 
   void net_reachable_notification(struct net_params) noexcept override;
-  void nh_reachable_notification(struct nh_params) noexcept override;
+  void nh_reachable_notification(struct rtnl_neigh *,
+                                 struct nh_params) noexcept override;
 
   int create_vni(rtnl_link *link);
   int remove_vni(rtnl_link *link);

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1226,12 +1226,7 @@ int controller::l3_egress_remove(uint32_t l3_interface_id) noexcept {
     rv = -EINVAL;
   }
 
-  if (l3_interface_id == egress_interface_id + 1) {
-    egress_interface_id--;
-    // TODO free even more ids from set?
-  } else {
-    freed_egress_interfaces_ids.insert(l3_interface_id);
-  }
+  freed_egress_interfaces_ids.insert(l3_interface_id);
 
   return rv;
 }

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1452,12 +1452,18 @@ int controller::l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
   return rv;
 }
 
-int controller::l3_ecmp_add(uint32_t l3_ecmp_id,
+int controller::l3_ecmp_add(uint32_t *l3_ecmp_id,
                             const std::set<uint32_t> &l3_interfaces) noexcept {
   int rv = 0;
+  uint32_t _ecmp_interface_id;
+  bool increment = false;
 
-  if (l3_ecmp_id > 0x0fffffff)
-    return -EINVAL;
+  if (freed_ecmp_interfaces_ids.size()) {
+    _ecmp_interface_id = *freed_ecmp_interfaces_ids.begin();
+  } else {
+    _ecmp_interface_id = ecmp_interface_id;
+    increment = true;
+  }
 
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
@@ -1468,11 +1474,11 @@ int controller::l3_ecmp_add(uint32_t l3_ecmp_id,
         std::inserter(l3_interface_groups, l3_interface_groups.end()),
         [&](uint32_t id) { return fm_driver.group_id_l3_unicast(id); });
 
-    l3_ecmp_id = fm_driver.group_id_l3_ecmp(l3_ecmp_id);
     dpt.send_group_mod_message(
         rofl::cauxid(0),
-        fm_driver.enable_group_l3_ecmp(dpt.get_version(), l3_ecmp_id,
-                                       l3_interface_groups));
+        fm_driver.enable_group_l3_ecmp(
+            dpt.get_version(), fm_driver.group_id_l3_ecmp(_ecmp_interface_id),
+            l3_interface_groups, false));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1484,6 +1490,13 @@ int controller::l3_ecmp_add(uint32_t l3_ecmp_id,
     rv = -EINVAL;
   }
 
+  if (increment) {
+    ecmp_interface_id++;
+  } else {
+    freed_ecmp_interfaces_ids.erase(freed_ecmp_interfaces_ids.begin());
+  }
+
+  *l3_ecmp_id = _ecmp_interface_id;
   return rv;
 }
 
@@ -1496,10 +1509,10 @@ int controller::l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept {
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
 
-    l3_ecmp_id = fm_driver.group_id_l3_ecmp(l3_ecmp_id);
     dpt.send_group_mod_message(
         rofl::cauxid(0),
-        fm_driver.disable_group_l3_ecmp(dpt.get_version(), l3_ecmp_id));
+        fm_driver.disable_group_l3_ecmp(
+            dpt.get_version(), fm_driver.group_id_l3_ecmp(l3_ecmp_id)));
   } catch (rofl::eRofBaseNotFound &e) {
     LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
     rv = -EINVAL;
@@ -1510,6 +1523,8 @@ int controller::l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept {
     LOG(ERROR) << ": caught unknown exception: " << e.what();
     rv = -EINVAL;
   }
+
+  freed_ecmp_interfaces_ids.insert(l3_ecmp_id);
 
   return rv;
 }

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -233,6 +233,8 @@ public:
 
   int l3_ecmp_add(uint32_t *l3_ecmp_id,
                   const std::set<uint32_t> &l3_interfaces) noexcept override;
+  int l3_ecmp_update(uint32_t l3_ecmp_id,
+                     const std::set<uint32_t> &l3_interfaces) noexcept override;
   int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept override;
 
   int ingress_port_vlan_accept_all(uint32_t port) noexcept override;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -59,8 +59,8 @@ public:
                  rofl::openflow::cofhello_elem_versionbitmap(),
              uint16_t ofdpa_grpc_port = 50051)
       : nb(std::move(nb)), bb_thread(1), egress_interface_id(1),
-        default_idle_timeout(0), connected(false), ofdpa(nullptr),
-        ofdpa_grpc_port(ofdpa_grpc_port) {
+        ecmp_interface_id(1), default_idle_timeout(0), connected(false),
+        ofdpa(nullptr), ofdpa_grpc_port(ofdpa_grpc_port) {
     this->nb->register_switch(this);
     rofl::crofbase::set_versionbitmap(versionbitmap);
     bb_thread.start();
@@ -231,7 +231,7 @@ public:
                               const rofl::caddress_in6 &mask,
                               uint16_t vrf_id = 0) noexcept override;
 
-  int l3_ecmp_add(uint32_t l3_ecmp_id,
+  int l3_ecmp_add(uint32_t *l3_ecmp_id,
                   const std::set<uint32_t> &l3_interfaces) noexcept override;
   int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept override;
 
@@ -360,6 +360,8 @@ private:
   rofl::openflow::cofportstatsarray stats_array;
   uint32_t egress_interface_id;
   std::set<uint32_t> freed_egress_interfaces_ids;
+  uint32_t ecmp_interface_id;
+  std::set<uint32_t> freed_ecmp_interfaces_ids;
   uint16_t default_idle_timeout;
   bool connected;
   std::shared_ptr<ofdpa_client> ofdpa;

--- a/src/sai.h
+++ b/src/sai.h
@@ -142,6 +142,9 @@ public:
   /* @ Layer3 ECMP { */
   virtual int l3_ecmp_add(uint32_t *l3_ecmp_id,
                           const std::set<uint32_t> &l3_interfaces) noexcept = 0;
+  virtual int
+  l3_ecmp_update(uint32_t l3_ecmp_id,
+                 const std::set<uint32_t> &l3_interfaces) noexcept = 0;
   virtual int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept = 0;
   /* @} */
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -140,7 +140,7 @@ public:
   /* @} */
 
   /* @ Layer3 ECMP { */
-  virtual int l3_ecmp_add(uint32_t l3_ecmp_id,
+  virtual int l3_ecmp_add(uint32_t *l3_ecmp_id,
                           const std::set<uint32_t> &l3_interfaces) noexcept = 0;
   virtual int l3_ecmp_remove(uint32_t l3_ecmp_id) noexcept = 0;
   /* @} */


### PR DESCRIPTION
Implement ECMP route handling:

The current ECMP route handling implementation has seveal drawbacks:

* it assumes that all nexthops are reachable
* it does not handle nexthops becoming (un)reachable
* it uses a `set<l3_interface_id>` to ecmp group id, so if nexthops change their availability during route updates, ecmp groups may become orphaned
* it does not recycle ecmp group ids, so eventually it runs out

Fix this by implementing a `set<nh_stub>` to ecmp group id matching, for stable groups regardless of reachability of nexthops, and make `nl_l3::nh_{un}reachable_notification()` update ecmp routes, and not just mark them as (un)routable.

Finally, change the ECMP group id creation/destruction and id allocation being done in `of-dpa::controller`, like we already do for l3 interface ids, and recycle freed one. This ensures we do not eventually run out of ids.