### PR TITLE
fix handling of neighs regarding their routability

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -2093,13 +2093,10 @@ bool nl_l3::is_l3_neigh_routable(struct rtnl_neigh *n) {
   auto route = rq.query_route(rtnl_neigh_get_dst(n));
   if (route) {
     VLOG(2) << __FUNCTION__ << ": got route " << route << " for neigh " << n;
-    if (rtnl_route_get_nnexthops(route) > 0) {
-      std::deque<struct rtnl_nexthop *> nhs;
-      get_nexthops_of_route(route, &nhs);
-      if (nhs.size() > 0) {
-        VLOG(2) << __FUNCTION__ << ": neigh is routable in by us";
-        routable = true;
-      }
+
+    if (rtnl_route_guess_scope(route) == RT_SCOPE_LINK) {
+      VLOG(2) << __FUNCTION__ << ": neigh is routable in by us";
+      routable = true;
     }
     nl_object_put(OBJ_CAST(route));
   } else {
@@ -2107,7 +2104,7 @@ bool nl_l3::is_l3_neigh_routable(struct rtnl_neigh *n) {
   }
 
   return routable;
-};
+}
 
 std::deque<nh_stub> nl_l3::get_l3_neighs_of_prefix(std::set<nh_stub> &list,
                                                    nl_addr *prefix) {


### PR DESCRIPTION
Fix two issues when handling ip neighbours and their routability:

1. The check for routability was wrong, and was looking for a route with a nexthop (with ip). We actually want the opposite, a route without any nexthops with ip. So use `rtnl_route_guess_scope()` for that, which will tell us if this is this kind of route.
2. When marking ip neighbours as (un-)routable on route changes, we only need and should do that for on-link routes, and not any route. Without this, we may accidentally mark l3 neighs as routable if a route with the appropriate dst is added, but that isn't a on-link route (e.g. a default route).