### PR TITLE
add support for locked bridge ports and locked fdb entries

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1750,8 +1750,24 @@ void cnetlink::neigh_ll_created(rtnl_neigh *neigh) noexcept {
 
 void cnetlink::neigh_ll_updated(rtnl_neigh *old_neigh,
                                 rtnl_neigh *new_neigh) noexcept {
-  if (!check_ll_neigh(old_neigh) || !check_ll_neigh(new_neigh))
+  bool handle_old = check_ll_neigh(old_neigh);
+  bool handle_new = check_ll_neigh(new_neigh);
+
+  // nothing to do here
+  if (!handle_old && !handle_new)
     return;
+
+  // we ignored the previous one, so this is like a new neigh
+  if (!handle_old) {
+    neigh_ll_created(new_neigh);
+    return;
+  }
+
+  // we won't handle the neigh anymore
+  if (!handle_new) {
+    neigh_ll_deleted(old_neigh);
+    return;
+  }
 
   int old_ifindex = rtnl_neigh_get_ifindex(old_neigh);
   rtnl_link *old_base_link =

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1713,6 +1713,13 @@ bool cnetlink::check_ll_neigh(rtnl_neigh *neigh) noexcept {
     return false;
   }
 
+  uint32_t ext_flags;
+  if (!rtnl_neigh_get_ext_flags(neigh, &ext_flags) &&
+      ext_flags & NTF_EXT_LOCKED) {
+    VLOG(1) << __FUNCTION__ << ": state is locked for neighour " << neigh;
+    return false;
+  }
+
   return true;
 }
 

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -52,6 +52,14 @@ void nbi_impl::port_notification(
     case PORT_EVENT_TABLE:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
+        swi->port_set_learn(
+            ntfy.port_id,
+            switch_interface::
+                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+        swi->port_set_move_learn(
+            ntfy.port_id,
+            switch_interface::
+                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
         break;
       default:

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -196,6 +196,8 @@ public:
   int update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
                           const uint32_t tunnel_id, bool add);
 
+  void set_port_locked(rtnl_link *link, bool locked);
+
 private:
   struct bridge_stp_states bridge_stp_states;
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -531,6 +531,76 @@ errout:
   std::free(pkt);
   return rv;
 }
+int controller::sai_learn_mode_to_flags(sai_bridge_port_fdb_learning_t mode,
+                                        uint32_t *flags) {
+  uint32_t hw_flags;
+
+  switch (mode) {
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DROP:
+    hw_flags = ofdpa_client::SRC_MAC_LEARN_NONE;
+    break;
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE:
+    hw_flags = ofdpa_client::SRC_MAC_LEARN_FWD;
+    break;
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW:
+    hw_flags =
+        ofdpa_client::SRC_MAC_LEARN_FWD | ofdpa_client::SRC_MAC_LEARN_ARL;
+    break;
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_CPU_TRAP:
+    hw_flags = ofdpa_client::SRC_MAC_LEARN_CPU;
+    break;
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_CPU_LOG:
+    hw_flags =
+        ofdpa_client::SRC_MAC_LEARN_FWD | ofdpa_client::SRC_MAC_LEARN_CPU;
+    break;
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION:
+    hw_flags = ofdpa_client::SRC_MAC_LEARN_CPU |
+               ofdpa_client::SRC_MAC_LEARN_ARL |
+               ofdpa_client::SRC_MAC_LEARN_PENDING;
+    break;
+  case SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION:
+    hw_flags =
+        ofdpa_client::SRC_MAC_LEARN_FWD | ofdpa_client::SRC_MAC_LEARN_CPU |
+        ofdpa_client::SRC_MAC_LEARN_ARL | ofdpa_client::SRC_MAC_LEARN_PENDING;
+    break;
+  default:
+    return -EINVAL;
+  }
+
+  *flags = hw_flags;
+
+  return 0;
+}
+
+int controller::port_set_learn(
+    uint32_t port_id, sai_bridge_port_fdb_learning_t l2_learn) noexcept {
+  if (!connected) {
+    VLOG(1) << __FUNCTION__ << ": not connected";
+    return -EAGAIN;
+  }
+
+  uint32_t flags;
+  int rv = sai_learn_mode_to_flags(l2_learn, &flags);
+  if (rv)
+    return rv;
+
+  return ofdpa->ofdpaPortSourceMacLearningSet(port_id, flags);
+}
+
+int controller::port_set_move_learn(
+    uint32_t port_id, sai_bridge_port_fdb_learning_t l2_learn) noexcept {
+  if (!connected) {
+    VLOG(1) << __FUNCTION__ << ": not connected";
+    return -EAGAIN;
+  }
+
+  uint32_t flags;
+  int rv = sai_learn_mode_to_flags(l2_learn, &flags);
+  if (rv)
+    return rv;
+
+  return ofdpa->ofdpaPortSourceMacMoveLearningSet(port_id, l2_learn);
+}
 
 int controller::lag_create(uint32_t *lag_id, std::string name,
                            uint8_t mode) noexcept {

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -141,6 +141,11 @@ protected:
 
 public:
   // switch_interface
+  int port_set_learn(uint32_t port_id,
+                     sai_bridge_port_fdb_learning_t l2_learn) noexcept override;
+  int port_set_move_learn(
+      uint32_t port_id,
+      sai_bridge_port_fdb_learning_t l2_learn) noexcept override;
   int lag_create(uint32_t *lag_id, std::string name,
                  uint8_t mode) noexcept override;
   int lag_remove(uint32_t lag_id) noexcept override;
@@ -375,6 +380,9 @@ private:
     else
       return 1;
   }
+
+  int sai_learn_mode_to_flags(sai_bridge_port_fdb_learning_t mode,
+                              uint32_t *flags);
 
   enum timer_t {
     /* handle_timeout will be called as well from crofbase, hence we need some

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -79,6 +79,52 @@ ofdpa_client::ofdpaTunnelTenantDelete(uint32_t tunnel_id) {
 }
 
 OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaPortSourceMacLearningSet(uint32_t port_num,
+                                            uint32_t l2_learn) {
+  ::ofdpa::PortSrcMacLearning request;
+  ::ClientContext context;
+  ::OfdpaStatus response;
+
+  context.set_wait_for_ready(true);
+
+  request.set_port_num(port_num);
+  request.set_l2_learn(l2_learn);
+
+  ::Status rv =
+      stub_->ofdpaPortSourceMacLearningSet(&context, request, &response);
+
+  if (not rv.ok()) {
+    // LOG status
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaPortSourceMacMoveLearningSet(uint32_t port_num,
+                                                uint32_t l2_learn) {
+  ::ofdpa::PortSrcMacLearning request;
+  ::ClientContext context;
+  ::OfdpaStatus response;
+
+  context.set_wait_for_ready(true);
+
+  request.set_port_num(port_num);
+  request.set_l2_learn(l2_learn);
+
+  ::Status rv =
+      stub_->ofdpaPortSourceMacMoveLearningSet(&context, request, &response);
+
+  if (not rv.ok()) {
+    // LOG status
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+OfdpaStatus::OfdpaStatusCode
 ofdpa_client::ofdpaTunnelNextHopCreate(uint32_t next_hop_id, uint64_t src_mac,
                                        uint64_t dst_mac, uint32_t physical_port,
                                        uint16_t vlan_id) {

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -14,6 +14,14 @@ namespace basebox {
 
 class ofdpa_client {
 public:
+  typedef enum {
+    SRC_MAC_LEARN_NONE = 0,
+    SRC_MAC_LEARN_ARL = 1,
+    SRC_MAC_LEARN_CPU = 2,
+    SRC_MAC_LEARN_FWD = 4,
+    SRC_MAC_LEARN_PENDING = 8,
+  } ofdpa_src_mac_learn_mode_t;
+
   ofdpa_client(std::shared_ptr<grpc::Channel> channel);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode ofdpaTunnelReset();
@@ -22,6 +30,11 @@ public:
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelTenantDelete(uint32_t tunnel_id);
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  ofdpaPortSourceMacLearningSet(uint32_t port_num, uint32_t l2_learn);
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  ofdpaPortSourceMacMoveLearningSet(uint32_t port_num, uint32_t l2_learn);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelNextHopCreate(uint32_t next_hop_id, uint64_t src_mac,

--- a/src/sai.h
+++ b/src/sai.h
@@ -35,6 +35,36 @@ public:
     SAI_PORT_STAT_COLLISIONS,
   } sai_port_stat_t;
 
+  typedef enum {
+    // Drop packets with unknown source MAC. Do not learn. Do not forward.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DROP,
+    // Do not learn unknown source MAC. Forward based on destination MAC.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE,
+    // Hardware learning. Learn source MAC. Forward based on destination MAC.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW,
+    // Trap packets with unknown source MAC to CPU. Do not learn. Do not
+    // forward.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_CPU_TRAP,
+    // Trap packets with unknown source MAC to CPU. Do not learn. Forward based
+    // on destination MAC.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_CPU_LOG,
+    // Do not learn in hardware. Do not forward. This mode will generate only
+    // one notification per unknown source MAC to FDB callback.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION,
+    // Do not learn in hardware, but forward. This mode will generate only one
+    // notification per unknown source MAC to FDB callback.
+    // Not an official SAI mode, but there is no equivalent to what we currently
+    // do by default in OF-DPA.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION,
+  } sai_bridge_port_fdb_learning_t;
+
+  virtual int
+  port_set_learn(uint32_t port_id,
+                 sai_bridge_port_fdb_learning_t l2_learn) noexcept = 0;
+  virtual int
+  port_set_move_learn(uint32_t port_id,
+                      sai_bridge_port_fdb_learning_t l2_learn) noexcept = 0;
+
   /* @ LAG { */
   virtual int lag_create(uint32_t *lag_id, std::string name,
                          uint8_t mode) noexcept = 0;


### PR DESCRIPTION
Add support for the `LOCKED` flag of switch ports and fdb entries:

* `LOCKED` ports do not learn and do not forward packets from unknown mac addresses, so disable learning and forwarding for them.
* `LOCKED` fdb entries are not used for forwarding, but mark a mac address as "seen" on a port. Since this is basically like they weren't learnt, ignore these entries and only add them to OF-DPA once they lose their `LOCKED` flag.

To be able to do so, we need to enhance OF-DPA with the ability to do fine grained learning configuration. Since OF-DPA is old, model the internal interface after SAI [1], with a two modifications:

* add a mode that corresponds to what we currently use, where we log and forward
* add a method for configuring learning behavior for source port violations (i.e. a neighbor moved to a different port)

[1] https://github.com/opencomputeproject/SAI/blob/5ff3424512031258ed2431b06b64beea5bc36712/inc/saibridge.h#L39