### PR TITLE
2.0.x: backport fixes from main

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -14,6 +14,9 @@
 #
 # Mark switched packets as offloaded:
 # FLAGS_mark_fwd_offload=true
+#
+# Vlan ID used for untagged traffic on unbridged ports (1-4095):
+# FLAGS_port_untagged_vid=1
 
 ### glog
 #

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -21,10 +21,19 @@ DEFINE_int32(port, 6653, "Listening port");
 DEFINE_int32(ofdpa_grpc_port, 50051, "Listening port of ofdpa gRPC server");
 DEFINE_bool(use_knet, true, "Use KNET interfaces");
 DEFINE_bool(mark_fwd_offload, true, "Mark switched packets as offloaded");
+DEFINE_int32(port_untagged_vid, 1,
+             "VLAN ID used for untagged traffic on unbridged ports");
 
 static bool validate_port(const char *flagname, gflags::int32 value) {
   VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;
   if (value > 0 && value <= UINT16_MAX) // value is ok
+    return true;
+  return false;
+}
+
+static bool validate_vid(const char *flagname, gflags::int32 value) {
+  VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;
+  if (value > 0 && value <= 4095) // value is ok
     return true;
   return false;
 }
@@ -48,9 +57,14 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
+  if (!gflags::RegisterFlagValidator(&FLAGS_port_untagged_vid, &validate_vid)) {
+    std::cerr << "Failed to register vid validator" << std::endl;
+    exit(1);
+  }
+
   // all variables can be set from env
-  FLAGS_tryfromenv =
-      std::string("multicast,port,ofdpa_grpc_port,use_knet,mark_fwd_offload");
+  FLAGS_tryfromenv = std::string("multicast,port,ofdpa_grpc_port,use_knet,mark_"
+                                 "fwd_offload,port_untagged_vid");
   gflags::SetUsageMessage("");
   gflags::SetVersionString(PROJECT_VERSION);
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -5,6 +5,7 @@
 #include "nl_bond.h"
 
 #include <cassert>
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <linux/if_bridge.h>
 #include <netlink/route/link.h>
@@ -13,6 +14,8 @@
 #include "cnetlink.h"
 #include "nl_output.h"
 #include "sai.h"
+
+DECLARE_int32(port_untagged_vid);
 
 namespace basebox {
 
@@ -242,8 +245,8 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
     std::deque<uint16_t> vlans;
 
     if (nl->has_l3_addresses(bond)) {
-      swi->ingress_port_vlan_add(port_id, 1, true);
-      swi->egress_port_vlan_add(port_id, 1, true);
+      swi->ingress_port_vlan_add(port_id, FLAGS_port_untagged_vid, true);
+      swi->egress_port_vlan_add(port_id, FLAGS_port_untagged_vid, true);
     }
 
     nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
@@ -322,8 +325,8 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     }
 
     if (nl->has_l3_addresses(bond)) {
-      swi->ingress_port_vlan_remove(port_id, 1, true);
-      swi->egress_port_vlan_remove(port_id, 1);
+      swi->ingress_port_vlan_remove(port_id, FLAGS_port_untagged_vid, true);
+      swi->egress_port_vlan_remove(port_id, FLAGS_port_untagged_vid);
     }
   }
 #endif

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -837,7 +837,7 @@ int nl_bridge::fdb_timeout(rtnl_link *br_link, uint16_t vid,
                       rtnl_link_get_ifindex(br_link)) {
     // * remove l2 entry from kernel
     nl_msg *msg = nullptr;
-    rtnl_neigh_build_delete_request(n.get(), NLM_F_REQUEST, &msg);
+    rtnl_neigh_build_delete_request(n_lookup.get(), NLM_F_REQUEST, &msg);
     assert(msg);
 
     // send the message and create new fdb entry

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1998,9 +1998,8 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
   for (auto i : unresolved_nh) {
     auto it = std::find_if(nh_callbacks.begin(), nh_callbacks.end(),
                            [&](std::pair<nh_reachable *, nh_params> &cb) {
-                             return cb.first == this &&
-                                    cb.second.nh.ifindex == i.ifindex &&
-                                    !nl_addr_cmp_prefix(cb.second.np.addr, dst);
+                             return cb.first == this && cb.second.nh == i &&
+                                    !nl_addr_cmp(cb.second.np.addr, dst);
                            });
 
     if (it != nh_callbacks.end())

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <netlink/route/addr.h>
 #include <netlink/route/link.h>
@@ -27,6 +28,8 @@
 #include "nl_route_query.h"
 #include "sai.h"
 #include "utils/rofl-utils.h"
+
+DECLARE_int32(port_untagged_vid);
 
 namespace std {
 
@@ -476,7 +479,7 @@ int nl_l3::del_l3_addr(struct rtnl_addr *a) {
 
   std::deque<rtnl_addr *> addresses;
   get_l3_addrs(link, &addresses, family);
-  if (vid == 1 && addresses.empty()) {
+  if (vid == FLAGS_port_untagged_vid && addresses.empty()) {
     struct rtnl_link *other;
 
     if (rtnl_link_is_vlan(link)) {

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -2055,6 +2055,20 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
 
   // remove egress references
   for (auto n : neighs) {
+    int ifindex = rtnl_neigh_get_ifindex(n);
+    struct nl_addr *addr = rtnl_neigh_get_dst(n);
+
+    auto it =
+        std::find_if(nh_unreach_callbacks.begin(), nh_unreach_callbacks.end(),
+                     [&](std::pair<nh_unreachable *, nh_params> &cb) {
+                       return cb.first == this &&
+                              cb.second.nh.ifindex == ifindex &&
+                              !nl_addr_cmp(cb.second.nh.nh, addr) &&
+                              !nl_addr_cmp(cb.second.np.addr, dst);
+                     });
+
+    if (it != nh_unreach_callbacks.end())
+      nh_unreach_callbacks.erase(it);
     rv = del_l3_neigh_egress(n);
 
     if (rv < 0 and rv != -EEXIST) {

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -58,6 +58,13 @@ struct nh_stub {
     return ifindex < other.ifindex;
   }
 
+  bool operator==(const nh_stub &other) const {
+    if (nl_addr_cmp(nh, other.nh) != 0)
+      return false;
+
+    return ifindex == other.ifindex;
+  }
+
   nl_addr *nh;
   int ifindex;
 };

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -52,8 +52,12 @@ struct nh_stub {
   }
 
   bool operator<(const nh_stub &other) const {
-    if (nl_addr_cmp(nh, other.nh) < 0)
+    int cmp = nl_addr_cmp(nh, other.nh);
+
+    if (cmp < 0)
       return true;
+    if (cmp > 0)
+      return false;
 
     return ifindex < other.ifindex;
   }

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -58,7 +58,6 @@ public:
 private:
   static const uint16_t vid_low = 1;
   static const uint16_t vid_high = 0xfff;
-  static const uint16_t default_vid = vid_low;
 
   int enable_vlan(uint32_t port_id, uint16_t vid, bool tagged,
                   uint16_t vrf_id = 0);

--- a/src/netlink/nl_vxlan.cc
+++ b/src/netlink/nl_vxlan.cc
@@ -11,6 +11,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include <gflags/gflags.h>
+
 #include <netlink/cache.h>
 #include <netlink/route/link.h>
 #include <netlink/route/neighbour.h>
@@ -25,6 +27,8 @@
 #include "nl_output.h"
 #include "nl_route_query.h"
 #include "nl_vxlan.h"
+
+DECLARE_int32(port_untagged_vid);
 
 namespace basebox {
 
@@ -1051,7 +1055,8 @@ int nl_vxlan::create_next_hop(rtnl_neigh *neigh, uint32_t *next_hop_id) {
   }
 
   uint64_t dst_mac = nlall2uint64(addr);
-  uint16_t vlan_id = 1; // XXX TODO currently hardcoded to vid 1
+  uint16_t vlan_id =
+      FLAGS_port_untagged_vid; // XXX TODO currently hardcoded to untagged vid
   auto tnh = tunnel_nh(src_mac, dst_mac, physical_port, vlan_id);
   auto tnh_it = tunnel_next_hop_id.equal_range(tnh);
 
@@ -1127,7 +1132,8 @@ int nl_vxlan::delete_next_hop(rtnl_neigh *neigh) {
   }
 
   uint64_t dst_mac = nlall2uint64(addr);
-  uint16_t vlan_id = 1; // XXX TODO currently hardcoded to vid 1
+  uint16_t vlan_id =
+      FLAGS_port_untagged_vid; // XXX TODO currently hardcoded to untagged vid
   auto tnh = tunnel_nh(src_mac, dst_mac, physical_port, vlan_id);
 
   return delete_next_hop(tnh);


### PR DESCRIPTION
In preparation of a BISDN Linux 5.1.1 maintenance release, create a baseboxd 2.0 release with fixes, but no new features.

The untagged internal VLAN flag I deemed as a fix, as it allows working around a known issue, and does not change behavior by default.