### PR TITLE
1.x: nl_l3::add_l3_neigh_egress(): handle vrf_id as nullptr

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -601,7 +601,8 @@ int nl_l3::add_l3_neigh_egress(struct rtnl_neigh *n, uint32_t *l3_interface_id,
     // attached to the bridge
     auto lladdr = rtnl_neigh_get_lladdr(n);
     uint16_t vid = vlan->get_vid(link.get());
-    *vrf_id = vlan->get_vrf_id(vid, link.get());
+    if (vrf_id)
+      *vrf_id = vlan->get_vrf_id(vid, link.get());
 
     auto fdb_neigh = nl->search_fdb(vid, lladdr);
     for (auto neigh : fdb_neigh) {


### PR DESCRIPTION
nl_l3::add_l3_neigh_egress()'s signature sets nullptr as the default value for vrf_id, but later accesses it unconditionally.

Fix this by only setting it if set.

Fixes: 7788e2d82804 ("feat: enable IP addressses on Bridge Virtual Interfaces; enable multiple creation of VRF interfaces and attachement of BVI to these interfaces; example script for configuration of the VRFs")
Fixes: 9db220e5c0bf ("nl_l3: use add_l3_neigh_egress() instead of open coding it")

(cherry picked from commit 0157c07e1f875805c05da404b927170d274a37c3)

