### PR TITLE
nl_l3: work around kernel sending routes using nhid with no nexthops

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -170,6 +170,18 @@ void cnetlink::init_caches() {
     LOG(FATAL) << __FUNCTION__ << ": add route/neigh to cache mngr";
   }
 
+  /* init nh cache */
+  rc = rtnl_nh_alloc_cache(nullptr, AF_UNSPEC, &caches[NL_NH_CACHE]);
+  if (0 != rc) {
+    LOG(FATAL) << __FUNCTION__
+               << ": rtnl_nh_alloc_cache_flags failed rc=" << rc;
+  }
+  rc = nl_cache_mngr_add_cache_v2(mngr, caches[NL_NH_CACHE],
+                                  (change_func_v2_t)&nl_cb_v2, this);
+  if (0 != rc) {
+    LOG(FATAL) << __FUNCTION__ << ": add route/nh to cache mngr";
+  }
+
 #ifdef HAVE_NETLINK_ROUTE_MDB_H
   if (FLAGS_multicast) {
     /* init mdb cache */
@@ -904,6 +916,10 @@ void cnetlink::handle_wakeup(rofl::cthread &thread) {
     case RTM_DELROUTE:
       route_route_apply(obj);
       break;
+    case RTM_NEWNEXTHOP:
+    case RTM_DELNEXTHOP:
+      route_nh_apply(obj);
+      break;
     case RTM_NEWADDR:
     case RTM_DELADDR:
       route_addr_apply(obj);
@@ -1349,6 +1365,37 @@ void cnetlink::route_route_apply(const nl_obj &obj) {
       LOG(WARNING) << __FUNCTION__ << ": family not supported: " << family;
       break;
     }
+    break;
+
+  default:
+    LOG(ERROR) << __FUNCTION__ << ": invalid action " << obj.get_action();
+    break;
+  }
+}
+
+void cnetlink::route_nh_apply(const nl_obj &obj) {
+  switch (obj.get_action()) {
+  case NL_ACT_NEW:
+    assert(obj.get_new_obj());
+
+    VLOG(2) << __FUNCTION__ << ": new nh " << obj.get_new_obj();
+
+    break;
+
+  case NL_ACT_CHANGE:
+    assert(obj.get_new_obj());
+    assert(obj.get_old_obj());
+
+    VLOG(2) << __FUNCTION__ << ": change new nh " << obj.get_new_obj();
+    VLOG(2) << __FUNCTION__ << ": change old nh " << obj.get_old_obj();
+
+    break;
+
+  case NL_ACT_DEL:
+    assert(obj.get_old_obj());
+
+    VLOG(2) << __FUNCTION__ << ": del nh " << obj.get_old_obj();
+
     break;
 
   default:

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -335,18 +335,18 @@ struct rtnl_link *cnetlink::get_link(int ifindex, int family) const {
 }
 
 std::unique_ptr<struct rtnl_route, decltype(&rtnl_route_put)>
-cnetlink::get_route_by_dst_ifindex(struct nl_addr *dst, int ifindex) const {
+cnetlink::get_route_by_nh_params(const struct nh_params &p) const {
   struct rtnl_route *route = nullptr;
   std::unique_ptr<rtnl_route, decltype(&rtnl_route_put)> filter(
       rtnl_route_alloc(), &rtnl_route_put);
 
   auto nh = rtnl_route_nh_alloc();
 
-  rtnl_route_nh_set_ifindex(nh, ifindex);
+  rtnl_route_nh_set_ifindex(nh, p.nh.ifindex);
   rtnl_route_add_nexthop(filter.get(), nh);
 
   rtnl_route_set_type(filter.get(), RTN_UNICAST);
-  rtnl_route_set_dst(filter.get(), dst);
+  rtnl_route_set_dst(filter.get(), p.np.addr);
 
   nl_cache_foreach_filter(
       caches[NL_ROUTE_CACHE], OBJ_CAST(filter.get()),

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -382,6 +382,10 @@ cnetlink::get_route_by_nh_params(const struct nh_params &p) const {
   return ret;
 }
 
+struct rtnl_nh *cnetlink::get_nh_by_id(int nhid) const {
+  return rtnl_nh_get(caches[NL_NH_CACHE], nhid);
+}
+
 void cnetlink::get_bridge_ports(
     int br_ifindex, std::deque<rtnl_link *> *link_list) const noexcept {
   assert(link_list);

--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -340,10 +340,14 @@ cnetlink::get_route_by_nh_params(const struct nh_params &p) const {
   std::unique_ptr<rtnl_route, decltype(&rtnl_route_put)> filter(
       rtnl_route_alloc(), &rtnl_route_put);
 
-  auto nh = rtnl_route_nh_alloc();
+  if (p.nh.nhid > 0) {
+    rtnl_route_set_nhid(filter.get(), p.nh.nhid);
+  } else {
+    auto nh = rtnl_route_nh_alloc();
 
-  rtnl_route_nh_set_ifindex(nh, p.nh.ifindex);
-  rtnl_route_add_nexthop(filter.get(), nh);
+    rtnl_route_nh_set_ifindex(nh, p.nh.ifindex);
+    rtnl_route_add_nexthop(filter.get(), nh);
+  }
 
   rtnl_route_set_type(filter.get(), RTN_UNICAST);
   rtnl_route_set_dst(filter.get(), p.np.addr);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -10,6 +10,7 @@
 #include <tuple>
 
 #include <netlink/cache.h>
+#include <netlink/route/nh.h>
 #include <netlink/route/route.h>
 #include <rofl/common/cthread.hpp>
 
@@ -36,6 +37,7 @@ public:
     NL_LINK_CACHE,
     NL_NEIGH_CACHE,
     NL_ROUTE_CACHE,
+    NL_NH_CACHE,
     NL_MDB_CACHE,
     NL_BVLAN_CACHE,
     NL_MAX_CACHE,
@@ -179,6 +181,7 @@ private:
   void route_link_apply(const nl_obj &obj);
   void route_neigh_apply(const nl_obj &obj);
   void route_route_apply(const nl_obj &obj);
+  void route_nh_apply(const nl_obj &obj);
   void route_mdb_apply(const nl_obj &obj);
   void route_bridge_vlan_apply(const nl_obj &obj);
 

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -67,7 +67,7 @@ public:
   struct rtnl_neigh *get_neighbour(int ifindex, struct nl_addr *a) const;
 
   std::unique_ptr<struct rtnl_route, decltype(&rtnl_route_put)>
-  get_route_by_dst_ifindex(struct nl_addr *dst, int ifindex) const;
+  get_route_by_nh_params(const struct nh_params &p) const;
 
   int add_l3_configuration(rtnl_link *link);
   int remove_l3_configuration(rtnl_link *link);

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -68,6 +68,7 @@ public:
 
   std::unique_ptr<struct rtnl_route, decltype(&rtnl_route_put)>
   get_route_by_nh_params(const struct nh_params &p) const;
+  struct rtnl_nh *get_nh_by_id(int nh_id) const;
 
   int add_l3_configuration(rtnl_link *link);
   int remove_l3_configuration(rtnl_link *link);

--- a/src/netlink/netlink-utils.h
+++ b/src/netlink/netlink-utils.h
@@ -13,6 +13,7 @@ struct rtnl_addr;
 struct rtnl_bridge_vlan;
 struct rtnl_link;
 struct rtnl_neigh;
+struct rtnl_nh;
 struct rtnl_route;
 struct rtnl_mdb;
 }
@@ -20,6 +21,7 @@ struct rtnl_mdb;
 #define LINK_CAST(obj) reinterpret_cast<struct rtnl_link *>(obj)
 #define NEIGH_CAST(obj) reinterpret_cast<struct rtnl_neigh *>(obj)
 #define ROUTE_CAST(obj) reinterpret_cast<struct rtnl_route *>(obj)
+#define NH_CAST(obj) reinterpret_cast<struct rtnl_nh *>(obj)
 #define ADDR_CAST(obj) reinterpret_cast<struct rtnl_addr *>(obj)
 #define MDB_CAST(obj) reinterpret_cast<struct rtnl_mdb *>(obj)
 #define BRIDGE_VLAN_CAST(obj) reinterpret_cast<struct rtnl_bridge_vlan *>(obj)

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1460,6 +1460,8 @@ int nl_l3::get_neighbours_of_route(rtnl_route *route,
   assert(route);
   assert(nhs);
 
+  uint32_t nhid = rtnl_route_get_nhid(route);
+
   get_nexthops_of_route(route, &rnhs);
 
   if (rnhs.size() == 0)
@@ -1484,7 +1486,7 @@ int nl_l3::get_neighbours_of_route(rtnl_route *route,
         continue;
       }
 
-      nhs->emplace(nh_stub{nh_addr, ifindex});
+      nhs->emplace(nh_stub{nh_addr, ifindex, nhid});
     }
   }
 

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1649,7 +1649,7 @@ int nl_l3::del_l3_unicast_route(nl_addr *rt_dst, uint16_t vrf_id) {
 
 void nl_l3::nh_reachable_notification(struct rtnl_neigh *n,
                                       struct nh_params p) noexcept {
-  auto route = nl->get_route_by_dst_ifindex(p.np.addr, p.nh.ifindex);
+  auto route = nl->get_route_by_nh_params(p);
   if (route == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": failed to find route for dst=" << p.np.addr
                << " on ifindex=" << p.nh.ifindex << " for nh" << p.nh.nh;
@@ -1695,7 +1695,7 @@ void nl_l3::nh_reachable_notification(struct rtnl_neigh *n,
 
 void nl_l3::nh_unreachable_notification(struct rtnl_neigh *n,
                                         struct nh_params p) noexcept {
-  auto route = nl->get_route_by_dst_ifindex(p.np.addr, p.nh.ifindex);
+  auto route = nl->get_route_by_nh_params(p);
   if (route == nullptr) {
     LOG(ERROR) << __FUNCTION__ << ": failed to find route for dst=" << p.np.addr
                << " on ifindex=" << p.nh.ifindex << " for nh" << p.nh.nh;

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -39,7 +39,7 @@ struct nh_stub {
     nl_addr_get(nh);
   }
 
-  nh_stub(const nh_stub &r) : nh(r.nh), ifindex(r.ifindex) {
+  nh_stub(const nh_stub &r) : nh(r.nh), ifindex(r.ifindex), nhid(r.nhid) {
     VLOG(4) << __FUNCTION__ << ": this=" << this
             << ", refcnt=" << nl_object_get_refcnt(OBJ_CAST(nh));
     nl_addr_get(nh);

--- a/src/netlink/nl_l3_interfaces.h
+++ b/src/netlink/nl_l3_interfaces.h
@@ -34,7 +34,8 @@ struct net_params {
 };
 
 struct nh_stub {
-  nh_stub(nl_addr *nh, int ifindex) : nh(nh), ifindex(ifindex) {
+  nh_stub(nl_addr *nh, int ifindex, uint32_t nhid = 0)
+      : nh(nh), ifindex(ifindex), nhid(nhid) {
     VLOG(4) << __FUNCTION__ << ": this=" << this;
     nl_addr_get(nh);
   }
@@ -52,11 +53,17 @@ struct nh_stub {
   }
 
   bool operator<(const nh_stub &other) const {
+
     int cmp = nl_addr_cmp(nh, other.nh);
 
     if (cmp < 0)
       return true;
     if (cmp > 0)
+      return false;
+
+    if (nhid < other.nhid)
+      return true;
+    if (nhid > other.nhid)
       return false;
 
     return ifindex < other.ifindex;
@@ -66,11 +73,15 @@ struct nh_stub {
     if (nl_addr_cmp(nh, other.nh) != 0)
       return false;
 
+    if (nhid != other.nhid)
+      return false;
+
     return ifindex == other.ifindex;
   }
 
   nl_addr *nh;
   int ifindex;
+  uint32_t nhid;
 };
 
 struct nh_params {

--- a/src/netlink/nl_output.h
+++ b/src/netlink/nl_output.h
@@ -32,6 +32,10 @@ inline std::ostream &operator<<(std::ostream &stream,
   return operator<<(stream, OBJ_CAST(route));
 }
 
+inline std::ostream &operator<<(std::ostream &stream, struct rtnl_nh *route) {
+  return operator<<(stream, OBJ_CAST(route));
+}
+
 inline std::string_view safe_string_view(const char *str) {
   return std::string_view(str ? str : "(null)");
 }

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -1445,9 +1445,6 @@ int controller::l3_unicast_route_add(const rofl::caddress_in4 &ipv4_dst,
   if (l3_interface_id > 0x0fffffff)
     return -EINVAL;
 
-  if (is_ecmp && l3_interface_id == 0)
-    return -EINVAL;
-
   try {
     rofl::crofdpt &dpt = set_dpt(dptid, true);
 
@@ -1486,9 +1483,6 @@ int controller::l3_unicast_route_add(const rofl::caddress_in6 &ipv6_dst,
   int rv = 0;
 
   if (l3_interface_id > 0x0fffffff)
-    return -EINVAL;
-
-  if (is_ecmp && l3_interface_id == 0)
     return -EINVAL;
 
   try {


### PR DESCRIPTION
In rare instances it can happen that a route update targeting a nexthop object in kernel gets send to userspace without any nexthop information set exept the nexthop id.

Since we currently rely on routes having this information, this breaks us applying the route, since we do not know what the actual nexthop is.

Fix this by tracking nexthop objects and using the cache as a fallback for looking up the nextop data of routes by the nexthop id.