### PR TITLE
nl_bridge: do not try to flush fdb on removed interfaces

### DIFF
--- a/src/netlink/nl_bridge.cc
+++ b/src/netlink/nl_bridge.cc
@@ -568,14 +568,18 @@ void nl_bridge::update_vlans(rtnl_link *old_link, rtnl_link *new_link) {
           // the PVID is already being handled outside of the loop
           vlan->remove_bridge_vlan(_link, vid, false, !egress_untagged);
 
-          // remove all fdb entries by us
-          nl_fdb_flush ff;
+          // only flush on updating interfaces, kernel will take of it when
+          // removing from the bridge (new_link is a nullptr)
+          if (new_link) {
+            // remove all fdb entries by us
+            nl_fdb_flush ff;
 
-          auto ret = ff.flush_fdb(rtnl_link_get_ifindex(_link), vid,
-                                  NTF_MASTER | NTF_EXT_LEARNED);
-          if (ret < 0)
-            LOG(WARNING) << __FUNCTION__ << ": failed to flush vid=" << vid
-                         << " on port " << _link;
+            auto ret = ff.flush_fdb(rtnl_link_get_ifindex(_link), vid,
+                                    NTF_MASTER | NTF_EXT_LEARNED);
+            if (ret < 0)
+              LOG(WARNING) << __FUNCTION__ << ": failed to flush vid=" << vid
+                           << " on port " << _link;
+          }
         }
       }
     }


### PR DESCRIPTION
When removing a VLAN from a bridge port, we flush the fdb entries from the kernel. When removing a port form the bridge, we also remove all VLANs from that port.

When we try to flush the fdb for that port, the kernel refuses to do so since the port is not a bridge member anymore, and returns an error, causing baseboxd to treat this as fatal.

Since removing a port from a bridge will automatically delete all fdb entries for all vlans, there is no need for us to manually delete them, so skip flushing the fdb if we are in the interface removal path, i.e. new_link is a nullptr.
