### PR TITLE
of-dpa: only notify about idle timed out bridging table flows

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -446,6 +446,10 @@ void controller::handle_bridging_table_rm(
   rofl::caddress_ll eth_dst;
   uint16_t vid = 0;
 
+  // we only care about flows being timed out
+  if (msg.get_reason() != rofl::openflow13::OFPRR_IDLE_TIMEOUT)
+    return;
+
   try {
     eth_dst = msg.get_match().get_eth_dst();
     vid = msg.get_match().get_vlan_vid() & 0xfff;


### PR DESCRIPTION
`controller::handle_bridging_table_rm()` will be called for various reasons, but we actually only care for one, the idle timeout.

Especially we don't care about flows being removed which we deleted ourselves, so ignore any that aren't idle timeouts.

This avoid us trying to handle flows removals we initiated, or having to detect them.

Fixes: 291591d6f313 ("l2 aging added")