### PR TITLE
tap_io::handle_read_event(): fix potential buffer overrun

### DIFF
--- a/src/netlink/tap_io.cc
+++ b/src/netlink/tap_io.cc
@@ -107,7 +107,7 @@ void tap_io::handle_read_event(rofl::cthread &thread, int fd) {
     return;
   }
 
-  pkt->len = read(fd, pkt->data, len);
+  pkt->len = read(fd, pkt->data, len - sizeof(pkt->len));
 
   if (pkt->len > 0) {
     VLOG(3) << __FUNCTION__ << ": read " << pkt->len << " bytes from fd=" << fd


### PR DESCRIPTION
When accepting a packet, we may copy more than was allocated:

    size_t len = sizeof(std::size_t) + 22 + td->mtu;
    ...
    auto *pkt = (packet *)std::malloc(len);

    pkt->len = read(fd, pkt->data, len);
                        ^^^^^^^^^^^^^^

pkt->data is at an offset of pkt, but len is the size of the whole struct. So read() may write up to sizeof(pkt->len) over the end of the allocated pkt struct.

Fix this by reducing the maximum read size by size of pkt->len.

Found via valgrind:

    valgrind[1714]: ==1714== Thread 3:
    valgrind[1714]: ==1714== Syscall param read(buf) points to unaddressable byte(s)
    valgrind[1714]: ==1714==    at 0x625E22C: __libc_read (read.c:26)
    valgrind[1714]: ==1714==    by 0x625E22C: read (read.c:24)
    valgrind[1714]: ==1714==    by 0x278652: read (unistd.h:38)
    valgrind[1714]: ==1714==    by 0x278652: basebox::tap_io::handle_read_event(rofl::cthread&, int) (tap_io.cc:110)
    valgrind[1714]: ==1714==    by 0x58DF6C6: rofl::cthread::run_loop() (cthread.cpp:745)
    valgrind[1714]: ==1714==    by 0x61ECB39: start_thread (pthread_create.c:442)
    valgrind[1714]: ==1714==    by 0x626DA83: clone (clone.S:100)
    valgrind[1714]: ==1714==  Address 0xa8ae31a is 0 bytes after a block of size 1,530 alloc'd
    valgrind[1714]: ==1714==    at 0x484579B: malloc (vg_replace_malloc.c:381)
    valgrind[1714]: ==1714==    by 0x278638: basebox::tap_io::handle_read_event(rofl::cthread&, int) (tap_io.cc:103)
    valgrind[1714]: ==1714==    by 0x58DF6C6: rofl::cthread::run_loop() (cthread.cpp:745)
    valgrind[1714]: ==1714==    by 0x61ECB39: start_thread (pthread_create.c:442)
    valgrind[1714]: ==1714==    by 0x626DA83: clone (clone.S:100)

Fixes: 291591d6f313 ("l2 aging added")