### PR TITLE
cnetlink: sync route cache on linkdown events

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -949,6 +949,11 @@ void cnetlink::handle_read_event(rofl::cthread &thread, int fd) {
   if (fd == nl_cache_mngr_get_fd(mngr)) {
     int rv = nl_cache_mngr_data_ready(mngr);
     VLOG(3) << __FUNCTION__ << ": #processed=" << rv;
+    if (sync_route_cache) {
+      sync_route_cache = false;
+      nl_cache_resync_v2(sock_tx, caches[NL_ROUTE_CACHE],
+                         (change_func_v2_t)&nl_cb_v2, this);
+    }
     // notify update
     if (state != NL_STATE_STOPPED) {
       this->thread.wakeup(this);
@@ -1001,6 +1006,26 @@ void cnetlink::nl_cb_v2(struct nl_cache *cache, struct nl_object *old_obj,
 
   // only enqueue nl msgs if not in stopped state
   if (nl->state != NL_STATE_STOPPED) {
+    // linkdown events will silently delete routes with nexthops from that link,
+    // so we need to explicitly resync routes to catch those removed routes
+    if ((action == NL_ACT_CHANGE &&
+         nl_object_get_msgtype(old_obj) == RTM_NEWLINK) ||
+        (action == NL_ACT_DEL &&
+         nl_object_get_msgtype(old_obj) == RTM_DELLINK)) {
+      bool old_link, new_link = false;
+
+      old_link = (rtnl_link_get_flags(LINK_CAST(old_obj)) &
+                  (IFF_UP | IFF_RUNNING)) == (IFF_UP | IFF_RUNNING);
+
+      if (new_obj != nullptr)
+        new_link = (rtnl_link_get_flags(LINK_CAST(new_obj)) &
+                    (IFF_UP | IFF_RUNNING)) == (IFF_UP | IFF_RUNNING);
+
+      // link down event => nh and routes targeting them may have been deleted
+      if (old_link && !new_link)
+        nl->sync_route_cache = true;
+    }
+
     // If libnl updated the object instead of replacing it, old_obj will be a
     // clone of the old object, and new_obj is the updated old object. Since
     // later notifications may update the new_obj further, clone

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -141,6 +141,7 @@ private:
 
   int nl_proc_max;
   enum nl_state state;
+  bool sync_route_cache;
   std::deque<nl_obj> nl_objs;
 
   std::shared_ptr<port_manager> port_man;


### PR DESCRIPTION
Work around missing route removal notifications from kernel on link down with routes targeting nexthops on that link by forcing a cache resync on link down events to catch removed routes.

When a link goes down, the kernel will delete all nexthops on that link without sending out netlink notifications.

When a nexthop gets deleted, the kernel will delete all routes with the nexthop as destination without sending out netlink notifications.

These two combined means that when using nexthop objects, like FRR does by default, deletion of routes on link loss are never seen by libnl, and consequently never seen by baseboxd.

This causes flow table entries for routes to persist even though they were deleted in the kernel.

To work around this, `use nl_cache_resync_v2()` to trigger a resync of all routes when a link goes down.

## Motivation and Context

A customer reported routes still present in flow tables with EIGRP despite missing from kernel.

## How Has This Been Tested?

Pipeline run with changes applied (87710 on cel-questone-2a).
