### PR TITLE
1.x: backport support for locked ports and fdb entries

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1585,6 +1585,13 @@ bool cnetlink::check_ll_neigh(rtnl_neigh *neigh) noexcept {
     return false;
   }
 
+  uint32_t ext_flags;
+  if (!rtnl_neigh_get_ext_flags(neigh, &ext_flags) &&
+      ext_flags & NTF_EXT_LOCKED) {
+    VLOG(1) << __FUNCTION__ << ": state is locked for neighour " << neigh;
+    return false;
+  }
+
   return true;
 }
 

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1351,7 +1351,16 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
   } break;
   default: {
     bool handled = port_man->portdev_ready(link);
-    if (!handled)
+    if (handled) {
+      uint32_t port_id = get_port_id(link);
+
+      swi->port_set_learn(
+          port_id, switch_interface::
+                       SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+      swi->port_set_move_learn(
+          port_id, switch_interface::
+                       SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+    } else {
       LOG(WARNING) << __FUNCTION__ << ": ignoring link with lt=" << lt
                    << " link:" << OBJ_CAST(link);
   } break;

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1622,8 +1622,24 @@ void cnetlink::neigh_ll_created(rtnl_neigh *neigh) noexcept {
 
 void cnetlink::neigh_ll_updated(rtnl_neigh *old_neigh,
                                 rtnl_neigh *new_neigh) noexcept {
-  if (!check_ll_neigh(old_neigh) || !check_ll_neigh(new_neigh))
+  bool handle_old = check_ll_neigh(old_neigh);
+  bool handle_new = check_ll_neigh(new_neigh);
+
+  // nothing to do here
+  if (!handle_old && !handle_new)
     return;
+
+  // we ignored the previous one, so this is like a new neigh
+  if (!handle_old) {
+    neigh_ll_created(new_neigh);
+    return;
+  }
+
+  // we won't handle the neigh anymore
+  if (!handle_new) {
+    neigh_ll_deleted(old_neigh);
+    return;
+  }
 
   int old_ifindex = rtnl_neigh_get_ifindex(old_neigh);
   rtnl_link *old_base_link =

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -49,6 +49,14 @@ void nbi_impl::port_notification(
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
+        swi->port_set_learn(
+            ntfy.port_id,
+            switch_interface::
+                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+        swi->port_set_move_learn(
+            ntfy.port_id,
+            switch_interface::
+                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
         if (ntfy.status)
           port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);

--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -49,14 +49,6 @@ void nbi_impl::port_notification(
     case PORT_EVENT_ADD:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
-        swi->port_set_learn(
-            ntfy.port_id,
-            switch_interface::
-                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
-        swi->port_set_move_learn(
-            ntfy.port_id,
-            switch_interface::
-                SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
         if (ntfy.status)
           port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -197,6 +197,9 @@ void nl_bridge::add_interface(rtnl_link *link) {
   auto port_id = nl->get_port_id(link);
   set_port_stp_state(port_id, state);
 
+  auto locked = (rtnl_link_bridge_get_flags(link) & RTNL_BRIDGE_LOCKED) != 0;
+  set_port_locked(link, locked);
+
   // configure bonds and physical ports (non members of bond)
   update_vlans(nullptr, link);
 
@@ -233,6 +236,14 @@ void nl_bridge::update_interface(rtnl_link *old_link, rtnl_link *new_link) {
   }
 
   update_vlans(old_link, new_link);
+
+  auto old_locked =
+      (rtnl_link_bridge_get_flags(old_link) & RTNL_BRIDGE_LOCKED) != 0;
+  auto new_locked =
+      (rtnl_link_bridge_get_flags(new_link) & RTNL_BRIDGE_LOCKED) != 0;
+
+  if (old_locked != new_locked)
+    set_port_locked(new_link, new_locked);
 }
 
 void nl_bridge::delete_interface(rtnl_link *link) {
@@ -257,6 +268,7 @@ void nl_bridge::delete_interface(rtnl_link *link) {
   auto port_id = nl->get_port_id(link);
   // interface default is to STP state forward by default
   set_port_stp_state(port_id, BR_STATE_FORWARDING);
+  set_port_locked(link, false);
 }
 
 void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
@@ -1167,6 +1179,42 @@ nl_bridge::get_port_vlan_stp_states(rtnl_link *link) {
     return {};
 
   return bridge_stp_states.get_min_states(port_id);
+}
+
+void nl_bridge::set_port_locked(rtnl_link *link, bool locked) {
+  uint32_t port_id = nl->get_port_id(link);
+  std::set<uint32_t> ports;
+
+  if (port_id == 0)
+    return;
+
+  LOG(INFO) << __FUNCTION__ << ": " << (locked ? "locking" : "unlocking")
+            << " port " << rtnl_link_get_name(link);
+
+  if (nbi::get_port_type(port_id) == nbi::port_type_lag)
+    ports = nl->get_bond_members_by_port_id(port_id);
+  else
+    ports.insert(port_id);
+
+  for (auto port : ports) {
+    if (locked) {
+      // learn pending, but don't forward
+      sw->port_set_learn(
+          port,
+          switch_interface::SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION);
+      // kernel does not allow roaming to locked ports, so just drop it
+      sw->port_set_move_learn(
+          port, switch_interface::SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DROP);
+    } else {
+      // everything goes
+      sw->port_set_learn(
+          port, switch_interface::
+                    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+      sw->port_set_move_learn(
+          port, switch_interface::
+                    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION);
+    }
+  }
 }
 
 } /* namespace basebox */

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -197,6 +197,8 @@ public:
   int update_access_ports(rtnl_link *vxlan_link, rtnl_link *br_link,
                           const uint32_t tunnel_id, bool add);
 
+  void set_port_locked(rtnl_link *link, bool locked);
+
 private:
   struct bridge_stp_states bridge_stp_states;
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -562,7 +562,7 @@ int controller::port_set_move_learn(
   if (rv)
     return rv;
 
-  return ofdpa->ofdpaPortSourceMacMoveLearningSet(port_id, l2_learn);
+  return ofdpa->ofdpaPortSourceMacMoveLearningSet(port_id, flags);
 }
 
 int controller::lag_create(uint32_t *lag_id, std::string name,

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -141,6 +141,11 @@ protected:
 
 public:
   // switch_interface
+  int port_set_learn(uint32_t port_id,
+                     sai_bridge_port_fdb_learning_t l2_learn) noexcept override;
+  int port_set_move_learn(
+      uint32_t port_id,
+      sai_bridge_port_fdb_learning_t l2_learn) noexcept override;
   int lag_create(uint32_t *lag_id, std::string name,
                  uint8_t mode) noexcept override;
   int lag_remove(uint32_t lag_id) noexcept override;
@@ -368,6 +373,9 @@ private:
     else
       return 1;
   }
+
+  int sai_learn_mode_to_flags(sai_bridge_port_fdb_learning_t mode,
+                              uint32_t *flags);
 
   enum timer_t {
     /* handle_timeout will be called as well from crofbase, hence we need some

--- a/src/of-dpa/ofdpa_client.cc
+++ b/src/of-dpa/ofdpa_client.cc
@@ -62,6 +62,52 @@ ofdpa_client::ofdpaTunnelTenantDelete(uint32_t tunnel_id) {
 }
 
 OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaPortSourceMacLearningSet(uint32_t port_num,
+                                            uint32_t l2_learn) {
+  ::ofdpa::PortSrcMacLearning request;
+  ::ClientContext context;
+  ::OfdpaStatus response;
+
+  context.set_wait_for_ready(true);
+
+  request.set_port_num(port_num);
+  request.set_l2_learn(l2_learn);
+
+  ::Status rv =
+      stub_->ofdpaPortSourceMacLearningSet(&context, request, &response);
+
+  if (not rv.ok()) {
+    // LOG status
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+OfdpaStatus::OfdpaStatusCode
+ofdpa_client::ofdpaPortSourceMacMoveLearningSet(uint32_t port_num,
+                                                uint32_t l2_learn) {
+  ::ofdpa::PortSrcMacLearning request;
+  ::ClientContext context;
+  ::OfdpaStatus response;
+
+  context.set_wait_for_ready(true);
+
+  request.set_port_num(port_num);
+  request.set_l2_learn(l2_learn);
+
+  ::Status rv =
+      stub_->ofdpaPortSourceMacMoveLearningSet(&context, request, &response);
+
+  if (not rv.ok()) {
+    // LOG status
+    return ofdpa::OfdpaStatus::OFDPA_E_RPC;
+  }
+
+  return response.status();
+}
+
+OfdpaStatus::OfdpaStatusCode
 ofdpa_client::ofdpaTunnelNextHopCreate(uint32_t next_hop_id, uint64_t src_mac,
                                        uint64_t dst_mac, uint32_t physical_port,
                                        uint16_t vlan_id) {

--- a/src/of-dpa/ofdpa_client.h
+++ b/src/of-dpa/ofdpa_client.h
@@ -14,6 +14,14 @@ namespace basebox {
 
 class ofdpa_client {
 public:
+  typedef enum {
+    SRC_MAC_LEARN_NONE = 0,
+    SRC_MAC_LEARN_ARL = 1,
+    SRC_MAC_LEARN_CPU = 2,
+    SRC_MAC_LEARN_FWD = 4,
+    SRC_MAC_LEARN_PENDING = 8,
+  } ofdpa_src_mac_learn_mode_t;
+
   ofdpa_client(std::shared_ptr<grpc::Channel> channel);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
@@ -21,6 +29,11 @@ public:
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelTenantDelete(uint32_t tunnel_id);
+
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  ofdpaPortSourceMacLearningSet(uint32_t port_num, uint32_t l2_learn);
+  ofdpa::OfdpaStatus::OfdpaStatusCode
+  ofdpaPortSourceMacMoveLearningSet(uint32_t port_num, uint32_t l2_learn);
 
   ofdpa::OfdpaStatus::OfdpaStatusCode
   ofdpaTunnelNextHopCreate(uint32_t next_hop_id, uint64_t src_mac,

--- a/src/sai.h
+++ b/src/sai.h
@@ -35,6 +35,36 @@ public:
     SAI_PORT_STAT_COLLISIONS,
   } sai_port_stat_t;
 
+  typedef enum {
+    // Drop packets with unknown source MAC. Do not learn. Do not forward.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DROP,
+    // Do not learn unknown source MAC. Forward based on destination MAC.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE,
+    // Hardware learning. Learn source MAC. Forward based on destination MAC.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW,
+    // Trap packets with unknown source MAC to CPU. Do not learn. Do not
+    // forward.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_CPU_TRAP,
+    // Trap packets with unknown source MAC to CPU. Do not learn. Forward based
+    // on destination MAC.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_CPU_LOG,
+    // Do not learn in hardware. Do not forward. This mode will generate only
+    // one notification per unknown source MAC to FDB callback.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION,
+    // Do not learn in hardware, but forward. This mode will generate only one
+    // notification per unknown source MAC to FDB callback.
+    // Not an official SAI mode, but there is no equivalent to what we currently
+    // do by default in OF-DPA.
+    SAI_BRIDGE_PORT_FDB_LEARNING_MODE_FDB_LOG_NOTIFICATION,
+  } sai_bridge_port_fdb_learning_t;
+
+  virtual int
+  port_set_learn(uint32_t port_id,
+                 sai_bridge_port_fdb_learning_t l2_learn) noexcept = 0;
+  virtual int
+  port_set_move_learn(uint32_t port_id,
+                      sai_bridge_port_fdb_learning_t l2_learn) noexcept = 0;
+
   /* @ LAG { */
   virtual int lag_create(uint32_t *lag_id, std::string name,
                          uint8_t mode) noexcept = 0;


### PR DESCRIPTION
Backport of changes for support of locked ports and fdb entries.

Consists of backports of #457 and the follow up fix #460.

Depends on
* https://github.com/bisdn/meta-open-network-linux/pull/181
* https://github.com/bisdn/meta-bisdn-linux/pull/287
* https://github.com/bisdn/meta-ofdpa/pull/80