### PR TITLE
nl_bridge: flush our fdb entries on vlan removal

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ sources = files('''
   src/netlink/nl_hashing.h
   src/netlink/nl_interface.cc
   src/netlink/nl_interface.h
+  src/netlink/nl_fdb_flush.h
   src/netlink/nl_l3.cc
   src/netlink/nl_l3.h
   src/netlink/nl_l3_interfaces.h

--- a/src/netlink/nl_fdb_flush.h
+++ b/src/netlink/nl_fdb_flush.h
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <cassert>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <thread>
+
+#include <glog/logging.h>
+
+#include <netlink/attr.h>
+#include <linux/rtnetlink.h>
+
+#include "nl_output.h"
+
+namespace basebox {
+
+class nl_fdb_flush final {
+  struct nl_sock *sock;
+
+public:
+  nl_fdb_flush() {
+    sock = nl_socket_alloc();
+    int err;
+    if ((err = nl_connect(sock, NETLINK_ROUTE)) < 0)
+      LOG(FATAL) << __FUNCTION__ << ": Unable to connect netlink socket: %s"
+                 << nl_geterror(err);
+  }
+
+  ~nl_fdb_flush() { nl_socket_free(sock); }
+
+  /**
+   * flush fdb
+   */
+  int flush_fdb(int ifindex, uint16_t vlan, uint8_t flags) {
+    struct nl_msg *m;
+    struct ndmsg ndm;
+    int err;
+
+    memset(&ndm, 0, sizeof(ndm));
+    ndm.ndm_family = PF_BRIDGE;
+    ndm.ndm_ifindex = ifindex;
+    ndm.ndm_flags = flags;
+
+    m = nlmsg_alloc_simple(RTM_DELNEIGH, NLM_F_REQUEST | NLM_F_BULK);
+    if (!m)
+      LOG(FATAL) << __FUNCTION__ << ": out of memory";
+
+    if (nlmsg_append(m, &ndm, sizeof(ndm), NLMSG_ALIGNTO) < 0)
+      LOG(FATAL) << __FUNCTION__ << ": out of memory";
+
+    if (vlan > 0) {
+      if (nla_put_u16(m, NDA_VLAN, vlan) < 0)
+        LOG(FATAL) << __FUNCTION__ << ": out of memory";
+    }
+
+    if (flags > 0) {
+      if (nla_put_u8(m, NDA_NDM_FLAGS_MASK, flags) < 0)
+        LOG(FATAL) << __FUNCTION__ << ": out of memory";
+    }
+
+    err = nl_send_auto_complete(sock, m);
+    nlmsg_free(m);
+    if (err < 0)
+      LOG(FATAL) << __FUNCTION__ << ": " << nl_geterror(err);
+
+    if ((err = nl_recvmsgs_default(sock)) < 0) {
+      LOG(FATAL) << __FUNCTION__ << ": " << nl_geterror(err);
+    }
+
+    return 0;
+  }
+};
+
+} // namespace basebox


### PR DESCRIPTION
The kernel refuses to remove fdb entries for VLANs that are not configured, but at the same time won't remove permanent entries on VLAN deletion, including extern_learn entries.

Fortunately recent kernels gained the ability for bulk deletion, so add a new helper to send a flush of all extern_learn entries from a deleted vlan from a certain port.

Using this, we can make sure no entries are left behind in the removed vlan.

Any removed entry will trigger a DEL_NEIGH message from the kernel, but since we already removed the neigh from the cache and removed the flow, we do not need to handle it again here, so add a check before attempting to handle the deleted neigh.

This was tested via:

on switch:

```
$ ip link add swbridge type bridge vlan_filtering 1 vlan_default_pvid 0 $ ip link set dev port5 master swbridge
$ ip link set dev port5 up
$ bridge vlan add dev port5 vid 2 pvid untagged
```

(connect something to port5, let it generate packets)

```
$ bridge fdb show dev port5 | grep extern_learn
0c:c4:7a:9c:29:fc vlan 2 extern_learn master swbridge
$ bridge vlan del dev port5 vid 2
```

Before:

```
$ bridge fdb show dev port5 | grep extern_learn
0c:c4:7a:9c:29:fc vlan 2 extern_learn master swbridge
```

(entry still present)

After:

```
$ bridge fdb show dev port5 | grep extern_learn
```

(entry gone)
