### PR TITLE
fix and extend the bumpversion* make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ bumpversionminor bumpversionmajor:
 	@IFS='.' read -r -a ver <<< "$(VERSION)"; \
 	if [ "$(BUMP)" = "major" ]; then \
 	  ver[0]=$$(($${ver[0]} + 1)); \
+	  ver[1]=0; \
 	elif [ "$(BUMP)" = "minor" ]; then \
 	  ver[1]=$$(($${ver[1]} + 1)); \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bumpversionminor bumpversionmajor bumpversionpatch:
 	fi; \
 	BUMPED_VER="$${ver[0]}.$${ver[1]}.$${ver[2]}"; \
 	echo "$$BUMPED_VER" > VERSION; \
-	git commit -vsm "Bump version to $$BUMPED_VER" VERSION
+	git commit -S -vsm "Bump version to $$BUMPED_VER" VERSION
 	@echo "Don't forget to run 'make tag'"
 
 tag:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bumpversionminor bumpversionmajor bumpversionpatch:
 	fi; \
 	BUMPED_VER="$${ver[0]}.$${ver[1]}.$${ver[2]}"; \
 	echo "$$BUMPED_VER" > VERSION; \
-	git commit -vsam "Bump version to $$BUMPED_VER"
+	git commit -vsm "Bump version to $$BUMPED_VER" VERSION
 	@echo "Don't forget to run 'make tag'"
 
 tag:

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,15 @@ bumpversionminor bumpversionmajor:
 	if [ "$(BUMP)" = "major" ]; then \
 	  ver[0]=$$(($${ver[0]} + 1)); \
 	  ver[1]=0; \
+	  ver[2]=0; \
 	elif [ "$(BUMP)" = "minor" ]; then \
 	  ver[1]=$$(($${ver[1]} + 1)); \
+	  ver[2]=0; \
 	else \
 	  echo invalid bump target \'$(BUMP)\'; \
 	  exit -1; \
 	fi; \
-	BUMPED_VER="$${ver[0]}.$${ver[1]}"; \
+	BUMPED_VER="$${ver[0]}.$${ver[1]}.$${ver[2]}"; \
 	echo "$$BUMPED_VER" > VERSION; \
 	git commit -vsam "Bump version to $$BUMPED_VER"
 	@echo "Don't forget to run 'make tag'"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ srpm: $(BUILDDIR)
 srpm-release: $(BUILDDIR)
 	make -C pkg/release/rpm outdir=$(CURDIR)
 
-bumpversionminor bumpversionmajor:
+bumpversionminor bumpversionmajor bumpversionpatch:
 	$(eval BUMP = $(shell echo $@ | sed 's/bumpversion//'))
 	@IFS='.' read -r -a ver <<< "$(VERSION)"; \
 	if [ "$(BUMP)" = "major" ]; then \
@@ -44,6 +44,8 @@ bumpversionminor bumpversionmajor:
 	elif [ "$(BUMP)" = "minor" ]; then \
 	  ver[1]=$$(($${ver[1]} + 1)); \
 	  ver[2]=0; \
+	elif [ "$(BUMP)" = "patch" ]; then \
+	  ver[2]=$$(($${ver[2]} + 1)); \
 	else \
 	  echo invalid bump target \'$(BUMP)\'; \
 	  exit -1; \


### PR DESCRIPTION
Fix and extend the make targets for bumping the version:

1. fix major version bumps to reset the minor version to 0
2. always include the patchver, even when 0 to match existing release versions
3. add a new patchversion bump make target (e.g. 2.3.1 -> 2.3.2)
4. ensure a version bump commit only includes a VERSION file change
5. also sign the version bump commit (which we enforce for the tag as well)