### PR TITLE
cnetlink: fix compilation

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1363,6 +1363,7 @@ void cnetlink::link_created(rtnl_link *link) noexcept {
     } else {
       LOG(WARNING) << __FUNCTION__ << ": ignoring link with lt=" << lt
                    << " link:" << OBJ_CAST(link);
+    }
   } break;
   } // switch link type
 }


### PR DESCRIPTION
Fix compilation after merging 170617c7532c ("netlink: setup port learning from with the netlink thread"), where a closing brace was missing.

Fixes the following errors:

```
./src/netlink/cnetlink.cc: In member function ‘int basebox::cnetlink::handle_source_mac_learn()’: ../src/netlink/cnetlink.cc:954:9: warning: unused variable ‘ifindex’ [-Wunused-variable]
  954 |     int ifindex = port_man->get_ifindex(p.port_id);
      |         ^~~~~~~
../src/netlink/cnetlink.cc: In member function ‘void basebox::cnetlink::link_created(rtnl_link*)’:
../src/netlink/cnetlink.cc:1370:28: error: qualified-id in declaration before ‘(’ token
 1370 | void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
      |                            ^
../src/netlink/cnetlink.cc:1500:28: error: qualified-id in declaration before ‘(’ token
 1500 | void cnetlink::link_deleted(rtnl_link *link) noexcept {
      |                            ^
../src/netlink/cnetlink.cc:1565:30: error: qualified-id in declaration before ‘(’ token
 1565 | bool cnetlink::check_ll_neigh(rtnl_neigh *neigh) noexcept {
      |                              ^
../src/netlink/cnetlink.cc:1608:32: error: qualified-id in declaration before ‘(’ token
 1608 | void cnetlink::neigh_ll_created(rtnl_neigh *neigh) noexcept {
      |                                ^
../src/netlink/cnetlink.cc:1639:32: error: qualified-id in declaration before ‘(’ token
 1639 | void cnetlink::neigh_ll_updated(rtnl_neigh *old_neigh,
      |                                ^
../src/netlink/cnetlink.cc:1676:32: error: qualified-id in declaration before ‘(’ token
 1676 | void cnetlink::neigh_ll_deleted(rtnl_neigh *neigh) noexcept {
      |                                ^
../src/netlink/cnetlink.cc:1696:28: error: qualified-id in declaration before ‘(’ token
 1696 | void cnetlink::resend_state() noexcept {
      |                            ^
../src/netlink/cnetlink.cc:1701:31: error: qualified-id in declaration before ‘(’ token
 1701 | void cnetlink::register_switch(switch_interface *swi) noexcept {
      |                               ^
../src/netlink/cnetlink.cc:1712:33: error: qualified-id in declaration before ‘(’ token
 1712 | void cnetlink::unregister_switch(__attribute__((unused))
      |                                 ^
../src/netlink/cnetlink.cc:1718:21: error: qualified-id in declaration before ‘(’ token
 1718 | void cnetlink::start() noexcept {
      |                     ^
../src/netlink/cnetlink.cc:1726:20: error: qualified-id in declaration before ‘(’ token
 1726 | void cnetlink::stop() noexcept {
      |                    ^
../src/netlink/cnetlink.cc:1735:36: error: qualified-id in declaration before ‘(’ token
 1735 | bool cnetlink::is_bridge_configured(rtnl_link *l) {
      |                                    ^
../src/netlink/cnetlink.cc:1749:40: error: qualified-id in declaration before ‘(’ token
 1749 | int cnetlink::set_bridge_port_vlan_tpid(rtnl_link *l) {
      |                                        ^
../src/netlink/cnetlink.cc:1757:42: error: qualified-id in declaration before ‘(’ token
 1757 | int cnetlink::unset_bridge_port_vlan_tpid(rtnl_link *l) {
      |                                          ^
../src/netlink/cnetlink.cc:1765:46: error: qualified-id in declaration before ‘(’ token
 1765 | std::deque<rtnl_neigh *> cnetlink::search_fdb(uint16_t vid, nl_addr *lladdr) {
      |                                              ^
../src/netlink/cnetlink.cc:1783:31: error: qualified-id in declaration before ‘(’ token
 1783 | void cnetlink::route_mdb_apply(const nl_obj &obj) {
      |                               ^
../src/netlink/cnetlink.cc:1806:39: error: qualified-id in declaration before ‘(’ token
 1806 | void cnetlink::route_bridge_vlan_apply(const nl_obj &obj) {
      |                                       ^
../src/netlink/cnetlink.cc: At global scope:
../src/netlink/cnetlink.cc:1826:2: error: expected ‘}’ at end of input
 1826 | } // namespace basebox
      |  ^
../src/netlink/cnetlink.cc:46:19: note: to match this ‘{’
   46 | namespace basebox {
      |                   ^
```

Fixes: 170617c7532c ("netlink: setup port learning from with the netlink thread")

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
