### PR TITLE
nl_l3: also compare prefix length in duplicate route check

### DIFF
--- a/src/netlink/nl_l3.cc
+++ b/src/netlink/nl_l3.cc
@@ -1818,8 +1818,7 @@ int nl_l3::add_l3_unicast_route(rtnl_route *r, bool update_route) {
       VLOG(2) << __FUNCTION__ << ": got route " << route << " for dst "
               << rtnl_route_get_dst(r);
       if (rtnl_route_get_protocol(route) == RTPROT_KERNEL &&
-          nl_addr_cmp_prefix(rtnl_route_get_dst(r),
-                             rtnl_route_get_dst(route)) == 0) {
+          nl_addr_cmp(rtnl_route_get_dst(r), rtnl_route_get_dst(route)) == 0) {
         // we already have a kernel route for the same dst
         duplicate = true;
       }
@@ -1993,8 +1992,7 @@ int nl_l3::del_l3_unicast_route(rtnl_route *r, bool keep_route) {
       VLOG(2) << __FUNCTION__ << ": got route " << route << " for dst "
               << rtnl_route_get_dst(r);
       if (rtnl_route_get_protocol(route) == RTPROT_KERNEL &&
-          nl_addr_cmp_prefix(rtnl_route_get_dst(r),
-                             rtnl_route_get_dst(route)) == 0) {
+          nl_addr_cmp(rtnl_route_get_dst(r), rtnl_route_get_dst(route)) == 0) {
         // we have a kernel route for the same dst
         duplicate = true;
       }


### PR DESCRIPTION
When checking for duplicate routes, we also need to check the prefix lengths, else e.g. a route `10.0.0.0/8` will match with a `10.0.10.0/24` route. This can lead to routes falsely being identified as duplicates and not added or removed as expected.

So switch from `nl_addr_cmp_prefix()` to `nl_addr_cmp()` to ensure that different prefix lengths will be treated as different routes.

Fixes: 96e14a879fde ("nl_l3: ignore duplicated link routes from FRR")