### PR TITLE
knet_manager: do not try to set state for non-existing links

### DIFF
--- a/src/netlink/knet_manager.cc
+++ b/src/netlink/knet_manager.cc
@@ -290,6 +290,15 @@ bool knet_manager::portdev_removed(rtnl_link *link) {
  * @return 0 on success
  */
 int knet_manager::change_port_status(const std::string name, bool status) {
+  {
+    std::lock_guard<std::mutex> lock{tn_mutex};
+
+    if (port_names2id.find(name) == port_names2id.end()) {
+      VLOG(1) << __FUNCTION__ << ": unknown port " << name;
+      return -EINVAL;
+    }
+  }
+
   std::ofstream file("/proc/bcm/knet/link");
 
   if (file.is_open()) {
@@ -312,6 +321,15 @@ int knet_manager::change_port_status(const std::string name, bool status) {
  */
 int knet_manager::set_port_speed(const std::string name, uint32_t speed,
                                  uint8_t duplex) {
+  {
+    std::lock_guard<std::mutex> lock{tn_mutex};
+
+    if (port_names2id.find(name) == port_names2id.end()) {
+      VLOG(1) << __FUNCTION__ << ": unknown port " << name;
+      return -EINVAL;
+    }
+  }
+
   std::ofstream file("/proc/bcm/knet/link");
 
   if (file.is_open()) {


### PR DESCRIPTION
Since OF-DPA brings all links up at boot, there is a chance that the is a link state change before we received the port table and created the ports.

If this happens, then we get a change modification for speed/link, but there is no link to modify. This is harmless since we will set the link to down once we do create the port interface, but triggers a warning from knet on startup:

```
kernel: linux-bcm-knet (1197): Warning: unknown network interface: 'port1'
kernel: linux-bcm-knet (1197): Warning: unknown network interface: 'port2'
...
kernel: linux-bcm-knet (1197): Warning: unknown network interface: 'port54'
```

So check if the link is created before trying to update its state.

Fixes: 40f68c81c10a ("add knet manager for using knet based interfaces")