### PR TITLE
of-dpa: use termination mac instead of acl flows for BPDUs

### DIFF
--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -2364,7 +2364,10 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
                                 fm_driver.enable_policy_arp(dpt.get_version()));
     }
     dpt.send_flow_mod_message(rofl::cauxid(0),
-                              fm_driver.enable_policy_8021d(dpt.get_version()));
+                              fm_driver.enable_tmac_bpdu_multicast_mac(
+                                  dpt.get_version(),
+                                  rofl::caddress_ll("01:80:c2:00:00:00"),
+                                  rofl::caddress_ll("ff:ff:ff:ff:ff:f0")));
 
     /* Add flowmods to always copy IS-IS PDUs (identified by eth_dst mac) to
      * controller and clear them from the pipeline to avoid duplication
@@ -2373,16 +2376,16 @@ int controller::subscribe_to(enum swi_flags flags) noexcept {
      * 09-00-2B-00-00-04 ("all end systems")
      * 09-00-2B-00-00-05 ("all intermediate systems")
      */
-    dpt.send_flow_mod_message(
-        rofl::cauxid(0),
-        fm_driver.enable_policy_l2(dpt.get_version(),
-                                   rofl::caddress_ll("01:80:C2:00:00:14"),
-                                   rofl::caddress_ll("ff:ff:ff:ff:ff:fe")));
-    dpt.send_flow_mod_message(
-        rofl::cauxid(0),
-        fm_driver.enable_policy_l2(dpt.get_version(),
-                                   rofl::caddress_ll("09:00:2B:00:00:04"),
-                                   rofl::caddress_ll("ff:ff:ff:ff:ff:fe")));
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.enable_tmac_bpdu_multicast_mac(
+                                  dpt.get_version(),
+                                  rofl::caddress_ll("01:80:C2:00:00:14"),
+                                  rofl::caddress_ll("ff:ff:ff:ff:ff:fe")));
+    dpt.send_flow_mod_message(rofl::cauxid(0),
+                              fm_driver.enable_tmac_bpdu_multicast_mac(
+                                  dpt.get_version(),
+                                  rofl::caddress_ll("09:00:2B:00:00:04"),
+                                  rofl::caddress_ll("ff:ff:ff:ff:ff:fe")));
 
     // Adding policy entry so that the multicast packets reach the switch
     // The ff02:: address is a permanent multicast address with a link scope


### PR DESCRIPTION
Make use of the newly introduced BPDU Termination MAC flows and use them instead of ACL flows for BPDU traffic.

This properly marks them as BPDUs for KNET, and prevents them from being counted as dropped.

Depends on https://github.com/bisdn/rofl-ofdpa/pull/119