### PR TITLE
1.x: nbi_impl: set speed/duplex before setting link up

### DIFF
--- a/src/netlink/nbi_impl.cc
+++ b/src/netlink/nbi_impl.cc
@@ -37,8 +37,9 @@ void nbi_impl::port_notification(
     case PORT_EVENT_MODIFY:
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
+        if (ntfy.status)
+          port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         port_man->change_port_status(ntfy.name, ntfy.status);
-        port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;
       default:
         LOG(ERROR) << __FUNCTION__ << ": unknown port";
@@ -49,8 +50,9 @@ void nbi_impl::port_notification(
       switch (get_port_type(ntfy.port_id)) {
       case nbi::port_type_physical:
         port_man->create_portdev(ntfy.port_id, ntfy.name, ntfy.hwaddr, *this);
+        if (ntfy.status)
+          port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         port_man->change_port_status(ntfy.name, ntfy.status);
-        port_man->set_port_speed(ntfy.name, ntfy.speed, ntfy.duplex);
         break;
       case nbi::port_type_vxlan:
         // XXX TODO notify this?


### PR DESCRIPTION
This is a backport of https://github.com/bisdn/basebox/pull/451.

Link speed/duplex changes do not trigger any notifications, only link state changes do. Therefore we need to make sure that speed/duplex is set correctly before setting the link state to up for ports.

When setting the link state first, it leaves a window where a process reacting to the link state event may read out old speed/duplex before we had a change to update them, and the default speed/duplex is 10mbit/half for TAP.

This can for example lead to breakage in LACP, where it uses the link speed to calculate the actor key. If it uses the wrong/old speed, it calculates a different key than the other side, and LACP will then fail to synchronize, breaking the link.

So make sure to set the speed and duplex first on link up. On link down, we do not need to set any speed or duplex values, since their values are undefined.

Fixes: b5fe46ca64d4 ("tap_manager: set port speed on tap interfaces")

(cherry picked from commit eac8d30fae63cd4802d9f80e8af54eb26b54eb32)