### PR TITLE
fix warnings and enable -Werror

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('baseboxd', 'cpp',
     'b_asneeded=false',
     'prefix=/usr',
     'sysconfdir=/etc',
+    'werror=true',
   ])
 
 sources = files('''

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -959,7 +959,6 @@ int cnetlink::handle_source_mac_learn() {
        cnt < nl_proc_max && _packet_in.size() && state == NL_STATE_RUNNING;
        cnt++) {
     auto p = _packet_in.front();
-    int ifindex = port_man->get_ifindex(p.port_id);
 
     // pass process packets to port_man
     port_man->enqueue(p.port_id, p.pkt);

--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -253,8 +253,6 @@ bool knet_manager::portdev_removed(rtnl_link *link) {
 
   int ifindex(rtnl_link_get_ifindex(link));
   std::string portname(rtnl_link_get_name(link));
-  int rv = 0;
-  bool port_removed(false);
   std::lock_guard<std::mutex> lock{tn_mutex};
 
   auto ifi2id_it = ifindex_to_id.find(ifindex);

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -200,7 +200,7 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
   if (mem_it == lag_members.end()) { // No ports in lag
     std::set<uint32_t> members;
     members.insert(port_id);
-    auto lm_rv = lag_members.emplace(lag_id, members);
+    lag_members.emplace(lag_id, members);
   } else {
     mem_it->second.insert(port_id);
   }

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -892,7 +892,7 @@ int nl_bridge::mdb_entry_add(rtnl_mdb *mdb_entry) {
       &mdb);
 
   for (auto i : mdb) {
-    uint32_t port_ifindex = rtnl_mdb_entry_get_ifindex(i);
+    int port_ifindex = rtnl_mdb_entry_get_ifindex(i);
     uint32_t port_id = nl->get_port_id(port_ifindex);
     uint16_t vid = rtnl_mdb_entry_get_vid(i);
     unsigned char buf[ETH_ALEN];
@@ -991,7 +991,7 @@ int nl_bridge::mdb_entry_remove(rtnl_mdb *mdb_entry) {
       &mdb);
 
   for (auto i : mdb) {
-    uint32_t port_ifindex = rtnl_mdb_entry_get_ifindex(i);
+    int port_ifindex = rtnl_mdb_entry_get_ifindex(i);
     uint32_t port_id = nl->get_port_id(port_ifindex);
     uint16_t vid = rtnl_mdb_entry_get_vid(i);
     unsigned char buf[ETH_ALEN];

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1430,7 +1430,6 @@ int nl_l3::get_neighbours_of_route(
     rtnl_route *route, std::deque<struct rtnl_neigh *> *neighs,
     std::deque<nh_stub> *unresolved_nh) noexcept {
 
-  auto route_dst = rtnl_route_get_dst(route);
   std::deque<struct rtnl_nexthop *> nhs;
 
   assert(route);


### PR DESCRIPTION
Warnings are important and should be addressed, so make sure they cannot be ignored by enabling -Werror after fixing all warnings.

No functional changes.