### PR TITLE
fix setup learning for ports

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1473,6 +1473,12 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
 
       port_man->set_offloaded(link, FLAGS_mark_fwd_offload);
       swi->port_set_config(port_id, port_man->get_hwaddr(port_id), false);
+      swi->port_set_learn(
+          port_id, switch_interface::
+                       SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+      swi->port_set_move_learn(
+          port_id, switch_interface::
+                       SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
     } else {
       LOG(WARNING) << __FUNCTION__ << ": ignoring link with lt=" << lt
                    << " link:" << link;

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -52,14 +52,6 @@ void nbi_impl::port_notification(
     case PORT_EVENT_TABLE:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        swi->port_set_learn(
-            ntfy.port_id,
-            switch_interface::
-                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
-        swi->port_set_move_learn(
-            ntfy.port_id,
-            switch_interface::
-                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
         break;
       default:

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -599,7 +599,7 @@ int controller::port_set_move_learn(
   if (rv)
     return rv;
 
-  return ofdpa->ofdpaPortSourceMacMoveLearningSet(port_id, l2_learn);
+  return ofdpa->ofdpaPortSourceMacMoveLearningSet(port_id, flags);
 }
 
 int controller::lag_create(uint32_t *lag_id, std::string name,


### PR DESCRIPTION
Fix two issues in the recently introduced port learning configuration support:

1. Fix the flags value for port_set_move_learn(), which may not correspond to the expected value else.
2. Fix racy initial port learning setup by moving the learning setup into the netlink thread, which also does all the other gRPC calls.

Especially the latter caused issues when setting up bond interfaces with systemd-networkd, as these bond setups were parallel to setting up learning, causing some bond interface calls to fail.