### PR TITLE
fix nl_addr leaks detected by valgrind

### DIFF
--- a/src/netlink/nl_bridge.h
+++ b/src/netlink/nl_bridge.h
@@ -230,6 +230,10 @@ private:
   rtnl_link_bridge_vlan empty_br_vlan;
   uint32_t vxlan_dom_bitmap[RTNL_LINK_BRIDGE_VLAN_BITMAP_LEN];
   std::map<uint16_t, uint32_t> vxlan_domain;
+
+  nl_addr *ipv4_igmp;
+  nl_addr *ipv6_all_hosts;
+  nl_addr *ipv6_mld;
 };
 
 } /* namespace basebox */

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -104,8 +104,19 @@ std::unordered_set<std::tuple<int, uint16_t, rofl::caddress_ll, uint16_t>>
 std::unordered_map<std::set<nh_stub>, l3_interface> nh_grp_to_l3_ecmp_mapping;
 
 nl_l3::nl_l3(std::shared_ptr<nl_vlan> vlan, cnetlink *nl)
-    : sw(nullptr), vlan(std::move(vlan)), nl(nl) {}
+    : sw(nullptr), vlan(std::move(vlan)), nl(nl) {
+  nl_addr_parse("127.0.0.0/8", AF_INET, &ipv4_lo);
+  nl_addr_parse("::1/128", AF_INET6, &ipv6_lo);
+  nl_addr_parse("fe80::/10", AF_INET6, &ipv6_ll);
+  nl_addr_parse("ff80::/10", AF_INET6, &ipv6_mc);
+}
 
+nl_l3::~nl_l3() {
+  nl_addr_put(ipv4_lo);
+  nl_addr_put(ipv6_lo);
+  nl_addr_put(ipv6_ll);
+  nl_addr_put(ipv6_mc);
+}
 rofl::caddress_ll libnl_lladdr_2_rofl(const struct nl_addr *lladdr) {
   // XXX check for family
   return rofl::caddress_ll((uint8_t *)nl_addr_get_binary_addr(lladdr),
@@ -246,11 +257,7 @@ int nl_l3::add_l3_addr(struct rtnl_addr *a) {
   }
 
   if (is_loopback) {
-    auto p = nl_addr_alloc(255);
-    nl_addr_parse("127.0.0.0/8", AF_INET, &p);
-    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
-
-    if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
+    if (!nl_addr_cmp_prefix(addr, ipv4_lo)) {
       VLOG(3) << __FUNCTION__ << ": skipping 127.0.0.0/8";
       return 0;
     }
@@ -398,11 +405,7 @@ int nl_l3::add_lo_addr_v6(struct rtnl_addr *a) {
   int rv = 0;
   auto addr = rtnl_addr_get_local(a);
 
-  auto p = nl_addr_alloc(16);
-  nl_addr_parse("::1/128", AF_INET6, &p);
-  std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
-
-  if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
+  if (!nl_addr_cmp_prefix(addr, ipv6_lo)) {
     VLOG(1) << __FUNCTION__ << ": skipping loopback address";
     rv = -EINVAL;
     return rv;
@@ -746,11 +749,7 @@ int nl_l3::add_l3_neigh(struct rtnl_neigh *n) {
 
   addr = rtnl_neigh_get_dst(n);
   if (family == AF_INET6) {
-    auto p = nl_addr_alloc(16);
-    nl_addr_parse("fe80::/10", AF_INET6, &p);
-    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
-
-    if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
+    if (!nl_addr_cmp_prefix(addr, ipv6_ll)) {
       VLOG(1) << __FUNCTION__ << ": skipping fe80::/10";
       // we must not route IPv6 LL addresses, so do not add a host entry
       add_host_entry = false;
@@ -1002,11 +1001,7 @@ int nl_l3::del_l3_neigh(struct rtnl_neigh *n) {
     // delete next hop
     rv = sw->l3_unicast_host_remove(ipv4_dst);
   } else if (family == AF_INET6 && !skip_addr_remove) {
-    auto p = nl_addr_alloc(16);
-    nl_addr_parse("fe80::/10", AF_INET6, &p);
-    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> lo_addr(p, nl_addr_put);
-
-    if (!nl_addr_cmp_prefix(addr, lo_addr.get())) {
+    if (!nl_addr_cmp_prefix(addr, ipv6_ll)) {
       VLOG(1) << __FUNCTION__ << ": skipping fe80::/10";
       // we never added a host route, and therefore no egress interface
       skip_egress_remove = true;

--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -108,7 +108,7 @@ nl_l3::nl_l3(std::shared_ptr<nl_vlan> vlan, cnetlink *nl)
   nl_addr_parse("127.0.0.0/8", AF_INET, &ipv4_lo);
   nl_addr_parse("::1/128", AF_INET6, &ipv6_lo);
   nl_addr_parse("fe80::/10", AF_INET6, &ipv6_ll);
-  nl_addr_parse("ff80::/10", AF_INET6, &ipv6_mc);
+  nl_addr_parse("ff00::/8", AF_INET6, &ipv6_mc);
 }
 
 nl_l3::~nl_l3() {

--- a/src/netlink/nl_l3.h
+++ b/src/netlink/nl_l3.h
@@ -46,7 +46,7 @@ public:
 class nl_l3 : public nh_reachable, public nh_unreachable {
 public:
   nl_l3(std::shared_ptr<nl_vlan> vlan, cnetlink *nl);
-  ~nl_l3() {}
+  ~nl_l3();
 
   int init() noexcept;
 
@@ -127,19 +127,11 @@ private:
   int del_l3_ecmp_group(const std::set<nh_stub> &nhs);
 
   bool is_ipv6_link_local_address(const struct nl_addr *addr) {
-    auto p = nl_addr_alloc(16);
-    nl_addr_parse("fe80::/10", AF_INET6, &p);
-    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> ll_addr(p, nl_addr_put);
-
-    return !nl_addr_cmp_prefix(ll_addr.get(), addr);
+    return !nl_addr_cmp_prefix(ipv6_ll, addr);
   }
 
   bool is_ipv6_multicast_address(const struct nl_addr *addr) {
-    auto p = nl_addr_alloc(16);
-    nl_addr_parse("ff80::/10", AF_INET6, &p);
-    std::unique_ptr<nl_addr, decltype(&nl_addr_put)> mc_addr(p, nl_addr_put);
-
-    return !nl_addr_cmp_prefix(mc_addr.get(), addr);
+    return !nl_addr_cmp_prefix(ipv6_mc, addr);
   }
 
   bool is_l3_neigh_routable(struct rtnl_neigh *n);
@@ -159,6 +151,11 @@ private:
   struct l3_prefix_comp l3_prefix_comp;
 
   const uint8_t MAIN_ROUTING_TABLE = 254;
+
+  nl_addr *ipv4_lo;
+  nl_addr *ipv6_lo;
+  nl_addr *ipv6_ll;
+  nl_addr *ipv6_mc;
 };
 
 } // namespace basebox


### PR DESCRIPTION
Running valgrind, it detected we are leaking allocated `nl_addr`s at various places following the pattern:

```
auto p = nl_addr_alloc(...);
nl_addr_parse(<address>, <family>, &p);
std::unique_ptr<nl_addr, decltype(&nl_addr_put)> tm_addr(p, nl_addr_put);
```

The core issue here is that `nl_addr_parse() does its own allocation and updates `p` with a pointer to it, and thus the initial allocation behind `p is leaked.

Since we always parse static addresses, replace those dynamic allocations with statically allocated addresses in the constructor.

while fixing this, also fix the IPv6 multicast prefix from `ff80::/10` to `ff00::/8`.

