### PR TITLE
Revert "cnetlink: sync route cache on linkdown events"

### DIFF
--- a/src/netlink/cnetlink.cc
+++ b/src/netlink/cnetlink.cc
@@ -973,11 +973,6 @@ void cnetlink::handle_read_event(rofl::cthread &thread, int fd) {
   if (fd == nl_cache_mngr_get_fd(mngr)) {
     int rv = nl_cache_mngr_data_ready(mngr);
     VLOG(3) << __FUNCTION__ << ": #processed=" << rv;
-    if (sync_route_cache) {
-      sync_route_cache = false;
-      nl_cache_resync_v2(sock_tx, caches[NL_ROUTE_CACHE],
-                         (change_func_v2_t)&nl_cb_v2, this);
-    }
     // notify update
     if (state != NL_STATE_STOPPED) {
       this->thread.wakeup(this);
@@ -1030,26 +1025,6 @@ void cnetlink::nl_cb_v2(struct nl_cache *cache, struct nl_object *old_obj,
 
   // only enqueue nl msgs if not in stopped state
   if (nl->state != NL_STATE_STOPPED) {
-    // linkdown events will silently delete routes with nexthops from that link,
-    // so we need to explicitly resync routes to catch those removed routes
-    if ((action == NL_ACT_CHANGE &&
-         nl_object_get_msgtype(old_obj) == RTM_NEWLINK) ||
-        (action == NL_ACT_DEL &&
-         nl_object_get_msgtype(old_obj) == RTM_DELLINK)) {
-      bool old_link, new_link = false;
-
-      old_link = (rtnl_link_get_flags(LINK_CAST(old_obj)) &
-                  (IFF_UP | IFF_RUNNING)) == (IFF_UP | IFF_RUNNING);
-
-      if (new_obj != nullptr)
-        new_link = (rtnl_link_get_flags(LINK_CAST(new_obj)) &
-                    (IFF_UP | IFF_RUNNING)) == (IFF_UP | IFF_RUNNING);
-
-      // link down event => nh and routes targeting them may have been deleted
-      if (old_link && !new_link)
-        nl->sync_route_cache = true;
-    }
-
     // If libnl updated the object instead of replacing it, old_obj will be a
     // clone of the old object, and new_obj is the updated old object. Since
     // later notifications may update the new_obj further, clone

--- a/src/netlink/cnetlink.h
+++ b/src/netlink/cnetlink.h
@@ -144,7 +144,6 @@ private:
 
   int nl_proc_max;
   enum nl_state state;
-  bool sync_route_cache;
   std::deque<nl_obj> nl_objs;
 
   std::shared_ptr<port_manager> port_man;


### PR DESCRIPTION
Syncing routes on link down may trigger updates on link local routes due to route flag changes, but baseboxd is not prepared to handle this, and causes all l3 neighbors on that link to be treated as unroutable.

IPv6 routes with nexthops seem to behave differently than IPv4 routes, and seem to reappear silently on link up again. Since there is no notification (again) from the kernel, we miss the reappearance of the route.

Due to the amount of breakage, lets's revert this for now until we have addresses these two issues.

This reverts commit 9a58b5ddbe9e7ce65228f4bc5bcf325e6905e14c.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
