### PR TITLE
add support for wrapping traffic on a port with a stacked VLAN tag

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1539,6 +1539,8 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     if (lt_new == LT_BOND_SLAVE) { // bond slave updated
       bond->update_lag_member(old_link, new_link);
     } else if (port_id > 0) { // bond slave removed
+      rtnl_link *_bond = get_link(rtnl_link_get_master(old_link), AF_UNSPEC);
+      vlan->bond_member_detached(_bond, old_link);
       bond->remove_lag_member(old_link);
     }
     break;
@@ -1604,6 +1606,7 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
                   << rtnl_link_get_name(new_link);
         rtnl_link *_bond = get_link(rtnl_link_get_master(new_link), AF_UNSPEC);
         bond->add_lag_member(_bond, new_link);
+        vlan->bond_member_attached(_bond, new_link);
 
         LOG(INFO) << __FUNCTION__ << " set active member " << get_port_id(_bond)
                   << " port id " << rtnl_link_get_ifindex(new_link);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -1541,6 +1541,8 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
     } else if (port_id > 0) { // bond slave removed
       rtnl_link *_bond = get_link(rtnl_link_get_master(old_link), AF_UNSPEC);
       vlan->bond_member_detached(_bond, old_link);
+      if (bridge)
+        bridge->bond_member_detached(_bond, old_link);
       bond->remove_lag_member(old_link);
     }
     break;
@@ -1606,6 +1608,8 @@ void cnetlink::link_updated(rtnl_link *old_link, rtnl_link *new_link) noexcept {
                   << rtnl_link_get_name(new_link);
         rtnl_link *_bond = get_link(rtnl_link_get_master(new_link), AF_UNSPEC);
         bond->add_lag_member(_bond, new_link);
+        if (bridge)
+          bridge->bond_member_attached(_bond, new_link);
         vlan->bond_member_attached(_bond, new_link);
 
         LOG(INFO) << __FUNCTION__ << " set active member " << get_port_id(_bond)
@@ -1874,22 +1878,6 @@ bool cnetlink::is_bridge_configured(rtnl_link *l) {
     return is_bridge_interface(l);
 
   return bridge->is_bridge_interface(l);
-}
-
-int cnetlink::set_bridge_port_vlan_tpid(rtnl_link *l) {
-  if (!bridge) {
-    return -EINVAL;
-  }
-
-  return bridge->set_vlan_proto(l);
-}
-
-int cnetlink::unset_bridge_port_vlan_tpid(rtnl_link *l) {
-  if (!bridge) {
-    return -EINVAL;
-  }
-
-  return bridge->delete_vlan_proto(l);
 }
 
 std::deque<rtnl_neigh *> cnetlink::search_fdb(uint16_t vid, nl_addr *lladdr) {

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -81,16 +81,9 @@ public:
   bool is_switch_interface(rtnl_link *l) const;
   bool is_switch_interface(int ifindex) const;
 
-  int set_bridge_port_vlan_tpid(rtnl_link *l);
-  int unset_bridge_port_vlan_tpid(rtnl_link *l);
   int get_port_id(rtnl_link *l) const;
   int get_port_id(int ifindex) const;
   int get_ifindex_by_port_id(uint32_t port_id) const;
-
-  std::map<uint16_t, uint8_t> get_port_vlan_stp_states(rtnl_link *link) {
-    assert(bridge);
-    return bridge->get_port_vlan_stp_states(link);
-  }
 
   nl_cache *get_cache(enum nl_cache_t id) { return caches[id]; }
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -241,19 +241,6 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
     if (rv < 0)
       LOG(ERROR) << __FUNCTION__
                  << ": failed to set egress TPID entry for port " << link;
-  } else {
-    std::deque<uint16_t> vlans;
-
-    if (nl->has_l3_addresses(bond)) {
-      swi->ingress_port_vlan_add(port_id, FLAGS_port_untagged_vid, true);
-      swi->egress_port_vlan_add(port_id, FLAGS_port_untagged_vid, true);
-    }
-
-    nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
-    for (auto vid : vlans) {
-      swi->ingress_port_vlan_add(port_id, vid, false);
-      swi->egress_port_vlan_add(port_id, vid, false);
-    }
   }
 
   if (new_lag)
@@ -308,26 +295,6 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
     if (rv < 0)
       LOG(ERROR) << __FUNCTION__
                  << ": failed to set egress TPID entry for port " << link;
-  } else {
-    std::deque<uint16_t> vlans;
-
-    nl->get_vlans(rtnl_link_get_ifindex(bond), &vlans);
-
-    if (lm_rv->second.empty())
-      nl->remove_l3_configuration(bond);
-
-    if (nl->is_bridge_interface(bond))
-      swi->ofdpa_stg_state_port_set(port_id, 1, BR_STATE_FORWARDING);
-
-    for (auto vid : vlans) {
-      swi->ingress_port_vlan_remove(port_id, vid, false);
-      swi->egress_port_vlan_remove(port_id, vid);
-    }
-
-    if (nl->has_l3_addresses(bond)) {
-      swi->ingress_port_vlan_remove(port_id, FLAGS_port_untagged_vid, true);
-      swi->egress_port_vlan_remove(port_id, FLAGS_port_untagged_vid);
-    }
   }
 #endif
 

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -140,6 +140,14 @@ int nl_bond::add_lag(rtnl_link *bond) {
       swi->lag_remove(lag_id);
   }
 
+  if (rtnl_link_get_master(bond)) {
+    // check bridge attachement
+    auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
+    if (br_link) {
+      VLOG(2) << __FUNCTION__ << ": bond was already bridge slave: " << br_link;
+      nl->link_created(br_link);
+    }
+  }
 #endif
 
   return rv;
@@ -227,7 +235,6 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
     auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
     if (br_link) {
       VLOG(2) << __FUNCTION__ << ": bond was already bridge slave: " << br_link;
-      nl->link_created(br_link);
 
       auto new_state = rtnl_link_bridge_get_port_state(br_link);
       swi->ofdpa_stg_state_port_set(port_id, 0, new_state);

--- a/src/netlink/nl_bond.cc
+++ b/src/netlink/nl_bond.cc
@@ -230,26 +230,6 @@ int nl_bond::add_lag_member(rtnl_link *bond, rtnl_link *link) {
     return -EINVAL;
   }
 
-  if (rtnl_link_get_master(bond)) {
-    // check bridge attachement
-    auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
-    if (br_link) {
-      VLOG(2) << __FUNCTION__ << ": bond was already bridge slave: " << br_link;
-
-      auto new_state = rtnl_link_bridge_get_port_state(br_link);
-      swi->ofdpa_stg_state_port_set(port_id, 0, new_state);
-      auto pv_states = nl->get_port_vlan_stp_states(bond);
-      for (auto state : pv_states) {
-        swi->ofdpa_stg_state_port_set(port_id, state.first, state.second);
-      }
-    }
-
-    rv = nl->set_bridge_port_vlan_tpid(br_link);
-    if (rv < 0)
-      LOG(ERROR) << __FUNCTION__
-                 << ": failed to set egress TPID entry for port " << link;
-  }
-
   if (new_lag)
     nl->add_l3_configuration(bond);
 #endif
@@ -289,20 +269,6 @@ int nl_bond::remove_lag_member(rtnl_link *bond, rtnl_link *link) {
   rv = swi->lag_remove_member(it->second, port_id);
   lag_members.erase(lm_rv);
 
-  if (nl->is_bridge_interface(bond)) {
-    swi->ofdpa_stg_state_port_set(port_id, 0, BR_STATE_FORWARDING);
-    auto pv_states = nl->get_port_vlan_stp_states(bond);
-    for (auto state : pv_states) {
-      swi->ofdpa_stg_state_port_set(port_id, state.first, BR_STATE_FORWARDING);
-    }
-
-    auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
-    rv = nl->unset_bridge_port_vlan_tpid(br_link);
-
-    if (rv < 0)
-      LOG(ERROR) << __FUNCTION__
-                 << ": failed to set egress TPID entry for port " << link;
-  }
 #endif
 
   return rv;

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -546,6 +546,62 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
   }
 }
 
+int nl_bridge::bond_member_attached(rtnl_link *bond, rtnl_link *member) {
+  if (rtnl_link_get_master(bond) != rtnl_link_get_ifindex(bridge))
+    return 0;
+
+  auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
+  if (!br_link) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to find AF_BRIDGE link for "
+               << bond;
+    return -EINVAL;
+  }
+  auto bond_id = nl->get_port_id(bond);
+  auto port_id = nl->get_port_id(member);
+
+  auto state = rtnl_link_bridge_get_port_state(br_link);
+  auto pv_states = bridge_stp_states.get_min_states(bond_id);
+  for (auto it : pv_states)
+    set_port_vlan_stp_state(port_id, it.first, it.second);
+  set_port_vlan_stp_state(port_id, 0, state);
+
+  auto locked = (rtnl_link_bridge_get_flags(br_link) & RTNL_BRIDGE_LOCKED) != 0;
+  set_port_locked(member, locked);
+
+  set_vlan_proto(member);
+
+  return 0;
+}
+
+int nl_bridge::bond_member_detached(rtnl_link *bond, rtnl_link *member) {
+  if (rtnl_link_get_master(bond) != rtnl_link_get_ifindex(bridge))
+    return 0;
+
+  auto br_link = nl->get_link(rtnl_link_get_ifindex(bond), AF_BRIDGE);
+  if (!br_link) {
+    LOG(ERROR) << __FUNCTION__ << ": failed to find AF_BRIDGE link for "
+               << bond;
+    return -EINVAL;
+  }
+
+  auto bond_id = nl->get_port_id(bond);
+  auto port_id = nl->get_port_id(member);
+
+  // interface default is to STP state forward by default
+  set_port_stp_state(port_id, BR_STATE_FORWARDING);
+
+  auto pv_states = bridge_stp_states.get_min_states(bond_id);
+  for (auto it : pv_states)
+    set_port_vlan_stp_state(port_id, it.first, BR_STATE_FORWARDING);
+  set_port_vlan_stp_state(port_id, 0, BR_STATE_FORWARDING);
+
+  set_port_locked(member, false);
+
+  delete_vlan_proto(member);
+
+  return 0;
+}
+
 std::deque<rtnl_neigh *> nl_bridge::get_fdb_entries_of_port(rtnl_link *br_port,
                                                             uint16_t vid,
                                                             nl_addr *lladdr) {
@@ -1179,15 +1235,6 @@ int nl_bridge::drop_pvlan_stp(struct rtnl_bridge_vlan *bvlan_info) {
     err = del_port_vlan_stp_state(port_id, vlan_id);
 #endif
   return err;
-}
-
-std::map<uint16_t, uint8_t>
-nl_bridge::get_port_vlan_stp_states(rtnl_link *link) {
-  uint32_t port_id = nl->get_port_id(link);
-  if (port_id == 0)
-    return {};
-
-  return bridge_stp_states.get_min_states(port_id);
 }
 
 void nl_bridge::set_port_locked(rtnl_link *link, bool locked) {

--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -812,7 +812,8 @@ void nl_bridge::add_neigh_to_fdb(rtnl_neigh *neigh, bool update) {
   assert(neigh);
 
   int ifindex = rtnl_neigh_get_ifindex(neigh);
-  uint32_t port = nl->get_port_id(ifindex);
+  auto link = nl->get_link(ifindex, AF_UNSPEC);
+  uint32_t port = nl->get_port_id(link);
   if (port == 0) {
     VLOG(1) << __FUNCTION__ << ": unknown port for neigh " << neigh;
     return;
@@ -930,7 +931,8 @@ void nl_bridge::remove_neigh_from_fdb(rtnl_neigh *neigh) {
     }
   }
 
-  const uint32_t port = nl->get_port_id(rtnl_neigh_get_ifindex(neigh));
+  auto link = nl->get_link(rtnl_neigh_get_ifindex(neigh), AF_UNSPEC);
+  const uint32_t port = nl->get_port_id(link);
   rofl::caddress_ll mac((uint8_t *)nl_addr_get_binary_addr(addr),
                         nl_addr_get_len(addr));
 

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -213,8 +213,8 @@ private:
   int del_port_vlan_stp_state(uint32_t port_id, uint16_t vid);
   int set_port_vlan_stp_state(uint32_t port_id, uint16_t vid, uint8_t state);
 
-  int set_vlan_proto(rtnl_link *link);
-  int delete_vlan_proto(rtnl_link *link);
+  int set_vlan_proto(rtnl_link *link, uint32_t port_id);
+  int delete_vlan_proto(rtnl_link *link, uint32_t port_id);
 
   int mdb_to_set(rtnl_mdb *,
                  std::set<std::tuple<uint32_t, uint16_t, rofl::caddress_ll>> *);

--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -173,11 +173,7 @@ public:
   int get_ifindex() { return bridge ? rtnl_link_get_ifindex(bridge) : 0; }
 
   uint32_t get_vlan_proto();
-  int set_vlan_proto(rtnl_link *link);
-  int delete_vlan_proto(rtnl_link *link);
   uint32_t get_vlan_filtering();
-
-  std::map<uint16_t, uint8_t> get_port_vlan_stp_states(rtnl_link *link);
 
   void clear_tpid_entries();
 
@@ -198,6 +194,9 @@ public:
 
   void set_port_locked(rtnl_link *link, bool locked);
 
+  int bond_member_attached(rtnl_link *bond, rtnl_link *member);
+  int bond_member_detached(rtnl_link *bond, rtnl_link *member);
+
 private:
   struct bridge_stp_states bridge_stp_states;
 
@@ -213,6 +212,9 @@ private:
                               uint8_t stp_state);
   int del_port_vlan_stp_state(uint32_t port_id, uint16_t vid);
   int set_port_vlan_stp_state(uint32_t port_id, uint16_t vid, uint8_t state);
+
+  int set_vlan_proto(rtnl_link *link);
+  int delete_vlan_proto(rtnl_link *link);
 
   int mdb_to_set(rtnl_mdb *,
                  std::set<std::tuple<uint32_t, uint16_t, rofl::caddress_ll>> *);

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -106,6 +106,15 @@ int nl_vlan::add_ingress_pvid(rtnl_link *link, uint16_t pvid) {
   int rv;
   uint32_t port_id = nl->get_port_id(link);
 
+  auto pvid_config = port_pvid.find(port_id);
+  if (pvid_config != port_pvid.end()) {
+    LOG(WARNING) << __FUNCTION__ << ": vid " << pvid_config->second
+                 << " was aleady configured as PVID for port_id " << port_id;
+    return -EINVAL;
+  } else {
+    port_pvid.emplace(port_id, pvid);
+  }
+
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
     auto members = nl->get_bond_members_by_port_id(port_id);
 
@@ -125,6 +134,21 @@ int nl_vlan::remove_ingress_pvid(rtnl_link *link, uint16_t pvid) {
 
   int rv;
   uint32_t port_id = nl->get_port_id(link);
+
+  auto pvid_config = port_pvid.find(port_id);
+  if (pvid_config != port_pvid.end()) {
+    if (pvid_config->second != pvid) {
+      LOG(WARNING) << __FUNCTION__ << ": vid " << pvid_config->second
+                   << " was aleady configured as PVID for port_id " << port_id;
+      return -EINVAL;
+    }
+
+    port_pvid.erase(pvid_config);
+  } else {
+    LOG(WARNING) << __FUNCTION__ << ": vid " << pvid
+                 << " was not configured as PVID for port_id " << port_id;
+    return -EINVAL;
+  }
 
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
     auto members = nl->get_bond_members_by_port_id(port_id);
@@ -367,6 +391,33 @@ int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
     return -EINVAL;
   }
 
+  auto vlans = bridge_vlan.find(port_id);
+  if (vlans == bridge_vlan.end()) {
+    std::map<uint16_t, bool> _vlans;
+    _vlans.emplace(vid, tagged);
+    bridge_vlan.emplace(port_id, _vlans);
+  } else {
+    if (vlans->second.find(vid) == vlans->second.end()) {
+      vlans->second.emplace(vid, tagged);
+    } else {
+      LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                   << " is already configured for port_id " << port_id;
+    }
+  }
+
+  auto pvid_config = port_pvid.find(port_id);
+  if (pvid_config != port_pvid.end()) {
+    if (!pvid && pvid_config->second == vid)
+      LOG(WARNING) << __FUNCTION__ << ": vid " << pvid_config->second
+                   << " was aleady configured as PVID for port_id " << port_id;
+    if (pvid && pvid_config->second != vid)
+      LOG(WARNING) << __FUNCTION__ << ": vid " << pvid_config->second
+                   << " was aleady configured as PVID for port_id " << port_id;
+  } else {
+    if (pvid)
+      port_pvid.emplace(port_id, vid);
+  }
+
   rv = swi->egress_bridge_port_vlan_add(port_id, vid, !tagged);
   if (rv < 0)
     return rv;
@@ -410,6 +461,26 @@ int nl_vlan::update_egress_bridge_vlan(rtnl_link *link, uint16_t vid,
     return -EINVAL;
   }
 
+  auto vlans = bridge_vlan.find(port_id);
+  if (vlans == bridge_vlan.end()) {
+    LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                 << " was not configured for port_id " << port_id;
+    return -EINVAL;
+  } else {
+    auto vlan_config = vlans->second.find(vid);
+    if (vlan_config == vlans->second.end()) {
+      LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                   << " was not configured for port_id " << port_id;
+      return -EINVAL;
+    }
+
+    if (vlan_config->second == !untagged)
+      LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                   << " was already configured as " << (untagged ? "un" : "")
+                   << "tagged for port_id " << port_id;
+    vlan_config->second = !untagged;
+  }
+
   VLOG(2) << __FUNCTION__ << ": update egress vid=" << vid
           << " tagged=" << untagged;
 
@@ -437,6 +508,33 @@ void nl_vlan::remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
   if (port_id == 0) {
     VLOG(1) << __FUNCTION__ << ": unknown interface " << link;
     return;
+  }
+
+  auto vlans = bridge_vlan.find(port_id);
+  if (vlans != bridge_vlan.end()) {
+    if (vlans->second.find(vid) != vlans->second.end())
+      vlans->second.erase(vid);
+    else
+      LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                   << " was not configured for port_id " << port_id;
+    if (vlans->second.empty())
+      bridge_vlan.erase(vlans);
+  } else {
+    LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                 << " was not configured for port_id " << port_id;
+  }
+
+  auto pvid_config = port_pvid.find(port_id);
+  if (pvid_config == port_pvid.end()) {
+    if (pvid)
+      LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                   << " was not configured as PVID for port_id " << port_id;
+  } else {
+    if (!pvid || pvid_config->second != vid)
+      LOG(WARNING) << __FUNCTION__ << ": vid " << vid
+                   << " was not configured as PVID for port_id " << port_id;
+    if (pvid)
+      port_pvid.erase(pvid_config);
   }
 
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -49,6 +49,9 @@ int nl_vlan::add_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
     return 0;
   }
 
+  if (nl->is_bridge_interface(link))
+    return 0;
+
   int rv = enable_vlan(port_id, vid, tagged, vrf_id);
   if (rv < 0) {
     LOG(ERROR) << __FUNCTION__ << ": failed to enable vlan " << vid
@@ -216,6 +219,9 @@ int nl_vlan::remove_vlan(rtnl_link *link, uint16_t vid, bool tagged) {
     return rv;
 
   port_vlan.erase(refcount);
+
+  if (nl->is_bridge_interface(link))
+    return 0;
 
   // remove vid at ingress
   rv = disable_vlan(port_id, vid, tagged, vrf_id);

--- a/src/netlink/nl_vlan.cc
+++ b/src/netlink/nl_vlan.cc
@@ -371,8 +371,9 @@ int nl_vlan::disable_vlans(rtnl_link *link) {
 
 int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
                              bool tagged) {
-  int rv;
+  int rv = 0;
   assert(swi);
+  std::set<uint32_t> ports;
 
   uint16_t vrf_id = get_vrf_id(vid, link);
 
@@ -418,28 +419,23 @@ int nl_vlan::add_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
       port_pvid.emplace(port_id, vid);
   }
 
-  rv = swi->egress_bridge_port_vlan_add(port_id, vid, !tagged);
-  if (rv < 0)
-    return rv;
-
-  rv = swi->ingress_port_vlan_add(port_id, vid, pvid, vrf_id);
-  if (rv < 0) {
-    swi->egress_bridge_port_vlan_remove(port_id, vid);
-    return rv;
-  }
-
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
-    auto members = nl->get_bond_members_by_port_id(port_id);
-
-    for (auto mem : members) {
-      swi->egress_bridge_port_vlan_add(mem, vid, !tagged);
-      swi->ingress_port_vlan_add(mem, vid, pvid, vrf_id);
-    }
-
-    if (rv < 0) {
-      remove_bridge_vlan(link, vid, pvid, tagged);
-    }
+    ports = nl->get_bond_members_by_port_id(port_id);
   }
+  ports.insert(port_id);
+
+  for (auto port : ports) {
+    rv = swi->egress_bridge_port_vlan_add(port, vid, !tagged);
+    if (rv < 0)
+      break;
+
+    rv = swi->ingress_port_vlan_add(port, vid, pvid, vrf_id);
+    if (rv < 0)
+      break;
+  }
+
+  if (rv < 0)
+    remove_bridge_vlan(link, vid, pvid, tagged);
 
   return rv;
 }
@@ -502,6 +498,7 @@ int nl_vlan::update_egress_bridge_vlan(rtnl_link *link, uint16_t vid,
 void nl_vlan::remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
                                  bool tagged) {
   assert(swi);
+  std::set<uint32_t> ports;
 
   uint16_t vrf_id = get_vrf_id(vid, link);
 
@@ -548,16 +545,14 @@ void nl_vlan::remove_bridge_vlan(rtnl_link *link, uint16_t vid, bool pvid,
   }
 
   if (nbi::get_port_type(port_id) == nbi::port_type_lag) {
-    auto members = nl->get_bond_members_by_port_id(port_id);
-
-    for (auto mem : members) {
-      swi->egress_bridge_port_vlan_remove(mem, vid);
-      swi->ingress_port_vlan_remove(mem, vid, pvid, vrf_id);
-    }
+    ports = nl->get_bond_members_by_port_id(port_id);
   }
+  ports.insert(port_id);
 
-  swi->egress_bridge_port_vlan_remove(port_id, vid);
-  swi->ingress_port_vlan_remove(port_id, vid, pvid, vrf_id);
+  for (auto port : ports) {
+    swi->egress_bridge_port_vlan_remove(port, vid);
+    swi->ingress_port_vlan_remove(port, vid, pvid, vrf_id);
+  }
 }
 
 uint16_t nl_vlan::get_vid(rtnl_link *link) {

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -72,8 +72,8 @@ private:
   // vlan - vrf
   std::map<uint16_t, uint16_t> vlan_vrf;
 
-  // ifindex - vlan - untagged
-  std::map<uint32_t, std::map<uint16_t, bool>> bridge_vlan;
+  // ifindex - vlan - ovid, untagged
+  std::map<uint32_t, std::map<uint16_t, std::pair<uint16_t, bool>>> bridge_vlan;
   // ifindex - pvid
   std::map<uint32_t, uint16_t> port_pvid;
 

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -69,6 +69,11 @@ private:
   // vlan - vrf
   std::map<uint16_t, uint16_t> vlan_vrf;
 
+  // ifindex - vlan - untagged
+  std::map<uint32_t, std::map<uint16_t, bool>> bridge_vlan;
+  // ifindex - pvid
+  std::map<uint32_t, uint16_t> port_pvid;
+
   switch_interface *swi;
   cnetlink *nl;
 };

--- a/src/netlink/nl_vlan.h
+++ b/src/netlink/nl_vlan.h
@@ -55,6 +55,9 @@ public:
   void vrf_detach(rtnl_link *old_link, rtnl_link *new_link);
   uint16_t get_vrf_id(uint16_t vid, rtnl_link *link);
 
+  int bond_member_attached(rtnl_link *bond, rtnl_link *member);
+  int bond_member_detached(rtnl_link *bond, rtnl_link *member);
+
 private:
   static const uint16_t vid_low = 1;
   static const uint16_t vid_high = 0xfff;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2155,6 +2155,131 @@ int controller::egress_bridge_port_vlan_remove(uint32_t port,
   }
   return rv;
 }
+int controller::ingress_port_stacked_vlan_enable(uint32_t port,
+                                                 uint16_t vid) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0), fm_driver.enable_port_vid_ingress(dpt.get_version(),
+                                                           port, vid, 0, true));
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+int controller::ingress_port_stacked_vlan_disable(uint32_t port,
+                                                  uint16_t vid) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.disable_port_vid_ingress(
+                                  dpt.get_version(), port, vid, 0, true));
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+int controller::ingress_port_pop_vlan_add(uint32_t port, uint16_t outer_vid,
+                                          uint16_t inner_vid,
+                                          uint16_t vrf_id) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0),
+        fm_driver.enable_port_pop_tag_ingress(dpt.get_version(), port,
+                                              inner_vid, outer_vid, vrf_id));
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+int controller::ingress_port_pop_vlan_remove(uint32_t port, uint16_t outer_vid,
+                                             uint16_t inner_vid,
+                                             uint16_t vrf_id) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(
+        rofl::cauxid(0),
+        fm_driver.disable_port_pop_tag_ingress(dpt.get_version(), port,
+                                               inner_vid, outer_vid, vrf_id));
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+
+int controller::egress_port_push_vlan_add(uint32_t port, uint16_t vid,
+                                          uint16_t push_vid) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.enable_vlan_egress_push_tag(
+                                  dpt.get_version(), port, vid, push_vid));
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
+int controller::egress_port_push_vlan_remove(uint32_t port, uint16_t vid,
+                                             uint16_t push_vid) noexcept {
+  int rv = 0;
+  try {
+    rofl::crofdpt &dpt = set_dpt(dptid, true);
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.disable_vlan_egress_push_tag(
+                                  dpt.get_version(), port, vid, push_vid));
+  } catch (rofl::eRofBaseNotFound &e) {
+    LOG(ERROR) << ": caught rofl::eRofBaseNotFound";
+    rv = -EINVAL;
+  } catch (rofl::eRofConnNotConnected &e) {
+    LOG(ERROR) << ": not connected msg=" << e.what();
+    rv = -ENOTCONN;
+  } catch (std::exception &e) {
+    LOG(ERROR) << ": caught unknown exception: " << e.what();
+    rv = -EINVAL;
+  }
+  return rv;
+}
 
 int controller::set_egress_tpid(uint32_t port) noexcept {
   int rv = 0;

--- a/src/of-dpa/controller.h
+++ b/src/of-dpa/controller.h
@@ -267,6 +267,23 @@ public:
                                   bool untagged) noexcept override;
   int egress_bridge_port_vlan_remove(uint32_t port,
                                      uint16_t vid) noexcept override;
+
+  int ingress_port_stacked_vlan_enable(uint32_t port,
+                                       uint16_t vid) noexcept override;
+  int ingress_port_stacked_vlan_disable(uint32_t port,
+                                        uint16_t vid) noexcept override;
+  int ingress_port_pop_vlan_add(uint32_t port, uint16_t outer_vid,
+                                uint16_t inner_vid,
+                                uint16_t vrf_id = 0) noexcept override;
+  int ingress_port_pop_vlan_remove(uint32_t port, uint16_t outer_vid,
+                                   uint16_t inner_vid,
+                                   uint16_t vrf_id = 0) noexcept override;
+
+  int egress_port_push_vlan_add(uint32_t port, uint16_t vid,
+                                uint16_t push_vid) noexcept override;
+  int egress_port_push_vlan_remove(uint32_t port, uint16_t vid,
+                                   uint16_t push_vid) noexcept override;
+
   int set_egress_tpid(uint32_t port) noexcept override;
   int delete_egress_tpid(uint32_t port) noexcept override;
 

--- a/src/sai.h
+++ b/src/sai.h
@@ -212,6 +212,25 @@ public:
   /* @} */
 
   /* @ QnQ  { */
+
+  /* translate double tag to single tag on ingress */
+  virtual int ingress_port_stacked_vlan_enable(uint32_t port,
+                                               uint16_t vid) noexcept = 0;
+  virtual int ingress_port_stacked_vlan_disable(uint32_t port,
+                                                uint16_t vid) noexcept = 0;
+  virtual int ingress_port_pop_vlan_add(uint32_t port, uint16_t outer_vid,
+                                        uint16_t inner_vid,
+                                        uint16_t vrf_id = 0) noexcept = 0;
+  virtual int ingress_port_pop_vlan_remove(uint32_t port, uint16_t outer_vid,
+                                           uint16_t inner_vid,
+                                           uint16_t vrf_id = 0) noexcept = 0;
+
+  /* translate single tag to double tag on egress */
+  virtual int egress_port_push_vlan_add(uint32_t port, uint16_t vid,
+                                        uint16_t push_vid) noexcept = 0;
+  virtual int egress_port_push_vlan_remove(uint32_t port, uint16_t vid,
+                                           uint16_t push_vid) noexcept = 0;
+
   virtual int set_egress_tpid(uint32_t port) noexcept = 0;
   virtual int delete_egress_tpid(uint32_t port) noexcept = 0;
   /* @} */


### PR DESCRIPTION
Add support for wrapping traffic on a port with an additional stacked VLAN tag. This is configured by having a VLAN interface of that port as a bridge member, where the VLAN configuration of that interface is used for the stacked VLAN tag.

The general OF-DPA configuration for that is:

* On attachment of the VLAN interface to the bridge, configure an appropriate pop VLAN tag flow.
* On configuration of a VLAN for that (VLAN interface) port, add a ingress VLAN translation that translates from (VLANInterface.VID, BridgeVLAN.VID) to BridgeVLAN.VID, and an egress VLAN translation flow that translates Bridge.VLAN.VID to (VLANInterface.VID, BridgeVLAN.VID).

Since properly updating flows on bond membership changes becomes much harder with these new type of flows, rework the VLAN handling for bonds first by moving the VLAN handling to `nl_vlan`. To allow this, we now keep track of bridge VLAN configuration in `nl_vlan` as well.

As a side effect also fixes VRF handling on bond membership changes.

Depends on:
* https://github.com/bisdn/rofl-ofdpa/pull/117
* TODO: OF-DPA changes to drop L2 Unfiltered Interface requirement