### PR TITLE
1.x: nl_l3: use add_l3_neigh_egress() instead of open coding it

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1800,22 +1800,8 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
     uint32_t l3_interface_id = 0;
     auto ifindex = rtnl_neigh_get_ifindex(n);
 
-    auto link = nl->get_link_by_ifindex(ifindex);
-    auto vid = vlan->get_vid(link.get());
-    struct nl_addr *s_mac = rtnl_link_get_addr(link.get());
-    struct nl_addr *d_mac = rtnl_neigh_get_lladdr(n);
-
-    // For the Bridge SVI, the l3 interface already exists
-    // so we can just get that one
-    if (nl->is_bridge_interface(ifindex)) {
-      auto fdb_res = nl->search_fdb(vid, d_mac);
-
-      assert(fdb_res.size() == 1);
-      ifindex = rtnl_neigh_get_ifindex(fdb_res.front());
-    }
-
     // add neigh
-    rv = add_l3_egress(ifindex, vid, s_mac, d_mac, &l3_interface_id);
+    rv = add_l3_neigh_egress(n, &l3_interface_id);
     if (rv < 0) {
       LOG(ERROR) << __FUNCTION__ << ": add l3 egress failed for neigh "
                  << OBJ_CAST(n);


### PR DESCRIPTION
Use nl_l3::add_l3_neigh_egress() in nl_l3::add_l3_unicast_route() instead of open coding it.

This changes the ifindex of the nh notification, but that aligns with all other places using it:

- nl_l3::del_l3_unicast_route() uses ifindex of the neigh
- nh_{un}reachable_notification() uses ifindex of the neigh for matching

This also fixes an add/remove vlan imbalance between add_l3_unicast_route() and del_l3_unicast_route() for nexthops, as del_l3_unicast_route() is using del_l3_neigh(), which removes the vlan, but the open coded add in add_l3_unicast_route() does not add one.

(cherry picked from commit 200eba451c7c2bbece0efd8043c7e5a8ffa404a8)
Fixes: 3a96b2def21a ("nl_l3::del_l3_neigh_egress(): remove created VLAN as well")