### PR TITLE
nl_l3: fix nnhs handling a bit

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -2024,7 +2024,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
     return rv;
   }
 
-  if (neighs.size() > 1) {
+  if (nnhs > 1) {
     // get all l3 interfaces
     std::set<uint32_t> l3_interfaces; // all create l3 interface ids
     for (auto n : neighs) {

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1926,12 +1926,18 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
   int rv = 0;
   auto dst = rtnl_route_get_dst(r);
 
+  int nnhs = rtnl_route_get_nnexthops(r);
   uint16_t vrf_id = rtnl_route_get_table(r);
   // Routing table 254 id matches the main routing table on linux.
   // Adding a vrf with this id will collide with the main routing
   // table, but will enter the wrong info into the OFDPA tables
   if (vrf_id == MAIN_ROUTING_TABLE)
     vrf_id = 0;
+
+  if (nnhs == 0) {
+    LOG(WARNING) << __FUNCTION__ << ": no neighbours of route " << r;
+    return -ENOTSUP;
+  }
 
   if (rtnl_route_get_priority(r) > 0 &&
       rtnl_route_get_protocol(r) != RTPROT_KERNEL) {


### PR DESCRIPTION
Fix a few issues around number of nexthops handling:

- we rejected/ignored routes with 0 nexthops (`nnhs` = 0) on add, but don't do so in removal (though I'm not convinced this is an actual thing that can happen)
- later on we assume `nnhs` = 0 means no reachable(?) nexthop yet, but we already rejected routes with `nnhs` = 0 earlier, so this can't happen! Instead, check if `l3_interfaces` is empty
- when removing a route, don't use the amount of `l3_interfaces` to determine if this is a ECMP route, but use `nnhs` instead
