### PR TITLE
increase OpenFlow connection timeouts and make them configurable

### DIFF
--- a/pkg/systemd/sysconfig.template
+++ b/pkg/systemd/sysconfig.template
@@ -26,6 +26,12 @@
 #   0 = force unlimited
 # Default is auto.
 # FLAGS_rx_rate_limit=-1
+#
+# Set OpenFlow echo request timeout in seconds:
+# FLAGS_of_timeout_echo=6
+#
+# Set OpenFlow idle delay for sending echo requests:
+# FLAGS_of_timeout_lifecheck=10
 
 ### glog logging configuration
 #

--- a/src/baseboxd.cc
+++ b/src/baseboxd.cc
@@ -27,6 +27,8 @@ DEFINE_int32(port_untagged_vid, 1,
 DEFINE_int32(
     rx_rate_limit, -1,
     "PPS limit for traffic to controller (-1 = auto, 0 = force unlimited)");
+DEFINE_int32(of_timeout_echo, 6, "timeout of sent echo requests");
+DEFINE_int32(of_timeout_lifecheck, 10, "delay of life check after last rx");
 
 static bool validate_port(const char *flagname, gflags::int32 value) {
   VLOG(3) << __FUNCTION__ << ": flagname=" << flagname << ", value=" << value;
@@ -67,8 +69,10 @@ int main(int argc, char **argv) {
   }
 
   // all variables can be set from env
-  FLAGS_tryfromenv = std::string("multicast,port,ofdpa_grpc_port,use_knet,mark_"
-                                 "fwd_offload,port_untagged_vid");
+  FLAGS_tryfromenv =
+      std::string("multicast,port,ofdpa_grpc_port,use_knet,mark_"
+                  "fwd_offload,port_untagged_vid,of_timeout_lifecheck,of_"
+                  "timeout_echo");
   gflags::SetUsageMessage("");
   gflags::SetVersionString(PROJECT_VERSION);
 

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -24,6 +24,9 @@ DECLARE_bool(clear_switch_configuration);
 DECLARE_bool(use_knet);
 DECLARE_int32(rx_rate_limit);
 
+DECLARE_int32(of_timeout_echo);
+DECLARE_int32(of_timeout_lifecheck);
+
 namespace basebox {
 
 void controller::handle_conn_established(rofl::crofdpt &dpt,
@@ -54,8 +57,9 @@ void controller::handle_dpt_open(rofl::crofdpt &dpt) {
   // set max queue size in rofl
   dpt.set_conn(rofl::cauxid(0)).set_txqueue_max_size(128 * 1024);
   // set timeout limits
-  dpt.set_conn(rofl::cauxid(0)).set_timeout_echo(6);
-  dpt.set_conn(rofl::cauxid(0)).set_timeout_lifecheck(10);
+  dpt.set_conn(rofl::cauxid(0)).set_timeout_echo(FLAGS_of_timeout_echo);
+  dpt.set_conn(rofl::cauxid(0))
+      .set_timeout_lifecheck(FLAGS_of_timeout_lifecheck);
 
   rofl::csockaddr raddr = dpt.set_conn(rofl::cauxid(0)).get_raddr();
   std::string buf;

--- a/src/of-dpa/controller.cc
+++ b/src/of-dpa/controller.cc
@@ -53,6 +53,9 @@ void controller::handle_dpt_open(rofl::crofdpt &dpt) {
 
   // set max queue size in rofl
   dpt.set_conn(rofl::cauxid(0)).set_txqueue_max_size(128 * 1024);
+  // set timeout limits
+  dpt.set_conn(rofl::cauxid(0)).set_timeout_echo(6);
+  dpt.set_conn(rofl::cauxid(0)).set_timeout_lifecheck(10);
 
   rofl::csockaddr raddr = dpt.set_conn(rofl::cauxid(0)).get_raddr();
   std::string buf;


### PR DESCRIPTION
OpenFlow says:
    
> "OpenFlow messages are processed out of order (see 6.2), and the processing of some requests by the switch may take a long time, therefore a controller must never terminate a connection because a request is taking too much time. An exception to that rule is for echo replies, a controller or a switch may terminate a connection if the reply for an echo request it sent takes too much time, however there must be a way to disable that feature and the timeout should be large enough to accommodate a wide variety of conditions."
    
A maximum of 4 seconds (1 lifetime + 3 echo) is not much if the OpenFlow connection is conguested due to a large amount of messages to process, so double the echo timout.
    
Since rofl-common also sends out echo requests on long-standing barrier requests, but barrier-requests inhibit processing messages until completed, also increase the lifetime check significantly to allow barrier_requests to take up to 16 seconds, not 4.
    
This should significantly increase the stability of the OpenFlow connection under stress conditions.

In case the chosen limits are insufficient or cause issues otherwise, make the values configurable.